### PR TITLE
Force CONFIGURATION to be debug or release only

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -148,6 +148,20 @@ tasks.podspec.configure {
                     |    spec.preserve_paths           = "**/*.*"
                     |$it
                 """.trimMargin()
+
+                // HACK: force CONFIGURATION to be debug or release only.
+                //       other values are not currently supported by the kotlin cocoapods plugin
+                it.contains("syncFramework") -> """
+                    |if [[ ${'$'}(echo ${'$'}CONFIGURATION | tr '[:upper:]' '[:lower:]') = 'debug' ]]
+                    |then
+                    |    SANITIZED_CONFIGURATION=debug
+                    |else
+                    |    SANITIZED_CONFIGURATION=release
+                    |fi
+                    |$it
+                """.trimMargin()
+                it.contains("\$CONFIGURATION") -> it.replace("CONFIGURATION", "SANITIZED_CONFIGURATION")
+
                 else -> it
             }
         }


### PR DESCRIPTION
currently the Kotlin cocoapods plugin only supports `DEBUG` and `RELEASE` configurations: https://github.com/JetBrains/kotlin/blob/master/libraries/tools/kotlin-gradle-plugin-api/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/NativeBinaryTypes.kt#L21-L22

This works around the limitation by sanitizing any configuration to one of the 2 supported types