### PR TITLE
Run iOS tests on both the main thread and a background thread

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,7 +107,7 @@ jobs:
           key: ${{ runner.os }}-konan-${{ github.sha }}
           restore-keys: ${{ runner.os }}-konan-
       - name: Run iOS Unit Tests
-        run: ./gradlew iosTest --parallel
+        run: ./gradlew iosTest iosBackgroundTest --parallel
 
   js_tests:
     name: JS Unit Tests

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.ajoberstar.grgit.Grgit
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTargetWithTests
 import org.jetbrains.kotlin.gradle.plugin.mpp.TestExecutable
 
 plugins {
@@ -37,6 +38,22 @@ kotlin {
     }.copyTestResources()
     js {
         nodejs()
+    }
+
+    // enable running ios tests on a background thread as well
+    // configuration copied from: https://github.com/square/okio/pull/929
+    targets.withType<KotlinNativeTargetWithTests<*>> {
+        binaries {
+            // Configure a separate test where code runs in background
+            test("background", setOf(DEBUG)) {
+                freeCompilerArgs += "-trw"
+            }
+        }
+        testRuns {
+            val background by creating {
+                setExecutionSourceFrom(binaries.getByName("backgroundDebugTest") as TestExecutable)
+            }
+        }
     }
 
     sourceSets {

--- a/src/commonMain/kotlin/org/cru/godtools/tool/Utils.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/Utils.kt
@@ -1,3 +1,6 @@
 package org.cru.godtools.tool
 
+import kotlin.native.concurrent.SharedImmutable
+
+@SharedImmutable
 internal val REGEX_SEQUENCE_SEPARATOR = Regex("\\s+")

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/EventIdTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/EventIdTest.kt
@@ -1,9 +1,11 @@
 package org.cru.godtools.tool.model
 
+import kotlin.native.concurrent.SharedImmutable
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 
+@SharedImmutable
 private val ID1 = EventId("followup", "seND")
 
 class EventTest {


### PR DESCRIPTION
Kotlin/Native currently requires any object shared between the main and background threads to be immutable. This adds a second test task to run all of our tests on a background thread to ensure we aren't writing logic that only works on the main thread.