### PR TITLE
Add Tract xml models

### DIFF
--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/Base.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/Base.kt
@@ -6,3 +6,4 @@ interface Base {
 }
 
 val Base?.stylesParent get() = this?.stylesParent
+internal val Base?.manifest get() = this?.manifest

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/Constants.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/Constants.kt
@@ -1,5 +1,7 @@
 package org.cru.godtools.tool.model
 
+import kotlin.native.concurrent.SharedImmutable
+
 internal const val SCHEMA_VERSION = 1
 
 // XML namespaces
@@ -20,3 +22,9 @@ internal const val XML_TEXT_COLOR = "text-color"
 internal const val XML_TEXT_SCALE = "text-scale"
 internal const val XML_EVENTS = "events"
 internal const val XML_LISTENERS = "listeners"
+
+// common colors
+@SharedImmutable
+internal val TRANSPARENT = color(0, 0, 0, 0.0)
+@SharedImmutable
+internal val WHITE = color(255, 255, 255, 1.0)

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
@@ -269,10 +269,7 @@ class Manifest : BaseModel, Styles {
                             @Suppress("NON_EXHAUSTIVE_WHEN")
                             when (type) {
                                 Type.LESSON -> result.lessonPages += LessonPage(this@Manifest, fileName, parseFile(src))
-                                Type.TRACT -> {
-                                    val pos = result.tractPages.size
-                                    result.tractPages += TractPage(this@Manifest, pos, fileName, parseFile(src))
-                                }
+                                Type.TRACT -> result.tractPages += TractPage(this@Manifest, fileName, parseFile(src))
                             }
                         }
                     }

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
@@ -181,6 +181,7 @@ class Manifest : BaseModel, Styles {
     @RestrictTo(RestrictTo.Scope.TESTS)
     internal constructor(
         type: Type = Type.DEFAULT,
+        code: String? = null,
         primaryColor: Color = DEFAULT_PRIMARY_COLOR,
         primaryTextColor: Color = DEFAULT_PRIMARY_TEXT_COLOR,
         navBarColor: Color? = null,
@@ -194,7 +195,7 @@ class Manifest : BaseModel, Styles {
         resources: ((Manifest) -> List<Resource>)? = null,
         tips: ((Manifest) -> List<Tip>)? = null
     ) {
-        code = null
+        this.code = code
         locale = null
         this.type = type
 

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
@@ -13,6 +13,7 @@ import org.cru.godtools.tool.model.lesson.LessonPage
 import org.cru.godtools.tool.model.lesson.XMLNS_LESSON
 import org.cru.godtools.tool.model.lesson.XML_CONTROL_COLOR
 import org.cru.godtools.tool.model.tips.Tip
+import org.cru.godtools.tool.model.tract.TractPage
 import org.cru.godtools.tool.model.tract.XMLNS_TRACT
 import org.cru.godtools.tool.model.tract.XML_CARD_BACKGROUND_COLOR
 import org.cru.godtools.tool.xml.XmlPullParser
@@ -115,6 +116,7 @@ class Manifest : BaseModel, Styles {
 
     val categories: List<Category>
     val lessonPages: List<LessonPage>
+    val tractPages: List<TractPage>
 
     @VisibleForTesting
     internal val resources: Map<String?, Resource>
@@ -156,6 +158,7 @@ class Manifest : BaseModel, Styles {
         val lessonPages = mutableListOf<LessonPage>()
         val resources = mutableListOf<Resource>()
         val tips = mutableListOf<Tip>()
+        tractPages = mutableListOf()
         parser.parseChildren {
             when (parser.namespace) {
                 XMLNS_MANIFEST -> when (parser.name) {
@@ -164,6 +167,7 @@ class Manifest : BaseModel, Styles {
                     XML_PAGES -> {
                         val result = parser.parsePages(parseFile)
                         lessonPages += result.lessonPages
+                        tractPages += result.tractPages
                     }
                     XML_RESOURCES -> resources += parser.parseResources()
                     XML_TIPS -> tips += parser.parseTips(parseFile)
@@ -223,6 +227,7 @@ class Manifest : BaseModel, Styles {
 
         categories = emptyList()
         lessonPages = emptyList()
+        tractPages = emptyList()
         this.resources = resources?.invoke(this)?.associateBy { it.name }.orEmpty()
         this.tips = tips?.invoke(this)?.associateBy { it.id }.orEmpty()
     }
@@ -246,6 +251,7 @@ class Manifest : BaseModel, Styles {
 
     private class PagesData {
         val lessonPages = mutableListOf<LessonPage>()
+        val tractPages = mutableListOf<TractPage>()
     }
 
     private fun XmlPullParser.parsePages(parseFile: (String) -> XmlPullParser) = PagesData().also { result ->
@@ -263,6 +269,10 @@ class Manifest : BaseModel, Styles {
                             @Suppress("NON_EXHAUSTIVE_WHEN")
                             when (type) {
                                 Type.LESSON -> result.lessonPages += LessonPage(this@Manifest, fileName, parseFile(src))
+                                Type.TRACT -> {
+                                    val pos = result.tractPages.size
+                                    result.tractPages += TractPage(this@Manifest, pos, fileName, parseFile(src))
+                                }
                             }
                         }
                     }

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/CallToAction.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/CallToAction.kt
@@ -1,0 +1,61 @@
+package org.cru.godtools.tool.model.tract
+
+import org.cru.godtools.tool.internal.AndroidColorInt
+import org.cru.godtools.tool.internal.VisibleForTesting
+import org.cru.godtools.tool.model.BaseModel
+import org.cru.godtools.tool.model.Color
+import org.cru.godtools.tool.model.EventId
+import org.cru.godtools.tool.model.Text
+import org.cru.godtools.tool.model.XML_EVENTS
+import org.cru.godtools.tool.model.parseTextChild
+import org.cru.godtools.tool.model.primaryColor
+import org.cru.godtools.tool.model.stylesParent
+import org.cru.godtools.tool.model.tips.XMLNS_TRAINING
+import org.cru.godtools.tool.model.toColorOrNull
+import org.cru.godtools.tool.model.toEventIds
+import org.cru.godtools.tool.xml.XmlPullParser
+
+private const val XML_CONTROL_COLOR = "control-color"
+private const val XML_TIP = "tip"
+
+class CallToAction : BaseModel {
+    companion object {
+        internal const val XML_CALL_TO_ACTION = "call-to-action"
+    }
+
+    private val page: TractPage
+
+    val label: Text?
+    val events: List<EventId>
+
+    @AndroidColorInt
+    private val _controlColor: Color?
+    @get:AndroidColorInt
+    val controlColor get() = _controlColor ?: stylesParent.primaryColor
+
+    @VisibleForTesting
+    internal val tipId: String?
+    val tip get() = manifest.findTip(tipId)
+
+    internal constructor(parent: TractPage) : super(parent) {
+        page = parent
+        label = null
+        events = emptyList()
+        _controlColor = null
+        tipId = null
+    }
+
+    internal constructor(parent: TractPage, parser: XmlPullParser) : super(parent) {
+        parser.require(XmlPullParser.START_TAG, XMLNS_TRACT, XML_CALL_TO_ACTION)
+
+        page = parent
+        events = parser.getAttributeValue(XML_EVENTS).toEventIds()
+        _controlColor = parser.getAttributeValue(XML_CONTROL_COLOR)?.toColorOrNull()
+        tipId = parser.getAttributeValue(XMLNS_TRAINING, XML_TIP)
+
+        label = parser.parseTextChild(this, XMLNS_TRACT, XML_CALL_TO_ACTION)
+    }
+}
+
+@get:AndroidColorInt
+val CallToAction?.controlColor get() = this?.controlColor ?: stylesParent.primaryColor

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Card.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Card.kt
@@ -1,0 +1,143 @@
+package org.cru.godtools.tool.model.tract
+
+import org.cru.godtools.tool.internal.AndroidColorInt
+import org.cru.godtools.tool.internal.RestrictTo
+import org.cru.godtools.tool.model.AnalyticsEvent
+import org.cru.godtools.tool.model.AnalyticsEvent.Companion.parseAnalyticsEvents
+import org.cru.godtools.tool.model.BaseModel
+import org.cru.godtools.tool.model.Color
+import org.cru.godtools.tool.model.Content
+import org.cru.godtools.tool.model.EventId
+import org.cru.godtools.tool.model.ImageGravity
+import org.cru.godtools.tool.model.ImageGravity.Companion.toImageGravityOrNull
+import org.cru.godtools.tool.model.ImageScaleType
+import org.cru.godtools.tool.model.ImageScaleType.Companion.toImageScaleTypeOrNull
+import org.cru.godtools.tool.model.Parent
+import org.cru.godtools.tool.model.Styles
+import org.cru.godtools.tool.model.Text
+import org.cru.godtools.tool.model.XMLNS_ANALYTICS
+import org.cru.godtools.tool.model.XML_BACKGROUND_COLOR
+import org.cru.godtools.tool.model.XML_BACKGROUND_IMAGE
+import org.cru.godtools.tool.model.XML_BACKGROUND_IMAGE_GRAVITY
+import org.cru.godtools.tool.model.XML_BACKGROUND_IMAGE_SCALE_TYPE
+import org.cru.godtools.tool.model.XML_DISMISS_LISTENERS
+import org.cru.godtools.tool.model.XML_LISTENERS
+import org.cru.godtools.tool.model.XML_TEXT_COLOR
+import org.cru.godtools.tool.model.backgroundColor
+import org.cru.godtools.tool.model.contentTips
+import org.cru.godtools.tool.model.getResource
+import org.cru.godtools.tool.model.parseContent
+import org.cru.godtools.tool.model.parseTextChild
+import org.cru.godtools.tool.model.toColorOrNull
+import org.cru.godtools.tool.model.toEventIds
+import org.cru.godtools.tool.model.tract.Card.Companion.DEFAULT_BACKGROUND_IMAGE_GRAVITY
+import org.cru.godtools.tool.model.tract.Card.Companion.DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE
+import org.cru.godtools.tool.xml.XmlPullParser
+
+private const val XML_LABEL = "label"
+private const val XML_HIDDEN = "hidden"
+
+class Card : BaseModel, Styles, Parent {
+    internal companion object {
+        internal const val XML_CARD = "card"
+
+        internal val DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE = ImageScaleType.FILL_X
+        internal val DEFAULT_BACKGROUND_IMAGE_GRAVITY = ImageGravity.CENTER
+    }
+
+    val page: TractPage
+
+    val id get() = "${page.id}-$position"
+    val position: Int
+    val visiblePosition get() = page.visibleCards.indexOf(this).takeUnless { it == -1 }
+    val isLastVisibleCard get() = this == page.visibleCards.lastOrNull()
+
+    val isHidden: Boolean
+    val listeners: Set<EventId>
+    val dismissListeners: Set<EventId>
+    val analyticsEvents: Collection<AnalyticsEvent>
+
+    @AndroidColorInt
+    private val _backgroundColor: Color?
+    @get:AndroidColorInt
+    internal val backgroundColor get() = _backgroundColor ?: page.cardBackgroundColor
+    private val _backgroundImage: String?
+    val backgroundImage get() = getResource(_backgroundImage)
+    internal val backgroundImageGravity: ImageGravity
+    val backgroundImageScaleType: ImageScaleType
+
+    @AndroidColorInt
+    private val _textColor: Color?
+    @get:AndroidColorInt
+    override val textColor get() = _textColor ?: page.cardTextColor
+
+    val label: Text?
+    override val content: List<Content>
+    val tips get() = contentTips
+
+    internal constructor(parent: TractPage, position: Int, parser: XmlPullParser) : super(parent) {
+        page = parent
+        this.position = position
+
+        parser.require(XmlPullParser.START_TAG, XMLNS_TRACT, XML_CARD)
+
+        isHidden = parser.getAttributeValue(null, XML_HIDDEN)?.toBoolean() ?: false
+        listeners = parser.getAttributeValue(XML_LISTENERS).toEventIds().toSet()
+        dismissListeners = parser.getAttributeValue(XML_DISMISS_LISTENERS).toEventIds().toSet()
+
+        _backgroundColor = parser.getAttributeValue(XML_BACKGROUND_COLOR)?.toColorOrNull()
+        _backgroundImage = parser.getAttributeValue(XML_BACKGROUND_IMAGE)
+        backgroundImageGravity = parser.getAttributeValue(XML_BACKGROUND_IMAGE_GRAVITY)?.toImageGravityOrNull()
+            ?: DEFAULT_BACKGROUND_IMAGE_GRAVITY
+        backgroundImageScaleType = parser.getAttributeValue(XML_BACKGROUND_IMAGE_SCALE_TYPE)?.toImageScaleTypeOrNull()
+            ?: DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE
+
+        _textColor = parser.getAttributeValue(XML_TEXT_COLOR)?.toColorOrNull()
+
+        // process any child elements
+        analyticsEvents = mutableListOf()
+        var label: Text? = null
+        content = parseContent(parser) {
+            when (parser.namespace) {
+                XMLNS_ANALYTICS -> when (parser.name) {
+                    AnalyticsEvent.XML_EVENTS -> analyticsEvents += parser.parseAnalyticsEvents(this)
+                }
+                XMLNS_TRACT -> when (parser.name) {
+                    XML_LABEL -> label = parser.parseTextChild(this@Card, XMLNS_TRACT, XML_LABEL)
+                }
+            }
+        }
+        this.label = label
+    }
+
+    @RestrictTo(RestrictTo.Scope.TESTS)
+    internal constructor(
+        parent: TractPage,
+        backgroundColor: Color? = null,
+        isHidden: Boolean = false,
+        content: ((Card) -> List<Content>?)? = null
+    ) : super(parent) {
+        page = parent
+        position = 0
+
+        this.isHidden = isHidden
+        listeners = emptySet()
+        dismissListeners = emptySet()
+        analyticsEvents = emptySet()
+
+        _backgroundColor = backgroundColor
+        _backgroundImage = null
+        backgroundImageGravity = DEFAULT_BACKGROUND_IMAGE_GRAVITY
+        backgroundImageScaleType = DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE
+
+        _textColor = null
+
+        label = null
+        this.content = content?.invoke(this).orEmpty()
+    }
+}
+
+@get:AndroidColorInt
+val Card?.backgroundColor get() = this?.backgroundColor ?: this?.manifest.backgroundColor
+val Card?.backgroundImageGravity get() = this?.backgroundImageGravity ?: DEFAULT_BACKGROUND_IMAGE_GRAVITY
+val Card?.backgroundImageScaleType get() = this?.backgroundImageScaleType ?: DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Card.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Card.kt
@@ -26,6 +26,7 @@ import org.cru.godtools.tool.model.XML_TEXT_COLOR
 import org.cru.godtools.tool.model.backgroundColor
 import org.cru.godtools.tool.model.contentTips
 import org.cru.godtools.tool.model.getResource
+import org.cru.godtools.tool.model.manifest
 import org.cru.godtools.tool.model.parseContent
 import org.cru.godtools.tool.model.parseTextChild
 import org.cru.godtools.tool.model.toColorOrNull
@@ -75,8 +76,8 @@ class Card : BaseModel, Styles, Parent {
     override val content: List<Content>
     val tips get() = contentTips
 
-    internal constructor(parent: TractPage, position: Int, parser: XmlPullParser) : super(parent) {
-        page = parent
+    internal constructor(page: TractPage, position: Int, parser: XmlPullParser) : super(page) {
+        this.page = page
         this.position = position
 
         parser.require(XmlPullParser.START_TAG, XMLNS_TRACT, XML_CARD)
@@ -112,12 +113,15 @@ class Card : BaseModel, Styles, Parent {
 
     @RestrictTo(RestrictTo.Scope.TESTS)
     internal constructor(
-        parent: TractPage,
+        page: TractPage,
         backgroundColor: Color? = null,
+        backgroundImage: String? = null,
+        backgroundImageGravity: ImageGravity = DEFAULT_BACKGROUND_IMAGE_GRAVITY,
+        backgroundImageScaleType: ImageScaleType = DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE,
         isHidden: Boolean = false,
         content: ((Card) -> List<Content>?)? = null
-    ) : super(parent) {
-        page = parent
+    ) : super(page) {
+        this.page = page
         position = 0
 
         this.isHidden = isHidden
@@ -126,9 +130,9 @@ class Card : BaseModel, Styles, Parent {
         analyticsEvents = emptySet()
 
         _backgroundColor = backgroundColor
-        _backgroundImage = null
-        backgroundImageGravity = DEFAULT_BACKGROUND_IMAGE_GRAVITY
-        backgroundImageScaleType = DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE
+        _backgroundImage = backgroundImage
+        this.backgroundImageGravity = backgroundImageGravity
+        this.backgroundImageScaleType = backgroundImageScaleType
 
         _textColor = null
 
@@ -138,6 +142,6 @@ class Card : BaseModel, Styles, Parent {
 }
 
 @get:AndroidColorInt
-val Card?.backgroundColor get() = this?.backgroundColor ?: this?.manifest.backgroundColor
+val Card?.backgroundColor get() = this?.backgroundColor ?: manifest.backgroundColor
 val Card?.backgroundImageGravity get() = this?.backgroundImageGravity ?: DEFAULT_BACKGROUND_IMAGE_GRAVITY
 val Card?.backgroundImageScaleType get() = this?.backgroundImageScaleType ?: DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Header.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Header.kt
@@ -1,0 +1,63 @@
+package org.cru.godtools.tool.model.tract
+
+import org.cru.godtools.tool.internal.AndroidColorInt
+import org.cru.godtools.tool.internal.VisibleForTesting
+import org.cru.godtools.tool.model.BaseModel
+import org.cru.godtools.tool.model.Color
+import org.cru.godtools.tool.model.Styles
+import org.cru.godtools.tool.model.Text
+import org.cru.godtools.tool.model.XML_BACKGROUND_COLOR
+import org.cru.godtools.tool.model.parseTextChild
+import org.cru.godtools.tool.model.primaryColor
+import org.cru.godtools.tool.model.stylesParent
+import org.cru.godtools.tool.model.tips.XMLNS_TRAINING
+import org.cru.godtools.tool.model.toColorOrNull
+import org.cru.godtools.tool.xml.XmlPullParser
+import org.cru.godtools.tool.xml.parseChildren
+
+private const val XML_NUMBER = "number"
+private const val XML_TITLE = "title"
+private const val XML_TIP = "tip"
+
+class Header : BaseModel, Styles {
+    internal companion object {
+        internal const val XML_HEADER = "header"
+    }
+
+    @AndroidColorInt
+    private val _backgroundColor: Color?
+    @get:AndroidColorInt
+    internal val backgroundColor get() = _backgroundColor ?: primaryColor
+
+    @get:AndroidColorInt
+    override val textColor get() = primaryTextColor
+
+    val number: Text?
+    val title: Text?
+
+    @VisibleForTesting
+    internal val tipId: String?
+    val tip get() = manifest.findTip(tipId)
+
+    internal constructor(page: TractPage, parser: XmlPullParser) : super(page) {
+        parser.require(XmlPullParser.START_TAG, XMLNS_TRACT, XML_HEADER)
+
+        _backgroundColor = parser.getAttributeValue(XML_BACKGROUND_COLOR)?.toColorOrNull()
+        tipId = parser.getAttributeValue(XMLNS_TRAINING, XML_TIP)
+
+        var number: Text? = null
+        var title: Text? = null
+        parser.parseChildren {
+            when (parser.namespace) {
+                XMLNS_TRACT -> when (parser.name) {
+                    XML_NUMBER -> number = parser.parseTextChild(this, XMLNS_TRACT, XML_NUMBER)
+                    XML_TITLE -> title = parser.parseTextChild(this, XMLNS_TRACT, XML_TITLE)
+                }
+            }
+        }
+        this.number = number
+        this.title = title
+    }
+}
+
+val Header?.backgroundColor get() = this?.backgroundColor ?: stylesParent.primaryColor

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Header.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Header.kt
@@ -1,6 +1,7 @@
 package org.cru.godtools.tool.model.tract
 
 import org.cru.godtools.tool.internal.AndroidColorInt
+import org.cru.godtools.tool.internal.RestrictTo
 import org.cru.godtools.tool.internal.VisibleForTesting
 import org.cru.godtools.tool.model.BaseModel
 import org.cru.godtools.tool.model.Color
@@ -57,6 +58,16 @@ class Header : BaseModel, Styles {
         }
         this.number = number
         this.title = title
+    }
+
+    @RestrictTo(RestrictTo.Scope.TESTS)
+    internal constructor(page: TractPage, backgroundColor: Color? = null, tip: String? = null) : super(page) {
+        _backgroundColor = backgroundColor
+
+        number = null
+        title = null
+
+        tipId = tip
     }
 }
 

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Hero.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Hero.kt
@@ -1,0 +1,45 @@
+package org.cru.godtools.tool.model.tract
+
+import org.cru.godtools.tool.model.AnalyticsEvent
+import org.cru.godtools.tool.model.AnalyticsEvent.Companion.parseAnalyticsEvents
+import org.cru.godtools.tool.model.Base
+import org.cru.godtools.tool.model.BaseModel
+import org.cru.godtools.tool.model.Content
+import org.cru.godtools.tool.model.Parent
+import org.cru.godtools.tool.model.Styles
+import org.cru.godtools.tool.model.Text
+import org.cru.godtools.tool.model.XMLNS_ANALYTICS
+import org.cru.godtools.tool.model.parseContent
+import org.cru.godtools.tool.model.parseTextChild
+import org.cru.godtools.tool.xml.XmlPullParser
+
+class Hero : BaseModel, Parent, Styles {
+    internal companion object {
+        internal const val XML_HERO = "hero"
+
+        private const val XML_HEADING = "heading"
+    }
+
+    val analyticsEvents: Collection<AnalyticsEvent>
+    val heading: Text?
+    override val content: List<Content>
+
+    internal constructor(parent: Base, parser: XmlPullParser) : super(parent) {
+        parser.require(XmlPullParser.START_TAG, XMLNS_TRACT, XML_HERO)
+
+        // process any child elements
+        analyticsEvents = mutableListOf()
+        var heading: Text? = null
+        content = parseContent(parser) {
+            when (parser.namespace) {
+                XMLNS_ANALYTICS -> when (parser.name) {
+                    AnalyticsEvent.XML_EVENTS -> analyticsEvents += parser.parseAnalyticsEvents(this)
+                }
+                XMLNS_TRACT -> when (parser.name) {
+                    XML_HEADING -> heading = parser.parseTextChild(this, XMLNS_TRACT, XML_HEADING)
+                }
+            }
+        }
+        this.heading = heading
+    }
+}

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Hero.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Hero.kt
@@ -2,7 +2,6 @@ package org.cru.godtools.tool.model.tract
 
 import org.cru.godtools.tool.model.AnalyticsEvent
 import org.cru.godtools.tool.model.AnalyticsEvent.Companion.parseAnalyticsEvents
-import org.cru.godtools.tool.model.Base
 import org.cru.godtools.tool.model.BaseModel
 import org.cru.godtools.tool.model.Content
 import org.cru.godtools.tool.model.Parent
@@ -24,7 +23,7 @@ class Hero : BaseModel, Parent, Styles {
     val heading: Text?
     override val content: List<Content>
 
-    internal constructor(parent: Base, parser: XmlPullParser) : super(parent) {
+    internal constructor(page: TractPage, parser: XmlPullParser) : super(page) {
         parser.require(XmlPullParser.START_TAG, XMLNS_TRACT, XML_HERO)
 
         // process any child elements

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Modal.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Modal.kt
@@ -1,0 +1,70 @@
+package org.cru.godtools.tool.model.tract
+
+import org.cru.godtools.tool.internal.AndroidColorInt
+import org.cru.godtools.tool.model.BaseModel
+import org.cru.godtools.tool.model.Button
+import org.cru.godtools.tool.model.Content
+import org.cru.godtools.tool.model.EventId
+import org.cru.godtools.tool.model.Parent
+import org.cru.godtools.tool.model.Styles
+import org.cru.godtools.tool.model.TRANSPARENT
+import org.cru.godtools.tool.model.Text
+import org.cru.godtools.tool.model.WHITE
+import org.cru.godtools.tool.model.XML_DISMISS_LISTENERS
+import org.cru.godtools.tool.model.XML_LISTENERS
+import org.cru.godtools.tool.model.parseContent
+import org.cru.godtools.tool.model.parseTextChild
+import org.cru.godtools.tool.model.toEventIds
+import org.cru.godtools.tool.xml.XmlPullParser
+
+private const val XML_TITLE = "title"
+
+class Modal : BaseModel, Parent, Styles {
+    internal companion object {
+        internal const val XML_MODAL = "modal"
+    }
+
+    val page: TractPage
+    val id get() = "${page.id}-$position"
+    private val position: Int
+
+    val title: Text?
+    override val content: List<Content>
+
+    val listeners: Set<EventId>
+    val dismissListeners: Set<EventId>
+
+    @get:AndroidColorInt
+    override val primaryColor get() = TRANSPARENT
+    @get:AndroidColorInt
+    override val primaryTextColor get() = WHITE
+    @get:AndroidColorInt
+    override val textColor get() = WHITE
+
+    override val buttonStyle get() = Button.Style.OUTLINED
+    @get:AndroidColorInt
+    override val buttonColor get() = WHITE
+
+    override val textAlign get() = Text.Align.CENTER
+
+    internal constructor(parent: TractPage, position: Int, parser: XmlPullParser) : super(parent) {
+        page = parent
+        this.position = position
+
+        parser.require(XmlPullParser.START_TAG, XMLNS_TRACT, XML_MODAL)
+
+        listeners = parser.getAttributeValue(XML_LISTENERS).toEventIds().toSet()
+        dismissListeners = parser.getAttributeValue(XML_DISMISS_LISTENERS).toEventIds().toSet()
+
+        // process any child elements
+        var title: Text? = null
+        content = parseContent(parser) {
+            when (parser.namespace) {
+                XMLNS_TRACT -> when (parser.name) {
+                    XML_TITLE -> title = parser.parseTextChild(this@Modal, XMLNS_TRACT, XML_TITLE)
+                }
+            }
+        }
+        this.title = title
+    }
+}

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Modal.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Modal.kt
@@ -38,14 +38,14 @@ class Modal : BaseModel, Parent, Styles {
     override val primaryColor get() = TRANSPARENT
     @get:AndroidColorInt
     override val primaryTextColor get() = WHITE
-    @get:AndroidColorInt
-    override val textColor get() = WHITE
 
-    override val buttonStyle get() = Button.Style.OUTLINED
     @get:AndroidColorInt
     override val buttonColor get() = WHITE
+    override val buttonStyle get() = Button.Style.OUTLINED
 
     override val textAlign get() = Text.Align.CENTER
+    @get:AndroidColorInt
+    override val textColor get() = WHITE
 
     internal constructor(parent: TractPage, parser: XmlPullParser) : super(parent) {
         page = parent

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Modal.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Modal.kt
@@ -26,7 +26,7 @@ class Modal : BaseModel, Parent, Styles {
 
     val page: TractPage
     val id get() = "${page.id}-$position"
-    private val position: Int
+    private val position get() = page.modals.indexOf(this)
 
     val title: Text?
     override val content: List<Content>
@@ -47,9 +47,8 @@ class Modal : BaseModel, Parent, Styles {
 
     override val textAlign get() = Text.Align.CENTER
 
-    internal constructor(parent: TractPage, position: Int, parser: XmlPullParser) : super(parent) {
+    internal constructor(parent: TractPage, parser: XmlPullParser) : super(parent) {
         page = parent
-        this.position = position
 
         parser.require(XmlPullParser.START_TAG, XMLNS_TRACT, XML_MODAL)
 

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/TractPage.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/TractPage.kt
@@ -65,6 +65,7 @@ class TractPage : BaseModel, Styles {
 
     val header: Header?
     val hero: Hero?
+    val callToAction: CallToAction
 
     @AndroidColorInt
     private val _primaryColor: Color?
@@ -124,16 +125,19 @@ class TractPage : BaseModel, Styles {
         // process any child elements
         var header: Header? = null
         var hero: Hero? = null
+        var callToAction: CallToAction? = null
         parser.parseChildren {
             when (parser.namespace) {
                 XMLNS_TRACT -> when (parser.name) {
                     Header.XML_HEADER -> header = Header(this, parser)
                     Hero.XML_HERO -> hero = Hero(this, parser)
+                    CallToAction.XML_CALL_TO_ACTION -> callToAction = CallToAction(this, parser)
                 }
             }
         }
         this.header = header
         this.hero = hero
+        this.callToAction = callToAction ?: CallToAction(this)
     }
 
     @RestrictTo(RestrictTo.Scope.TESTS)
@@ -143,6 +147,7 @@ class TractPage : BaseModel, Styles {
         fileName: String? = null,
         textScale: Double = DEFAULT_TEXT_SCALE,
         cardBackgroundColor: Color? = null,
+        callToAction: ((TractPage) -> CallToAction?)? = null
     ) : super(manifest) {
         this.position = position
         this.fileName = fileName
@@ -165,6 +170,7 @@ class TractPage : BaseModel, Styles {
 
         header = null
         hero = null
+        this.callToAction = callToAction?.invoke(this) ?: CallToAction(this)
     }
 }
 

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/TractPage.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/TractPage.kt
@@ -147,8 +147,14 @@ class TractPage : BaseModel, Styles {
     internal constructor(
         manifest: Manifest,
         fileName: String? = null,
+        backgroundColor: Color = DEFAULT_BACKGROUND_COLOR,
+        backgroundImage: String? = null,
+        backgroundImageGravity: ImageGravity = DEFAULT_BACKGROUND_IMAGE_GRAVITY,
+        backgroundImageScaleType: ImageScaleType = DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE,
+        textColor: Color? = null,
         textScale: Double = DEFAULT_TEXT_SCALE,
         cardBackgroundColor: Color? = null,
+        cardTextColor: Color? = null,
         cards: ((TractPage) -> List<Card>?)? = null,
         callToAction: ((TractPage) -> CallToAction?)? = null
     ) : super(manifest) {
@@ -159,16 +165,16 @@ class TractPage : BaseModel, Styles {
         _primaryColor = null
         _primaryTextColor = null
 
-        backgroundColor = DEFAULT_BACKGROUND_COLOR
-        _backgroundImage = null
-        backgroundImageGravity = DEFAULT_BACKGROUND_IMAGE_GRAVITY
-        backgroundImageScaleType = DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE
+        this.backgroundColor = backgroundColor
+        _backgroundImage = backgroundImage
+        this.backgroundImageGravity = backgroundImageGravity
+        this.backgroundImageScaleType = backgroundImageScaleType
 
-        _textColor = null
+        _textColor = textColor
         _textScale = textScale
 
         _cardBackgroundColor = cardBackgroundColor
-        _cardTextColor = null
+        _cardTextColor = cardTextColor
 
         header = null
         hero = null

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/TractPage.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/TractPage.kt
@@ -1,0 +1,169 @@
+package org.cru.godtools.tool.model.tract
+
+import org.cru.godtools.tool.internal.AndroidColorInt
+import org.cru.godtools.tool.internal.RestrictTo
+import org.cru.godtools.tool.internal.VisibleForTesting
+import org.cru.godtools.tool.model.BaseModel
+import org.cru.godtools.tool.model.Color
+import org.cru.godtools.tool.model.EventId
+import org.cru.godtools.tool.model.ImageGravity
+import org.cru.godtools.tool.model.ImageGravity.Companion.toImageGravityOrNull
+import org.cru.godtools.tool.model.ImageScaleType
+import org.cru.godtools.tool.model.ImageScaleType.Companion.toImageScaleTypeOrNull
+import org.cru.godtools.tool.model.Manifest
+import org.cru.godtools.tool.model.Styles
+import org.cru.godtools.tool.model.XML_BACKGROUND_COLOR
+import org.cru.godtools.tool.model.XML_BACKGROUND_IMAGE
+import org.cru.godtools.tool.model.XML_BACKGROUND_IMAGE_GRAVITY
+import org.cru.godtools.tool.model.XML_BACKGROUND_IMAGE_SCALE_TYPE
+import org.cru.godtools.tool.model.XML_LISTENERS
+import org.cru.godtools.tool.model.XML_PRIMARY_COLOR
+import org.cru.godtools.tool.model.XML_PRIMARY_TEXT_COLOR
+import org.cru.godtools.tool.model.XML_TEXT_COLOR
+import org.cru.godtools.tool.model.XML_TEXT_SCALE
+import org.cru.godtools.tool.model.color
+import org.cru.godtools.tool.model.getResource
+import org.cru.godtools.tool.model.primaryColor
+import org.cru.godtools.tool.model.primaryTextColor
+import org.cru.godtools.tool.model.textColor
+import org.cru.godtools.tool.model.textScale
+import org.cru.godtools.tool.model.toColorOrNull
+import org.cru.godtools.tool.model.toEventIds
+import org.cru.godtools.tool.model.tract.TractPage.Companion.DEFAULT_BACKGROUND_COLOR
+import org.cru.godtools.tool.model.tract.TractPage.Companion.DEFAULT_BACKGROUND_IMAGE_GRAVITY
+import org.cru.godtools.tool.model.tract.TractPage.Companion.DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE
+import org.cru.godtools.tool.xml.XmlPullParser
+import org.cru.godtools.tool.xml.parseChildren
+
+private const val XML_PAGE = "page"
+private const val XML_CARD_TEXT_COLOR = "card-text-color"
+
+class TractPage : BaseModel, Styles {
+    internal companion object {
+        @AndroidColorInt
+        internal val DEFAULT_BACKGROUND_COLOR = color(0, 0, 0, 0.0)
+        internal val DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE = ImageScaleType.FILL_X
+        internal val DEFAULT_BACKGROUND_IMAGE_GRAVITY = ImageGravity.CENTER
+
+        @VisibleForTesting
+        internal const val DEFAULT_TEXT_SCALE = 1.0
+    }
+
+    val id get() = fileName ?: "${manifest.code}-$position"
+    val position: Int
+
+    @VisibleForTesting
+    internal val fileName: String?
+    val listeners: Set<EventId>
+
+    @AndroidColorInt
+    val backgroundColor: Color
+    private val _backgroundImage: String?
+    val backgroundImage get() = getResource(_backgroundImage)
+    val backgroundImageGravity: ImageGravity
+    val backgroundImageScaleType: ImageScaleType
+
+    val hero: Hero?
+
+    @AndroidColorInt
+    private val _primaryColor: Color?
+    @get:AndroidColorInt
+    override val primaryColor get() = _primaryColor ?: stylesParent.primaryColor
+
+    @AndroidColorInt
+    private val _primaryTextColor: Color?
+    @get:AndroidColorInt
+    override val primaryTextColor get() = _primaryTextColor ?: stylesParent.primaryTextColor
+
+    @AndroidColorInt
+    private val _textColor: Color?
+    @get:AndroidColorInt
+    override val textColor get() = _textColor ?: stylesParent.textColor
+    private val _textScale: Double
+    override val textScale get() = _textScale * stylesParent.textScale
+
+    @AndroidColorInt
+    private val _cardTextColor: Color?
+    @get:AndroidColorInt
+    val cardTextColor get() = _cardTextColor ?: textColor
+
+    @AndroidColorInt
+    private val _cardBackgroundColor: Color?
+    @get:AndroidColorInt
+    val cardBackgroundColor get() = _cardBackgroundColor ?: manifest.cardBackgroundColor
+
+    internal constructor(
+        manifest: Manifest,
+        position: Int,
+        fileName: String?,
+        parser: XmlPullParser
+    ) : super(manifest) {
+        this.position = position
+        this.fileName = fileName
+
+        parser.require(XmlPullParser.START_TAG, XMLNS_TRACT, XML_PAGE)
+
+        listeners = parser.getAttributeValue(XML_LISTENERS).toEventIds().toSet()
+        _primaryColor = parser.getAttributeValue(XML_PRIMARY_COLOR)?.toColorOrNull()
+        _primaryTextColor = parser.getAttributeValue(XML_PRIMARY_TEXT_COLOR)?.toColorOrNull()
+
+        backgroundColor = parser.getAttributeValue(XML_BACKGROUND_COLOR)?.toColorOrNull() ?: DEFAULT_BACKGROUND_COLOR
+        _backgroundImage = parser.getAttributeValue(XML_BACKGROUND_IMAGE)
+        backgroundImageGravity = parser.getAttributeValue(XML_BACKGROUND_IMAGE_GRAVITY)?.toImageGravityOrNull()
+            ?: DEFAULT_BACKGROUND_IMAGE_GRAVITY
+        backgroundImageScaleType = parser.getAttributeValue(XML_BACKGROUND_IMAGE_SCALE_TYPE)?.toImageScaleTypeOrNull()
+            ?: DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE
+
+        _textColor = parser.getAttributeValue(XML_TEXT_COLOR)?.toColorOrNull()
+        _textScale = parser.getAttributeValue(XML_TEXT_SCALE)?.toDoubleOrNull() ?: DEFAULT_TEXT_SCALE
+
+        _cardBackgroundColor = parser.getAttributeValue(XML_CARD_BACKGROUND_COLOR)?.toColorOrNull()
+        _cardTextColor = parser.getAttributeValue(XML_CARD_TEXT_COLOR)?.toColorOrNull()
+
+        // process any child elements
+        var hero: Hero? = null
+        parser.parseChildren {
+            when (parser.namespace) {
+                XMLNS_TRACT -> when (parser.name) {
+                    Hero.XML_HERO -> hero = Hero(this, parser)
+                }
+            }
+        }
+        this.hero = hero
+    }
+
+    @RestrictTo(RestrictTo.Scope.TESTS)
+    internal constructor(
+        manifest: Manifest,
+        position: Int = 0,
+        fileName: String? = null,
+        textScale: Double = DEFAULT_TEXT_SCALE,
+        cardBackgroundColor: Color? = null,
+    ) : super(manifest) {
+        this.position = position
+        this.fileName = fileName
+
+        listeners = emptySet()
+
+        _primaryColor = null
+        _primaryTextColor = null
+
+        backgroundColor = DEFAULT_BACKGROUND_COLOR
+        _backgroundImage = null
+        backgroundImageGravity = DEFAULT_BACKGROUND_IMAGE_GRAVITY
+        backgroundImageScaleType = DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE
+
+        _textColor = null
+        _textScale = textScale
+
+        _cardBackgroundColor = cardBackgroundColor
+        _cardTextColor = null
+
+        hero = null
+    }
+}
+
+@get:AndroidColorInt
+val TractPage?.backgroundColor get() = this?.backgroundColor ?: DEFAULT_BACKGROUND_COLOR
+val TractPage?.backgroundImageScaleType get() = this?.backgroundImageScaleType ?: DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE
+val TractPage?.backgroundImageGravity get() = this?.backgroundImageGravity ?: DEFAULT_BACKGROUND_IMAGE_GRAVITY

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/TractPage.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/TractPage.kt
@@ -52,7 +52,7 @@ class TractPage : BaseModel, Styles {
     }
 
     val id get() = fileName ?: "${manifest.code}-$position"
-    val position: Int
+    val position by lazy { manifest.tractPages.indexOf(this) }
 
     @VisibleForTesting
     internal val fileName: String?
@@ -99,13 +99,7 @@ class TractPage : BaseModel, Styles {
     @get:AndroidColorInt
     val cardBackgroundColor get() = _cardBackgroundColor ?: manifest.cardBackgroundColor
 
-    internal constructor(
-        manifest: Manifest,
-        position: Int,
-        fileName: String?,
-        parser: XmlPullParser
-    ) : super(manifest) {
-        this.position = position
+    internal constructor(manifest: Manifest, fileName: String?, parser: XmlPullParser) : super(manifest) {
         this.fileName = fileName
 
         parser.require(XmlPullParser.START_TAG, XMLNS_TRACT, XML_PAGE)
@@ -152,14 +146,12 @@ class TractPage : BaseModel, Styles {
     @RestrictTo(RestrictTo.Scope.TESTS)
     internal constructor(
         manifest: Manifest,
-        position: Int = 0,
         fileName: String? = null,
         textScale: Double = DEFAULT_TEXT_SCALE,
         cardBackgroundColor: Color? = null,
         cards: ((TractPage) -> List<Card>?)? = null,
         callToAction: ((TractPage) -> CallToAction?)? = null
     ) : super(manifest) {
-        this.position = position
         this.fileName = fileName
 
         listeners = emptySet()
@@ -205,7 +197,7 @@ class TractPage : BaseModel, Styles {
         parseChildren {
             when (namespace) {
                 XMLNS_TRACT -> when (name) {
-                    Modal.XML_MODAL -> add(Modal(this@TractPage, size, this@parseModalsXml))
+                    Modal.XML_MODAL -> add(Modal(this@TractPage, this@parseModalsXml))
                 }
             }
         }

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/TractPage.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/TractPage.kt
@@ -63,6 +63,7 @@ class TractPage : BaseModel, Styles {
     val backgroundImageGravity: ImageGravity
     val backgroundImageScaleType: ImageScaleType
 
+    val header: Header?
     val hero: Hero?
 
     @AndroidColorInt
@@ -121,14 +122,17 @@ class TractPage : BaseModel, Styles {
         _cardTextColor = parser.getAttributeValue(XML_CARD_TEXT_COLOR)?.toColorOrNull()
 
         // process any child elements
+        var header: Header? = null
         var hero: Hero? = null
         parser.parseChildren {
             when (parser.namespace) {
                 XMLNS_TRACT -> when (parser.name) {
+                    Header.XML_HEADER -> header = Header(this, parser)
                     Hero.XML_HERO -> hero = Hero(this, parser)
                 }
             }
         }
+        this.header = header
         this.hero = hero
     }
 
@@ -159,6 +163,7 @@ class TractPage : BaseModel, Styles {
         _cardBackgroundColor = cardBackgroundColor
         _cardTextColor = null
 
+        header = null
         hero = null
     }
 }

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/ColorTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/ColorTest.kt
@@ -15,7 +15,7 @@ class ColorTest {
         assertEquals(TestColors.BLUE, "rgba(0,0,255,1)".toColorOrNull())
         assertEquals(TestColors.BLACK, "rgba(0,0,0,1)".toColorOrNull())
         assertEquals(TestColors.BLACK, "rgba(0,0,0,1.0)".toColorOrNull())
-        assertEquals(TestColors.TRANSPARENT, "rgba(0,0,0,0)".toColorOrNull())
+        assertEquals(TRANSPARENT, "rgba(0,0,0,0)".toColorOrNull())
     }
 
     @Test

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/ManifestTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/ManifestTest.kt
@@ -39,7 +39,7 @@ class ManifestTest : UsesResources() {
         assertEquals(Manifest.DEFAULT_TEXT_SCALE, manifest.textScale, 0.0001)
 //        assertEquals(0, manifest.aemImports.size)
         assertTrue(manifest.lessonPages.isEmpty())
-//        assertThat(manifest.tractPages, `is`(empty()))
+        assertTrue(manifest.tractPages.isEmpty())
         assertEquals(0, manifest.resources.size)
         assertEquals(0, manifest.tips.size)
     }
@@ -69,7 +69,7 @@ class ManifestTest : UsesResources() {
         assertEquals(Manifest.Type.LESSON, manifest.type)
         assertEquals(TestColors.RED, manifest.lessonControlColor)
         assertEquals(EventId.parse("dismiss_event").toSet(), manifest.dismissListeners)
-//        assertThat(manifest.tractPages, `is`(empty()))
+        assertTrue(manifest.tractPages.isEmpty())
         assertEquals(1, manifest.lessonPages.size)
         assertEquals("page0.xml", manifest.lessonPages[0].fileName)
     }
@@ -85,11 +85,11 @@ class ManifestTest : UsesResources() {
         assertEquals(color(255, 0, 255, 1.0), manifest.navBarControlColor)
         assertEquals(1.2345, manifest.textScale, 0.00001)
         assertTrue(manifest.lessonPages.isEmpty())
-//        assertEquals(2, manifest.tractPages.size)
-//        assertEquals("page0.xml", manifest.tractPages[0].fileName)
-//        assertEquals(0, manifest.tractPages[0].position)
-//        assertEquals(null, manifest.tractPages[1].fileName)
-//        assertEquals(1, manifest.tractPages[1].position)
+        assertEquals(2, manifest.tractPages.size)
+        assertEquals("page0.xml", manifest.tractPages[0].fileName)
+        assertEquals(0, manifest.tractPages[0].position)
+        assertEquals(null, manifest.tractPages[1].fileName)
+        assertEquals(1, manifest.tractPages[1].position)
     }
 
     @Test
@@ -107,7 +107,7 @@ class ManifestTest : UsesResources() {
     @Test
     fun testParseManifestContainingTips() {
         val manifest = parseManifest("manifest_tips.xml")
-//        assertEquals(0, manifest.tractPages.size)
+        assertEquals(0, manifest.tractPages.size)
         assertEquals(0, manifest.resources.size)
         assertEquals(1, manifest.tips.size)
         assertEquals("tip1", manifest.findTip("tip1")!!.id)
@@ -116,7 +116,7 @@ class ManifestTest : UsesResources() {
     @Test
     fun testParseManifestInvalidTips() {
         val manifest = parseManifest("manifest_tips_invalid.xml")
-//        assertEquals(0, manifest.tractPages.size)
+        assertEquals(0, manifest.tractPages.size)
         assertEquals(0, manifest.resources.size)
         assertEquals(0, manifest.tips.size)
     }

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/TestColors.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/TestColors.kt
@@ -5,5 +5,4 @@ object TestColors {
     val GREEN = color(0, 255, 0, 1.0)
     val BLUE = color(0, 0, 255, 1.0)
     val BLACK = color(0, 0, 0, 1.0)
-    val TRANSPARENT = color(0, 0, 0, 0.0)
 }

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/CallToActionTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/CallToActionTest.kt
@@ -13,7 +13,7 @@ import kotlin.test.assertEquals
 class CallToActionTest : UsesResources("model/tract") {
     @Test
     fun testParseCallToAction() {
-        val callToAction = TractPage(Manifest(), 0, null, getTestXmlParser("call_to_action.xml")).callToAction
+        val callToAction = TractPage(Manifest(), null, getTestXmlParser("call_to_action.xml")).callToAction
         assertEquals(TestColors.RED, callToAction.controlColor)
         assertEquals("event1 event2".toEventIds(), callToAction.events)
         assertEquals("Call To Action", callToAction.label!!.text)

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/CallToActionTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/CallToActionTest.kt
@@ -1,0 +1,22 @@
+package org.cru.godtools.tool.model.tract
+
+import org.cru.godtools.tool.internal.AndroidJUnit4
+import org.cru.godtools.tool.internal.RunOnAndroidWith
+import org.cru.godtools.tool.internal.UsesResources
+import org.cru.godtools.tool.model.Manifest
+import org.cru.godtools.tool.model.TestColors
+import org.cru.godtools.tool.model.toEventIds
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@RunOnAndroidWith(AndroidJUnit4::class)
+class CallToActionTest : UsesResources("model/tract") {
+    @Test
+    fun testParseCallToAction() {
+        val callToAction = TractPage(Manifest(), 0, null, getTestXmlParser("call_to_action.xml")).callToAction
+        assertEquals(TestColors.RED, callToAction.controlColor)
+        assertEquals("event1 event2".toEventIds(), callToAction.events)
+        assertEquals("Call To Action", callToAction.label!!.text)
+        assertEquals("tip1", callToAction.tipId)
+    }
+}

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/CardTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/CardTest.kt
@@ -1,0 +1,68 @@
+package org.cru.godtools.tool.model.tract
+
+import org.cru.godtools.tool.internal.AndroidJUnit4
+import org.cru.godtools.tool.internal.RunOnAndroidWith
+import org.cru.godtools.tool.internal.UsesResources
+import org.cru.godtools.tool.model.Manifest
+import org.cru.godtools.tool.model.Paragraph
+import org.cru.godtools.tool.model.TestColors
+import org.cru.godtools.tool.model.tips.InlineTip
+import org.cru.godtools.tool.model.tips.Tip
+import org.cru.godtools.tool.model.toEventIds
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+@RunOnAndroidWith(AndroidJUnit4::class)
+class CardTest : UsesResources("model/tract") {
+    @Test
+    fun verifyParseCard() {
+        val card = TractPage(Manifest(code = "test"), 0, null, getTestXmlParser("card.xml")).cards.single()
+        assertEquals("test-0-0", card.id)
+        assertEquals("Card 1", card.label!!.text)
+        assertEquals(TestColors.RED, card.backgroundColor)
+        assertEquals("listener1 listener2".toEventIds().toSet(), card.listeners)
+        assertEquals("dismiss-listener1 dismiss-listener2".toEventIds().toSet(), card.dismissListeners)
+        assertEquals(1, card.content.size)
+        assertIs<Paragraph>(card.content[0])
+    }
+
+    @Test
+    fun verifyCardTips() {
+        val tip1 = Tip(id = "tip1")
+        val tip2 = Tip(id = "tip2")
+        val page = TractPage(Manifest(tips = { listOf(tip1, tip2) }))
+        val card = Card(page) {
+            listOf(
+                InlineTip(it, "tip1"),
+                Paragraph(it) { listOf(InlineTip(it, "tip2")) },
+                InlineTip(it, "tip3"),
+                InlineTip(it, "tip1")
+            )
+        }
+
+        assertEquals(3, card.tips.size)
+        assertEquals(listOf(tip1, tip2, tip1), card.tips)
+    }
+
+    @Test
+    fun verifyCardIsLastVisibleCard() {
+        val page = TractPage(
+            Manifest(),
+            cards = { listOf(Card(it, isHidden = false), Card(it, isHidden = false), Card(it, isHidden = true)) }
+        )
+
+        assertFalse(page.cards[0].isLastVisibleCard)
+        assertTrue(page.cards[1].isLastVisibleCard)
+        assertFalse(page.cards[2].isLastVisibleCard)
+    }
+
+    @Test
+    fun testCardBackgroundColorFallbackBehavior() {
+        val page = TractPage(Manifest(), cardBackgroundColor = TestColors.GREEN)
+        assertEquals(TestColors.GREEN, Card(page).backgroundColor)
+        assertEquals(TestColors.BLUE, Card(page, backgroundColor = TestColors.BLUE).backgroundColor)
+    }
+}

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/CardTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/CardTest.kt
@@ -3,8 +3,11 @@ package org.cru.godtools.tool.model.tract
 import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
+import org.cru.godtools.tool.model.ImageGravity
+import org.cru.godtools.tool.model.ImageScaleType
 import org.cru.godtools.tool.model.Manifest
 import org.cru.godtools.tool.model.Paragraph
+import org.cru.godtools.tool.model.Resource
 import org.cru.godtools.tool.model.TestColors
 import org.cru.godtools.tool.model.tips.InlineTip
 import org.cru.godtools.tool.model.tips.Tip
@@ -25,6 +28,8 @@ class CardTest : UsesResources("model/tract") {
         assertEquals(TestColors.RED, card.backgroundColor)
         assertEquals("listener1 listener2".toEventIds().toSet(), card.listeners)
         assertEquals("dismiss-listener1 dismiss-listener2".toEventIds().toSet(), card.dismissListeners)
+        assertEquals(1, card.analyticsEvents.size)
+        assertEquals("firebaseEvent", card.analyticsEvents.single().action)
         assertEquals(1, card.content.size)
         assertIs<Paragraph>(card.content[0])
     }
@@ -57,6 +62,36 @@ class CardTest : UsesResources("model/tract") {
         assertFalse(page.cards[0].isLastVisibleCard)
         assertTrue(page.cards[1].isLastVisibleCard)
         assertFalse(page.cards[2].isLastVisibleCard)
+    }
+
+    @Test
+    fun testBackgroundAttributes() {
+        val manifest = Manifest(resources = { listOf(Resource(it, name = "background.png")) })
+        val card = Card(
+            TractPage(manifest),
+            backgroundColor = TestColors.GREEN,
+            backgroundImage = "background.png",
+            backgroundImageGravity = ImageGravity.END,
+            backgroundImageScaleType = ImageScaleType.FILL_Y
+        )
+        val resource = manifest.resources["background.png"]
+
+        with(null as Card?) {
+            assertEquals(manifest.backgroundColor, backgroundColor)
+            assertEquals(Card.DEFAULT_BACKGROUND_IMAGE_GRAVITY, backgroundImageGravity)
+            assertEquals(Card.DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE, backgroundImageScaleType)
+        }
+        with(card as Card?) {
+            assertEquals(TestColors.GREEN, backgroundColor)
+            assertEquals(ImageGravity.END, backgroundImageGravity)
+            assertEquals(ImageScaleType.FILL_Y, backgroundImageScaleType)
+        }
+        with(card) {
+            assertEquals(TestColors.GREEN, backgroundColor)
+            assertEquals(resource, backgroundImage)
+            assertEquals(ImageGravity.END, backgroundImageGravity)
+            assertEquals(ImageScaleType.FILL_Y, backgroundImageScaleType)
+        }
     }
 
     @Test

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/CardTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/CardTest.kt
@@ -19,8 +19,8 @@ import kotlin.test.assertTrue
 class CardTest : UsesResources("model/tract") {
     @Test
     fun verifyParseCard() {
-        val card = TractPage(Manifest(code = "test"), 0, null, getTestXmlParser("card.xml")).cards.single()
-        assertEquals("test-0-0", card.id)
+        val card = TractPage(Manifest(code = "test"), "page.xml", getTestXmlParser("card.xml")).cards.single()
+        assertEquals("page.xml-0", card.id)
         assertEquals("Card 1", card.label!!.text)
         assertEquals(TestColors.RED, card.backgroundColor)
         assertEquals("listener1 listener2".toEventIds().toSet(), card.listeners)

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/HeaderTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/HeaderTest.kt
@@ -1,0 +1,22 @@
+package org.cru.godtools.tool.model.tract
+
+import org.cru.godtools.tool.internal.AndroidJUnit4
+import org.cru.godtools.tool.internal.RunOnAndroidWith
+import org.cru.godtools.tool.internal.UsesResources
+import org.cru.godtools.tool.model.Manifest
+import org.cru.godtools.tool.model.TestColors
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+@RunOnAndroidWith(AndroidJUnit4::class)
+class HeaderTest : UsesResources("model/tract") {
+    @Test
+    fun testParseHeader() {
+        val header = assertNotNull(TractPage(Manifest(), 0, null, getTestXmlParser("header.xml")).header)
+        assertEquals("5", header.number!!.text)
+        assertEquals("title", header.title!!.text)
+        assertEquals(TestColors.RED, header.backgroundColor)
+        assertEquals("header-tip", header.tipId)
+    }
+}

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/HeaderTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/HeaderTest.kt
@@ -5,9 +5,13 @@ import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
 import org.cru.godtools.tool.model.Manifest
 import org.cru.godtools.tool.model.TestColors
+import org.cru.godtools.tool.model.primaryColor
+import org.cru.godtools.tool.model.stylesParent
+import org.cru.godtools.tool.model.tips.Tip
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 @RunOnAndroidWith(AndroidJUnit4::class)
 class HeaderTest : UsesResources("model/tract") {
@@ -18,5 +22,33 @@ class HeaderTest : UsesResources("model/tract") {
         assertEquals("title", header.title!!.text)
         assertEquals(TestColors.RED, header.backgroundColor)
         assertEquals("header-tip", header.tipId)
+    }
+
+    @Test
+    fun testParseHeaderDefaults() {
+        val page = TractPage(Manifest(), null, getTestXmlParser("header_defaults.xml"))
+        val header = assertNotNull(page.header)
+
+        assertEquals(page.primaryColor, header.backgroundColor)
+        assertEquals(page.primaryTextColor, header.textColor)
+        assertNull(header.number)
+        assertNull(header.title)
+        assertNull(header.tipId)
+    }
+
+    @Test
+    fun testBackgroundColorBehavior() {
+        val header = Header(TractPage(Manifest()), backgroundColor = TestColors.GREEN)
+
+        with(null as Header?) { assertEquals(stylesParent.primaryColor, backgroundColor) }
+        with(header as Header?) { assertEquals(TestColors.GREEN, backgroundColor) }
+        with(header) { assertEquals(TestColors.GREEN, backgroundColor) }
+    }
+
+    @Test
+    fun testTipProperty() {
+        val manifest = Manifest(tips = { listOf(Tip(it, "tip1")) })
+        val header = Header(TractPage(manifest), tip = "tip1")
+        assertEquals(manifest.findTip("tip1")!!, header.tip)
     }
 }

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/HeaderTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/HeaderTest.kt
@@ -13,7 +13,7 @@ import kotlin.test.assertNotNull
 class HeaderTest : UsesResources("model/tract") {
     @Test
     fun testParseHeader() {
-        val header = assertNotNull(TractPage(Manifest(), 0, null, getTestXmlParser("header.xml")).header)
+        val header = assertNotNull(TractPage(Manifest(), null, getTestXmlParser("header.xml")).header)
         assertEquals("5", header.number!!.text)
         assertEquals("title", header.title!!.text)
         assertEquals(TestColors.RED, header.backgroundColor)

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/HeroTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/HeroTest.kt
@@ -31,7 +31,7 @@ class HeroTest : UsesResources("model/tract") {
 
     @Test
     fun testParseHero() {
-        val hero = assertNotNull(TractPage(Manifest(), 0, null, getTestXmlParser("hero.xml")).hero)
+        val hero = assertNotNull(TractPage(Manifest(), null, getTestXmlParser("hero.xml")).hero)
         assertEquals(1, hero.analyticsEvents.size)
         assertEquals("Heading", hero.heading!!.text)
         assertEquals(3, hero.content.size)
@@ -42,7 +42,7 @@ class HeroTest : UsesResources("model/tract") {
 
     @Test
     fun testParseHeroIgnoredContent() {
-        val hero = assertNotNull(TractPage(Manifest(), 0, null, getTestXmlParser("hero_ignored_content.xml")).hero)
+        val hero = assertNotNull(TractPage(Manifest(), null, getTestXmlParser("hero_ignored_content.xml")).hero)
         assertEquals(2, hero.content.size)
         assertIs<Paragraph>(hero.content[0])
         assertIs<Tabs>(hero.content[1])

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/HeroTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/HeroTest.kt
@@ -15,6 +15,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertNotNull
 
 @RunOnAndroidWith(AndroidJUnit4::class)
 class HeroTest : UsesResources("model/tract") {
@@ -30,7 +31,7 @@ class HeroTest : UsesResources("model/tract") {
 
     @Test
     fun testParseHero() {
-        val hero = Hero(Manifest(), getTestXmlParser("hero.xml"))
+        val hero = assertNotNull(TractPage(Manifest(), 0, null, getTestXmlParser("hero.xml")).hero)
         assertEquals(1, hero.analyticsEvents.size)
         assertEquals("Heading", hero.heading!!.text)
         assertEquals(3, hero.content.size)
@@ -41,7 +42,7 @@ class HeroTest : UsesResources("model/tract") {
 
     @Test
     fun testParseHeroIgnoredContent() {
-        val hero = Hero(Manifest(), getTestXmlParser("hero_ignored_content.xml"))
+        val hero = assertNotNull(TractPage(Manifest(), 0, null, getTestXmlParser("hero_ignored_content.xml")).hero)
         assertEquals(2, hero.content.size)
         assertIs<Paragraph>(hero.content[0])
         assertIs<Tabs>(hero.content[1])

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/HeroTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/HeroTest.kt
@@ -1,0 +1,49 @@
+package org.cru.godtools.tool.model.tract
+
+import org.cru.godtools.tool.DEFAULT_SUPPORTED_DEVICE_TYPES
+import org.cru.godtools.tool.ParserConfig
+import org.cru.godtools.tool.internal.AndroidJUnit4
+import org.cru.godtools.tool.internal.RunOnAndroidWith
+import org.cru.godtools.tool.internal.UsesResources
+import org.cru.godtools.tool.model.DeviceType
+import org.cru.godtools.tool.model.Image
+import org.cru.godtools.tool.model.Manifest
+import org.cru.godtools.tool.model.Paragraph
+import org.cru.godtools.tool.model.Tabs
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+@RunOnAndroidWith(AndroidJUnit4::class)
+class HeroTest : UsesResources("model/tract") {
+    @BeforeTest
+    fun setupConfig() {
+        ParserConfig.supportedDeviceTypes = setOf(DeviceType.ANDROID, DeviceType.MOBILE)
+    }
+
+    @AfterTest
+    fun resetConfig() {
+        ParserConfig.supportedDeviceTypes = DEFAULT_SUPPORTED_DEVICE_TYPES
+    }
+
+    @Test
+    fun testParseHero() {
+        val hero = Hero(Manifest(), getTestXmlParser("hero.xml"))
+        assertEquals(1, hero.analyticsEvents.size)
+        assertEquals("Heading", hero.heading!!.text)
+        assertEquals(3, hero.content.size)
+        assertIs<Image>(hero.content[0])
+        assertIs<Paragraph>(hero.content[1])
+        assertIs<Tabs>(hero.content[2])
+    }
+
+    @Test
+    fun testParseHeroIgnoredContent() {
+        val hero = Hero(Manifest(), getTestXmlParser("hero_ignored_content.xml"))
+        assertEquals(2, hero.content.size)
+        assertIs<Paragraph>(hero.content[0])
+        assertIs<Tabs>(hero.content[1])
+    }
+}

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/ModalTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/ModalTest.kt
@@ -14,7 +14,7 @@ import kotlin.test.assertIs
 class ModalTest : UsesResources("model/tract") {
     @Test
     fun testParseModal() {
-        val modal = TractPage(Manifest(), 0, null, getTestXmlParser("modal.xml")).modals.single()
+        val modal = TractPage(Manifest(), null, getTestXmlParser("modal.xml")).modals.single()
         assertEquals("listener1 listener2".toEventIds().toSet(), modal.listeners)
         assertEquals("dismiss-listener1 dismiss-listener2".toEventIds().toSet(), modal.dismissListeners)
         assertEquals(2, modal.content.size)

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/ModalTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/ModalTest.kt
@@ -1,0 +1,25 @@
+package org.cru.godtools.tool.model.tract
+
+import org.cru.godtools.tool.internal.AndroidJUnit4
+import org.cru.godtools.tool.internal.RunOnAndroidWith
+import org.cru.godtools.tool.internal.UsesResources
+import org.cru.godtools.tool.model.Manifest
+import org.cru.godtools.tool.model.Paragraph
+import org.cru.godtools.tool.model.toEventIds
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+@RunOnAndroidWith(AndroidJUnit4::class)
+class ModalTest : UsesResources("model/tract") {
+    @Test
+    fun testParseModal() {
+        val modal = TractPage(Manifest(), 0, null, getTestXmlParser("modal.xml")).modals.single()
+        assertEquals("listener1 listener2".toEventIds().toSet(), modal.listeners)
+        assertEquals("dismiss-listener1 dismiss-listener2".toEventIds().toSet(), modal.dismissListeners)
+        assertEquals(2, modal.content.size)
+        assertIs<Paragraph>(modal.content[0])
+        assertIs<Paragraph>(modal.content[1])
+        assertEquals("Thank you", modal.title!!.text)
+    }
+}

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/ModalTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/ModalTest.kt
@@ -3,8 +3,12 @@ package org.cru.godtools.tool.model.tract
 import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
+import org.cru.godtools.tool.model.Button
 import org.cru.godtools.tool.model.Manifest
 import org.cru.godtools.tool.model.Paragraph
+import org.cru.godtools.tool.model.TRANSPARENT
+import org.cru.godtools.tool.model.Text
+import org.cru.godtools.tool.model.WHITE
 import org.cru.godtools.tool.model.toEventIds
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -14,12 +18,25 @@ import kotlin.test.assertIs
 class ModalTest : UsesResources("model/tract") {
     @Test
     fun testParseModal() {
-        val modal = TractPage(Manifest(), null, getTestXmlParser("modal.xml")).modals.single()
+        val modal = TractPage(Manifest(), "testPage", getTestXmlParser("modal.xml")).modals.single()
+        assertEquals("testPage-0", modal.id)
+        assertFixedAttributes(modal)
         assertEquals("listener1 listener2".toEventIds().toSet(), modal.listeners)
         assertEquals("dismiss-listener1 dismiss-listener2".toEventIds().toSet(), modal.dismissListeners)
         assertEquals(2, modal.content.size)
         assertIs<Paragraph>(modal.content[0])
         assertIs<Paragraph>(modal.content[1])
         assertEquals("Thank you", modal.title!!.text)
+    }
+
+    private fun assertFixedAttributes(modal: Modal) {
+        assertEquals(TRANSPARENT, modal.primaryColor)
+        assertEquals(WHITE, modal.primaryTextColor)
+
+        assertEquals(WHITE, modal.buttonColor)
+        assertEquals(Button.Style.OUTLINED, modal.buttonStyle)
+
+        assertEquals(Text.Align.CENTER, modal.textAlign)
+        assertEquals(WHITE, modal.textColor)
     }
 }

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/TractPageTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/TractPageTest.kt
@@ -23,7 +23,16 @@ class TractPageTest : UsesResources("model/tract") {
         assertEquals("header", page.header!!.title!!.text)
         assertEquals("hero", page.hero!!.heading!!.text)
         assertEquals("call to action", page.callToAction.label!!.text)
+        assertTrue(page.cards.isEmpty())
         assertTrue(page.modals.isEmpty())
+    }
+
+    @Test
+    fun verifyParseCards() {
+        val page = parsePageXml("page_cards.xml")
+        assertEquals(2, page.cards.size)
+        assertEquals("Card 1", page.cards[0].label!!.text)
+        assertEquals("Card 2", page.cards[1].label!!.text)
     }
 
     @Test

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/TractPageTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/TractPageTest.kt
@@ -3,11 +3,16 @@ package org.cru.godtools.tool.model.tract
 import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
+import org.cru.godtools.tool.model.ImageGravity
 import org.cru.godtools.tool.model.ImageScaleType
 import org.cru.godtools.tool.model.Manifest
+import org.cru.godtools.tool.model.Resource
 import org.cru.godtools.tool.model.TestColors
+import org.cru.godtools.tool.model.textColor
+import org.cru.godtools.tool.model.toEventIds
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
 @RunOnAndroidWith(AndroidJUnit4::class)
@@ -20,6 +25,7 @@ class TractPageTest : UsesResources("model/tract") {
         assertTrue(page.backgroundImageGravity.isStart)
         assertEquals(ImageScaleType.FILL, page.backgroundImageScaleType)
         assertEquals(1.2345, page.textScale, 0.00001)
+        assertEquals("event1 event2".toEventIds().toSet(), page.listeners)
         assertEquals("header", page.header!!.title!!.text)
         assertEquals("hero", page.hero!!.heading!!.text)
         assertEquals("call to action", page.callToAction.label!!.text)
@@ -44,10 +50,65 @@ class TractPageTest : UsesResources("model/tract") {
     }
 
     @Test
+    fun testBackgroundAttributes() {
+        val manifest = Manifest(resources = { listOf(Resource(it, name = "background.png")) })
+        val page = TractPage(
+            manifest,
+            backgroundColor = TestColors.GREEN,
+            backgroundImage = "background.png",
+            backgroundImageGravity = ImageGravity.END,
+            backgroundImageScaleType = ImageScaleType.FILL_Y
+        )
+        val resource = manifest.resources["background.png"]
+
+        with(null as TractPage?) {
+            assertEquals(TractPage.DEFAULT_BACKGROUND_COLOR, backgroundColor)
+            assertEquals(TractPage.DEFAULT_BACKGROUND_IMAGE_GRAVITY, backgroundImageGravity)
+            assertEquals(TractPage.DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE, backgroundImageScaleType)
+        }
+        with(page as TractPage?) {
+            assertEquals(TestColors.GREEN, backgroundColor)
+            assertEquals(ImageGravity.END, backgroundImageGravity)
+            assertEquals(ImageScaleType.FILL_Y, backgroundImageScaleType)
+        }
+        with(page) {
+            assertEquals(TestColors.GREEN, backgroundColor)
+            assertEquals(resource, backgroundImage)
+            assertEquals(ImageGravity.END, backgroundImageGravity)
+            assertEquals(ImageScaleType.FILL_Y, backgroundImageScaleType)
+        }
+    }
+
+    @Test
     fun testCardBackgroundColorFallbackBehavior() {
         val manifest = Manifest(cardBackgroundColor = TestColors.BLUE)
         assertEquals(TestColors.GREEN, TractPage(manifest, cardBackgroundColor = TestColors.GREEN).cardBackgroundColor)
         assertEquals(manifest.cardBackgroundColor, TractPage(manifest).cardBackgroundColor)
+    }
+
+    @Test
+    fun testCardTextColorBehavior() {
+        with(TractPage(Manifest(), textColor = TestColors.GREEN)) {
+            assertEquals(TestColors.GREEN, cardTextColor)
+            assertEquals(textColor, cardTextColor)
+        }
+        with(TractPage(Manifest(), cardTextColor = TestColors.GREEN)) {
+            assertEquals(TestColors.GREEN, cardTextColor)
+            assertNotEquals(textColor, cardTextColor)
+        }
+    }
+
+    @Test
+    fun testTextColor() {
+        with(null as TractPage?) { assertEquals(Manifest.DEFAULT_TEXT_COLOR, textColor) }
+        with(TractPage(Manifest(textColor = TestColors.GREEN))) {
+            assertEquals(TestColors.GREEN, (this as TractPage?).textColor)
+            assertEquals(TestColors.GREEN, textColor)
+        }
+        with(TractPage(Manifest(textColor = TestColors.RED), textColor = TestColors.GREEN)) {
+            assertEquals(TestColors.GREEN, (this as TractPage?).textColor)
+            assertEquals(TestColors.GREEN, textColor)
+        }
     }
 
     @Test

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/TractPageTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/TractPageTest.kt
@@ -1,0 +1,44 @@
+package org.cru.godtools.tool.model.tract
+
+import org.cru.godtools.tool.internal.AndroidJUnit4
+import org.cru.godtools.tool.internal.RunOnAndroidWith
+import org.cru.godtools.tool.internal.UsesResources
+import org.cru.godtools.tool.model.ImageScaleType
+import org.cru.godtools.tool.model.Manifest
+import org.cru.godtools.tool.model.TestColors
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@RunOnAndroidWith(AndroidJUnit4::class)
+class TractPageTest : UsesResources("model/tract") {
+    @Test
+    fun verifyParse() {
+        val page = parsePageXml("page.xml")
+        assertEquals(TestColors.RED, page.backgroundColor)
+        assertTrue(page.backgroundImageGravity.isTop)
+        assertTrue(page.backgroundImageGravity.isStart)
+        assertEquals(ImageScaleType.FILL, page.backgroundImageScaleType)
+        assertEquals(1.2345, page.textScale, 0.00001)
+        assertEquals("hero", page.hero!!.heading!!.text)
+    }
+
+    @Test
+    fun testCardBackgroundColorFallbackBehavior() {
+        val manifest = Manifest(cardBackgroundColor = TestColors.BLUE)
+        assertEquals(TestColors.GREEN, TractPage(manifest, cardBackgroundColor = TestColors.GREEN).cardBackgroundColor)
+        assertEquals(manifest.cardBackgroundColor, TractPage(manifest).cardBackgroundColor)
+    }
+
+    @Test
+    fun testTextScale() {
+        assertEquals(TractPage.DEFAULT_TEXT_SCALE, TractPage(Manifest()).textScale, 0.001)
+        assertEquals(2.0, TractPage(Manifest(), textScale = 2.0).textScale, 0.001)
+
+        val manifest = Manifest(textScale = 3.0)
+        assertEquals(3.0, TractPage(manifest).textScale, 0.001)
+        assertEquals(6.0, TractPage(manifest, textScale = 2.0).textScale, 0.001)
+    }
+
+    private fun parsePageXml(file: String) = TractPage(Manifest(), 0, null, getTestXmlParser(file))
+}

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/TractPageTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/TractPageTest.kt
@@ -20,6 +20,7 @@ class TractPageTest : UsesResources("model/tract") {
         assertTrue(page.backgroundImageGravity.isStart)
         assertEquals(ImageScaleType.FILL, page.backgroundImageScaleType)
         assertEquals(1.2345, page.textScale, 0.00001)
+        assertEquals("header", page.header!!.title!!.text)
         assertEquals("hero", page.hero!!.heading!!.text)
     }
 

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/TractPageTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/TractPageTest.kt
@@ -60,5 +60,5 @@ class TractPageTest : UsesResources("model/tract") {
         assertEquals(6.0, TractPage(manifest, textScale = 2.0).textScale, 0.001)
     }
 
-    private fun parsePageXml(file: String) = TractPage(Manifest(), 0, null, getTestXmlParser(file))
+    private fun parsePageXml(file: String) = TractPage(Manifest(), null, getTestXmlParser(file))
 }

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/TractPageTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/TractPageTest.kt
@@ -22,6 +22,16 @@ class TractPageTest : UsesResources("model/tract") {
         assertEquals(1.2345, page.textScale, 0.00001)
         assertEquals("header", page.header!!.title!!.text)
         assertEquals("hero", page.hero!!.heading!!.text)
+        assertEquals("call to action", page.callToAction.label!!.text)
+        assertTrue(page.modals.isEmpty())
+    }
+
+    @Test
+    fun verifyParseModals() {
+        val page = parsePageXml("page_modals.xml")
+        assertEquals(2, page.modals.size)
+        assertEquals("Modal 1", page.modals[0].title?.text)
+        assertEquals("Modal 2", page.modals[1].title?.text)
     }
 
     @Test

--- a/src/commonTest/resources/org/cru/godtools/tool/model/tract/call_to_action.xml
+++ b/src/commonTest/resources/org/cru/godtools/tool/model/tract/call_to_action.xml
@@ -1,0 +1,7 @@
+<page xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    xmlns:training="https://mobile-content-api.cru.org/xmlns/training"
+    xmlns="https://mobile-content-api.cru.org/xmlns/tract">
+    <call-to-action control-color="rgba(255,0,0,1)" events="event1 event2" training:tip="tip1">
+        <content:text>Call To Action</content:text>
+    </call-to-action>
+</page>

--- a/src/commonTest/resources/org/cru/godtools/tool/model/tract/card.xml
+++ b/src/commonTest/resources/org/cru/godtools/tool/model/tract/card.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<page xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
-    xmlns="https://mobile-content-api.cru.org/xmlns/tract">
+<page xmlns="https://mobile-content-api.cru.org/xmlns/tract"
+    xmlns:analytics="https://mobile-content-api.cru.org/xmlns/analytics"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content">
     <cards>
         <card background-color="rgba(255,0,0,1)"
             dismiss-listeners="dismiss-listener1 dismiss-listener2"
@@ -8,6 +9,9 @@
             <label>
                 <content:text>Card 1</content:text>
             </label>
+            <analytics:events>
+                <analytics:event system="firebase" action="firebaseEvent" />
+            </analytics:events>
             <content:paragraph>
                 <content:text>Test</content:text>
             </content:paragraph>

--- a/src/commonTest/resources/org/cru/godtools/tool/model/tract/card.xml
+++ b/src/commonTest/resources/org/cru/godtools/tool/model/tract/card.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    xmlns="https://mobile-content-api.cru.org/xmlns/tract">
+    <cards>
+        <card background-color="rgba(255,0,0,1)"
+            dismiss-listeners="dismiss-listener1 dismiss-listener2"
+            listeners="listener1 listener2">
+            <label>
+                <content:text>Card 1</content:text>
+            </label>
+            <content:paragraph>
+                <content:text>Test</content:text>
+            </content:paragraph>
+        </card>
+    </cards>
+</page>

--- a/src/commonTest/resources/org/cru/godtools/tool/model/tract/header.xml
+++ b/src/commonTest/resources/org/cru/godtools/tool/model/tract/header.xml
@@ -1,0 +1,11 @@
+<page xmlns:content="https://mobile-content-api.cru.org/xmlns/content" xmlns:training="https://mobile-content-api.cru.org/xmlns/training"
+    xmlns="https://mobile-content-api.cru.org/xmlns/tract">
+    <header background-color="rgba(255,0,0,1)" training:tip="header-tip">
+        <number>
+            <content:text>5</content:text>
+        </number>
+        <title>
+            <content:text>title</content:text>
+        </title>
+    </header>
+</page>

--- a/src/commonTest/resources/org/cru/godtools/tool/model/tract/header_defaults.xml
+++ b/src/commonTest/resources/org/cru/godtools/tool/model/tract/header_defaults.xml
@@ -1,0 +1,3 @@
+<page xmlns="https://mobile-content-api.cru.org/xmlns/tract">
+    <header />
+</page>

--- a/src/commonTest/resources/org/cru/godtools/tool/model/tract/hero.xml
+++ b/src/commonTest/resources/org/cru/godtools/tool/model/tract/hero.xml
@@ -1,0 +1,19 @@
+<tract:hero xmlns:analytics="https://mobile-content-api.cru.org/xmlns/analytics" xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    xmlns:tract="https://mobile-content-api.cru.org/xmlns/tract" background-color="rgba(255,0,0,1)">
+    <analytics:events>
+        <analytics:event system="adobe" action="test" />
+    </analytics:events>
+    <tract:heading>
+        <content:text>Heading</content:text>
+    </tract:heading>
+    <content:image resource="test.png" />
+    <content:paragraph />
+    <content:unrecognized />
+    <content:tabs>
+        <content:tab>
+            <content:label>
+                <content:text>Tab 1</content:text>
+            </content:label>
+        </content:tab>
+    </content:tabs>
+</tract:hero>

--- a/src/commonTest/resources/org/cru/godtools/tool/model/tract/hero.xml
+++ b/src/commonTest/resources/org/cru/godtools/tool/model/tract/hero.xml
@@ -1,19 +1,21 @@
-<tract:hero xmlns:analytics="https://mobile-content-api.cru.org/xmlns/analytics" xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
-    xmlns:tract="https://mobile-content-api.cru.org/xmlns/tract" background-color="rgba(255,0,0,1)">
-    <analytics:events>
-        <analytics:event system="adobe" action="test" />
-    </analytics:events>
-    <tract:heading>
-        <content:text>Heading</content:text>
-    </tract:heading>
-    <content:image resource="test.png" />
-    <content:paragraph />
-    <content:unrecognized />
-    <content:tabs>
-        <content:tab>
-            <content:label>
-                <content:text>Tab 1</content:text>
-            </content:label>
-        </content:tab>
-    </content:tabs>
-</tract:hero>
+<page xmlns="https://mobile-content-api.cru.org/xmlns/tract" xmlns:analytics="https://mobile-content-api.cru.org/xmlns/analytics"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content">
+    <hero>
+        <analytics:events>
+            <analytics:event system="adobe" action="test" />
+        </analytics:events>
+        <heading>
+            <content:text>Heading</content:text>
+        </heading>
+        <content:image resource="test.png" />
+        <content:paragraph />
+        <content:unrecognized />
+        <content:tabs>
+            <content:tab>
+                <content:label>
+                    <content:text>Tab 1</content:text>
+                </content:label>
+            </content:tab>
+        </content:tabs>
+    </hero>
+</page>

--- a/src/commonTest/resources/org/cru/godtools/tool/model/tract/hero_ignored_content.xml
+++ b/src/commonTest/resources/org/cru/godtools/tool/model/tract/hero_ignored_content.xml
@@ -1,0 +1,13 @@
+<tract:hero xmlns:analytics="https://mobile-content-api.cru.org/xmlns/analytics" xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    xmlns:tract="https://mobile-content-api.cru.org/xmlns/tract" background-color="rgba(255,0,0,1)">
+    <content:image resource="test.png" restrictTo="web" />
+    <content:paragraph />
+    <content:unrecognized />
+    <content:tabs>
+        <content:tab>
+            <content:label>
+                <content:text>Tab 1</content:text>
+            </content:label>
+        </content:tab>
+    </content:tabs>
+</tract:hero>

--- a/src/commonTest/resources/org/cru/godtools/tool/model/tract/hero_ignored_content.xml
+++ b/src/commonTest/resources/org/cru/godtools/tool/model/tract/hero_ignored_content.xml
@@ -1,13 +1,15 @@
-<tract:hero xmlns:analytics="https://mobile-content-api.cru.org/xmlns/analytics" xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
-    xmlns:tract="https://mobile-content-api.cru.org/xmlns/tract" background-color="rgba(255,0,0,1)">
-    <content:image resource="test.png" restrictTo="web" />
-    <content:paragraph />
-    <content:unrecognized />
-    <content:tabs>
-        <content:tab>
-            <content:label>
-                <content:text>Tab 1</content:text>
-            </content:label>
-        </content:tab>
-    </content:tabs>
-</tract:hero>
+<page xmlns="https://mobile-content-api.cru.org/xmlns/tract"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content">
+    <hero>
+        <content:image resource="test.png" restrictTo="web" />
+        <content:paragraph />
+        <content:unrecognized />
+        <content:tabs>
+            <content:tab>
+                <content:label>
+                    <content:text>Tab 1</content:text>
+                </content:label>
+            </content:tab>
+        </content:tabs>
+    </hero>
+</page>

--- a/src/commonTest/resources/org/cru/godtools/tool/model/tract/modal.xml
+++ b/src/commonTest/resources/org/cru/godtools/tool/model/tract/modal.xml
@@ -1,0 +1,16 @@
+<page xmlns="https://mobile-content-api.cru.org/xmlns/tract"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content">
+    <modals>
+        <modal listeners="listener1 listener2" dismiss-listeners="dismiss-listener1 dismiss-listener2">
+            <title>
+                <content:text>Thank you</content:text>
+            </title>
+            <content:paragraph>
+                <content:text>Check your email soon for your first study in following Jesus Christ.</content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text>If you don't receive it, please check your spam folder.</content:text>
+            </content:paragraph>
+        </modal>
+    </modals>
+</page>

--- a/src/commonTest/resources/org/cru/godtools/tool/model/tract/page.xml
+++ b/src/commonTest/resources/org/cru/godtools/tool/model/tract/page.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns="https://mobile-content-api.cru.org/xmlns/tract"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    background-color="rgba(255, 0, 0, 1)" background-image-align="start top" background-image-scale-type="fill"
+    text-scale="1.2345">
+    <header>
+        <title>
+            <content:text>header</content:text>
+        </title>
+    </header>
+    <hero>
+        <heading>
+            <content:text>hero</content:text>
+        </heading>
+    </hero>
+    <call-to-action>
+        <content:text>call to action</content:text>
+    </call-to-action>
+</page>

--- a/src/commonTest/resources/org/cru/godtools/tool/model/tract/page.xml
+++ b/src/commonTest/resources/org/cru/godtools/tool/model/tract/page.xml
@@ -2,7 +2,7 @@
 <page xmlns="https://mobile-content-api.cru.org/xmlns/tract"
     xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
     background-color="rgba(255, 0, 0, 1)" background-image-align="start top" background-image-scale-type="fill"
-    text-scale="1.2345">
+    text-scale="1.2345" listeners="event1 event2">
     <header>
         <title>
             <content:text>header</content:text>

--- a/src/commonTest/resources/org/cru/godtools/tool/model/tract/page_cards.xml
+++ b/src/commonTest/resources/org/cru/godtools/tool/model/tract/page_cards.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    xmlns="https://mobile-content-api.cru.org/xmlns/tract">
+    <cards>
+        <card card-background-color="rgba(0,0,0,1)">
+            <label>
+                <content:text>Card 1</content:text>
+            </label>
+        </card>
+        <card>
+            <label>
+                <content:text>Card 2</content:text>
+            </label>
+        </card>
+    </cards>
+</page>

--- a/src/commonTest/resources/org/cru/godtools/tool/model/tract/page_modals.xml
+++ b/src/commonTest/resources/org/cru/godtools/tool/model/tract/page_modals.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    xmlns="https://mobile-content-api.cru.org/xmlns/tract">
+    <modals>
+        <modal dismiss-listeners="dismiss" listeners="open">
+            <title>
+                <content:text>Modal 1</content:text>
+            </title>
+        </modal>
+        <modal dismiss-listeners="dismiss" listeners="open">
+            <title>
+                <content:text>Modal 2</content:text>
+            </title>
+        </modal>
+    </modals>
+</page>


### PR DESCRIPTION
- import hero model
- import tract page parsing logic
- adjust Hero tests
- import the Header model
- add the CallToAction model
- add a couple common color constants
- import Modal model
- import the Card model
- support parsing tract pages referenced by a manifest
