### PR TITLE
cleanup

### DIFF
--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Header.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Header.kt
@@ -61,7 +61,11 @@ class Header : BaseModel, Styles {
     }
 
     @RestrictTo(RestrictTo.Scope.TESTS)
-    internal constructor(page: TractPage, backgroundColor: Color? = null, tip: String? = null) : super(page) {
+    internal constructor(
+        page: TractPage = TractPage(),
+        backgroundColor: Color? = null,
+        tip: String? = null
+    ) : super(page) {
         _backgroundColor = backgroundColor
 
         number = null

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/TractPage.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/TractPage.kt
@@ -145,7 +145,7 @@ class TractPage : BaseModel, Styles {
 
     @RestrictTo(RestrictTo.Scope.TESTS)
     internal constructor(
-        manifest: Manifest,
+        manifest: Manifest = Manifest(),
         fileName: String? = null,
         backgroundColor: Color = DEFAULT_BACKGROUND_COLOR,
         backgroundImage: String? = null,

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/CardTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/CardTest.kt
@@ -55,7 +55,6 @@ class CardTest : UsesResources("model/tract") {
     @Test
     fun verifyCardIsLastVisibleCard() {
         val page = TractPage(
-            Manifest(),
             cards = { listOf(Card(it, isHidden = false), Card(it, isHidden = false), Card(it, isHidden = true)) }
         )
 
@@ -96,7 +95,7 @@ class CardTest : UsesResources("model/tract") {
 
     @Test
     fun testCardBackgroundColorFallbackBehavior() {
-        val page = TractPage(Manifest(), cardBackgroundColor = TestColors.GREEN)
+        val page = TractPage(cardBackgroundColor = TestColors.GREEN)
         assertEquals(TestColors.GREEN, Card(page).backgroundColor)
         assertEquals(TestColors.BLUE, Card(page, backgroundColor = TestColors.BLUE).backgroundColor)
     }

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/HeaderTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/HeaderTest.kt
@@ -38,7 +38,7 @@ class HeaderTest : UsesResources("model/tract") {
 
     @Test
     fun testBackgroundColorBehavior() {
-        val header = Header(TractPage(), backgroundColor = TestColors.GREEN)
+        val header = Header(backgroundColor = TestColors.GREEN)
 
         with(null as Header?) { assertEquals(stylesParent.primaryColor, backgroundColor) }
         with(header as Header?) { assertEquals(TestColors.GREEN, backgroundColor) }

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/HeaderTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/HeaderTest.kt
@@ -38,7 +38,7 @@ class HeaderTest : UsesResources("model/tract") {
 
     @Test
     fun testBackgroundColorBehavior() {
-        val header = Header(TractPage(Manifest()), backgroundColor = TestColors.GREEN)
+        val header = Header(TractPage(), backgroundColor = TestColors.GREEN)
 
         with(null as Header?) { assertEquals(stylesParent.primaryColor, backgroundColor) }
         with(header as Header?) { assertEquals(TestColors.GREEN, backgroundColor) }

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/TractPageTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/TractPageTest.kt
@@ -88,11 +88,11 @@ class TractPageTest : UsesResources("model/tract") {
 
     @Test
     fun testCardTextColorBehavior() {
-        with(TractPage(Manifest(), textColor = TestColors.GREEN)) {
+        with(TractPage(textColor = TestColors.GREEN)) {
             assertEquals(TestColors.GREEN, cardTextColor)
             assertEquals(textColor, cardTextColor)
         }
-        with(TractPage(Manifest(), cardTextColor = TestColors.GREEN)) {
+        with(TractPage(cardTextColor = TestColors.GREEN)) {
             assertEquals(TestColors.GREEN, cardTextColor)
             assertNotEquals(textColor, cardTextColor)
         }
@@ -114,7 +114,7 @@ class TractPageTest : UsesResources("model/tract") {
     @Test
     fun testTextScale() {
         assertEquals(TractPage.DEFAULT_TEXT_SCALE, TractPage(Manifest()).textScale, 0.001)
-        assertEquals(2.0, TractPage(Manifest(), textScale = 2.0).textScale, 0.001)
+        assertEquals(2.0, TractPage(textScale = 2.0).textScale, 0.001)
 
         val manifest = Manifest(textScale = 3.0)
         assertEquals(3.0, TractPage(manifest).textScale, 0.001)


### PR DESCRIPTION
- supply a default Manifest for the TractPage test constructor
- provide a default TractPage property for the Header test constructor
