### PR TITLE
Implement base textSizes utilizing textScale

### DIFF
--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/Category.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/Category.kt
@@ -1,5 +1,6 @@
 package org.cru.godtools.tool.model
 
+import org.cru.godtools.tool.internal.RestrictTo
 import org.cru.godtools.tool.xml.XmlPullParser
 import org.cru.godtools.tool.xml.parseChildren
 
@@ -9,7 +10,7 @@ private const val XML_BANNER = "banner"
 private const val XML_AEM_TAG = "aem-tag"
 
 @OptIn(ExperimentalStdlibApi::class)
-class Category internal constructor(manifest: Manifest, parser: XmlPullParser) : BaseModel(manifest) {
+class Category : BaseModel, Styles {
     internal companion object {
         internal const val XML_CATEGORY = "category"
     }
@@ -20,7 +21,9 @@ class Category internal constructor(manifest: Manifest, parser: XmlPullParser) :
     private val _banner: String?
     val banner get() = getResource(_banner)
 
-    init {
+    override val textScale get() = super.textScale * TEXT_SIZE_CATEGORY / TEXT_SIZE_BASE
+
+    internal constructor(manifest: Manifest, parser: XmlPullParser) : super(manifest) {
         parser.require(XmlPullParser.START_TAG, XMLNS_MANIFEST, XML_CATEGORY)
 
         id = parser.getAttributeValue(XML_ID)
@@ -40,5 +43,13 @@ class Category internal constructor(manifest: Manifest, parser: XmlPullParser) :
             }
         }
         this.label = label
+    }
+
+    @RestrictTo(RestrictTo.Scope.TESTS)
+    internal constructor(manifest: Manifest = Manifest(), label: (Base) -> Text?) : super(manifest) {
+        id = null
+        this.label = label(this)
+        aemTags = emptySet()
+        _banner = null
     }
 }

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/Constants.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/Constants.kt
@@ -36,6 +36,7 @@ internal const val TEXT_SIZE_CATEGORY = 30
 internal const val TEXT_SIZE_HEADER = 18
 internal const val TEXT_SIZE_HEADER_NUMBER = 54
 internal const val TEXT_SIZE_HERO_HEADING = 30
+internal const val TEXT_SIZE_CARD_LABEL = 18
 internal const val TEXT_SIZE_MODAL = 18
 internal const val TEXT_SIZE_MODAL_TITLE = 54
 // endregion Text Sizes

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/Constants.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/Constants.kt
@@ -32,6 +32,8 @@ internal val WHITE = color(255, 255, 255, 1.0)
 // region Text Sizes
 // these text sizes are exposed publicly via relative textScale properties based off the base text size
 internal const val TEXT_SIZE_BASE = 16
+internal const val TEXT_SIZE_HEADER = 18
+internal const val TEXT_SIZE_HEADER_NUMBER = 54
 internal const val TEXT_SIZE_MODAL = 18
 internal const val TEXT_SIZE_MODAL_TITLE = 54
 // endregion Text Sizes

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/Constants.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/Constants.kt
@@ -34,6 +34,7 @@ internal val WHITE = color(255, 255, 255, 1.0)
 internal const val TEXT_SIZE_BASE = 16
 internal const val TEXT_SIZE_HEADER = 18
 internal const val TEXT_SIZE_HEADER_NUMBER = 54
+internal const val TEXT_SIZE_HERO_HEADING = 30
 internal const val TEXT_SIZE_MODAL = 18
 internal const val TEXT_SIZE_MODAL_TITLE = 54
 // endregion Text Sizes

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/Constants.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/Constants.kt
@@ -28,3 +28,9 @@ internal const val XML_LISTENERS = "listeners"
 internal val TRANSPARENT = color(0, 0, 0, 0.0)
 @SharedImmutable
 internal val WHITE = color(255, 255, 255, 1.0)
+
+// region Text Sizes
+// these text sizes are exposed publicly via relative textScale properties based off the base text size
+internal const val TEXT_SIZE_BASE = 16
+internal const val TEXT_SIZE_MODAL = 18
+// endregion Text Sizes

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/Constants.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/Constants.kt
@@ -32,6 +32,7 @@ internal val WHITE = color(255, 255, 255, 1.0)
 // region Text Sizes
 // these text sizes are exposed publicly via relative textScale properties based off the base text size
 internal const val TEXT_SIZE_BASE = 16
+internal const val TEXT_SIZE_CATEGORY = 30
 internal const val TEXT_SIZE_HEADER = 18
 internal const val TEXT_SIZE_HEADER_NUMBER = 54
 internal const val TEXT_SIZE_HERO_HEADING = 30

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/Constants.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/Constants.kt
@@ -33,4 +33,5 @@ internal val WHITE = color(255, 255, 255, 1.0)
 // these text sizes are exposed publicly via relative textScale properties based off the base text size
 internal const val TEXT_SIZE_BASE = 16
 internal const val TEXT_SIZE_MODAL = 18
+internal const val TEXT_SIZE_MODAL_TITLE = 54
 // endregion Text Sizes

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
@@ -7,6 +7,7 @@ import org.cru.godtools.tool.internal.fluidlocale.PlatformLocale
 import org.cru.godtools.tool.internal.fluidlocale.toLocaleOrNull
 import org.cru.godtools.tool.model.ImageGravity.Companion.toImageGravityOrNull
 import org.cru.godtools.tool.model.ImageScaleType.Companion.toImageScaleTypeOrNull
+import org.cru.godtools.tool.model.Styles.Companion.DEFAULT_TEXT_SCALE
 import org.cru.godtools.tool.model.lesson.DEFAULT_LESSON_CONTROL_COLOR
 import org.cru.godtools.tool.model.lesson.DEFAULT_LESSON_NAV_BAR_COLOR
 import org.cru.godtools.tool.model.lesson.LessonPage
@@ -60,7 +61,6 @@ class Manifest : BaseModel, Styles {
 
         @AndroidColorInt
         internal val DEFAULT_TEXT_COLOR = color(90, 90, 90, 1.0)
-        internal const val DEFAULT_TEXT_SCALE = 1.0
         internal val DEFAULT_TEXT_ALIGN = Text.Align.START
 
         internal fun parse(fileName: String, parseFile: (String) -> XmlPullParser) =

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/Styles.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/Styles.kt
@@ -1,8 +1,13 @@
 package org.cru.godtools.tool.model
 
 import org.cru.godtools.tool.internal.AndroidColorInt
+import org.cru.godtools.tool.model.Styles.Companion.DEFAULT_TEXT_SCALE
 
 interface Styles : Base {
+    companion object {
+        internal const val DEFAULT_TEXT_SCALE = 1.0
+    }
+
     @get:AndroidColorInt
     val primaryColor: Color get() = stylesParent.primaryColor
     @get:AndroidColorInt
@@ -32,6 +37,6 @@ val Styles?.buttonStyle get() = this?.buttonStyle ?: Manifest.DEFAULT_BUTTON_STY
 // region Text styles
 @get:AndroidColorInt
 val Styles?.textColor get() = this?.textColor ?: Manifest.DEFAULT_TEXT_COLOR
-val Styles?.textScale get() = this?.textScale ?: Manifest.DEFAULT_TEXT_SCALE
+val Styles?.textScale get() = this?.textScale ?: DEFAULT_TEXT_SCALE
 val Styles?.textAlign get() = this?.textAlign ?: Manifest.DEFAULT_TEXT_ALIGN
 // endregion Text styles

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/StylesOverride.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/StylesOverride.kt
@@ -1,0 +1,12 @@
+package org.cru.godtools.tool.model
+
+import org.cru.godtools.tool.model.Styles.Companion.DEFAULT_TEXT_SCALE
+
+private class StylesOverride(
+    parent: Base,
+    private val _textScale: Double
+) : BaseModel(parent), Styles {
+    override val textScale get() = super.textScale * _textScale
+}
+
+internal fun Base.stylesOverride(textScale: Double = DEFAULT_TEXT_SCALE): Base = StylesOverride(this, textScale)

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/Text.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/Text.kt
@@ -6,6 +6,7 @@ import org.cru.godtools.tool.internal.AndroidDimension
 import org.cru.godtools.tool.internal.DP
 import org.cru.godtools.tool.internal.RestrictTo
 import org.cru.godtools.tool.internal.VisibleForTesting
+import org.cru.godtools.tool.model.Styles.Companion.DEFAULT_TEXT_SCALE
 import org.cru.godtools.tool.model.Text.Align.Companion.toTextAlignOrNull
 import org.cru.godtools.tool.model.Text.Style.Companion.toTextStyles
 import org.cru.godtools.tool.xml.XmlPullParser
@@ -27,8 +28,6 @@ private const val XML_TEXT_STYLE_UNDERLINE = "underline"
 class Text : Content {
     internal companion object {
         internal const val XML_TEXT = "text"
-
-        internal const val DEFAULT_TEXT_SCALE = 1.0
 
         @VisibleForTesting
         @AndroidDimension(unit = DP)

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/lesson/LessonPage.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/lesson/LessonPage.kt
@@ -14,6 +14,7 @@ import org.cru.godtools.tool.model.ImageScaleType.Companion.toImageScaleTypeOrNu
 import org.cru.godtools.tool.model.Manifest
 import org.cru.godtools.tool.model.Parent
 import org.cru.godtools.tool.model.Styles
+import org.cru.godtools.tool.model.Styles.Companion.DEFAULT_TEXT_SCALE
 import org.cru.godtools.tool.model.XML_BACKGROUND_COLOR
 import org.cru.godtools.tool.model.XML_BACKGROUND_IMAGE
 import org.cru.godtools.tool.model.XML_BACKGROUND_IMAGE_GRAVITY
@@ -45,9 +46,6 @@ class LessonPage : BaseModel, Parent, Styles {
         internal val DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE = ImageScaleType.FILL_X
         @VisibleForTesting
         internal val DEFAULT_BACKGROUND_IMAGE_GRAVITY = ImageGravity.CENTER
-
-        @VisibleForTesting
-        internal const val DEFAULT_TEXT_SCALE = 1.0
     }
 
     val id by lazy { fileName ?: "${manifest.code}-$position" }

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Header.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Header.kt
@@ -3,13 +3,18 @@ package org.cru.godtools.tool.model.tract
 import org.cru.godtools.tool.internal.AndroidColorInt
 import org.cru.godtools.tool.internal.RestrictTo
 import org.cru.godtools.tool.internal.VisibleForTesting
+import org.cru.godtools.tool.model.Base
 import org.cru.godtools.tool.model.BaseModel
 import org.cru.godtools.tool.model.Color
 import org.cru.godtools.tool.model.Styles
+import org.cru.godtools.tool.model.TEXT_SIZE_BASE
+import org.cru.godtools.tool.model.TEXT_SIZE_HEADER
+import org.cru.godtools.tool.model.TEXT_SIZE_HEADER_NUMBER
 import org.cru.godtools.tool.model.Text
 import org.cru.godtools.tool.model.XML_BACKGROUND_COLOR
 import org.cru.godtools.tool.model.parseTextChild
 import org.cru.godtools.tool.model.primaryColor
+import org.cru.godtools.tool.model.stylesOverride
 import org.cru.godtools.tool.model.stylesParent
 import org.cru.godtools.tool.model.tips.XMLNS_TRAINING
 import org.cru.godtools.tool.model.toColorOrNull
@@ -32,7 +37,9 @@ class Header : BaseModel, Styles {
 
     @get:AndroidColorInt
     override val textColor get() = primaryTextColor
+    override val textScale get() = super.textScale * TEXT_SIZE_HEADER / TEXT_SIZE_BASE
 
+    private val numberParent by lazy { stylesOverride(TEXT_SIZE_HEADER_NUMBER.toDouble() / TEXT_SIZE_HEADER) }
     val number: Text?
     val title: Text?
 
@@ -51,7 +58,7 @@ class Header : BaseModel, Styles {
         parser.parseChildren {
             when (parser.namespace) {
                 XMLNS_TRACT -> when (parser.name) {
-                    XML_NUMBER -> number = parser.parseTextChild(this, XMLNS_TRACT, XML_NUMBER)
+                    XML_NUMBER -> number = parser.parseTextChild(numberParent, XMLNS_TRACT, XML_NUMBER)
                     XML_TITLE -> title = parser.parseTextChild(this, XMLNS_TRACT, XML_TITLE)
                 }
             }
@@ -64,12 +71,14 @@ class Header : BaseModel, Styles {
     internal constructor(
         page: TractPage = TractPage(),
         backgroundColor: Color? = null,
-        tip: String? = null
+        tip: String? = null,
+        number: ((Base) -> Text?)? = null,
+        title: ((Base) -> Text?)? = null,
     ) : super(page) {
         _backgroundColor = backgroundColor
 
-        number = null
-        title = null
+        this.number = number?.invoke(numberParent)
+        this.title = title?.invoke(this)
 
         tipId = tip
     }

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Hero.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Hero.kt
@@ -1,25 +1,30 @@
 package org.cru.godtools.tool.model.tract
 
+import org.cru.godtools.tool.internal.RestrictTo
 import org.cru.godtools.tool.model.AnalyticsEvent
 import org.cru.godtools.tool.model.AnalyticsEvent.Companion.parseAnalyticsEvents
+import org.cru.godtools.tool.model.Base
 import org.cru.godtools.tool.model.BaseModel
 import org.cru.godtools.tool.model.Content
 import org.cru.godtools.tool.model.Parent
-import org.cru.godtools.tool.model.Styles
+import org.cru.godtools.tool.model.TEXT_SIZE_BASE
+import org.cru.godtools.tool.model.TEXT_SIZE_HERO_HEADING
 import org.cru.godtools.tool.model.Text
 import org.cru.godtools.tool.model.XMLNS_ANALYTICS
 import org.cru.godtools.tool.model.parseContent
 import org.cru.godtools.tool.model.parseTextChild
+import org.cru.godtools.tool.model.stylesOverride
 import org.cru.godtools.tool.xml.XmlPullParser
 
-class Hero : BaseModel, Parent, Styles {
+private const val XML_HEADING = "heading"
+
+class Hero : BaseModel, Parent {
     internal companion object {
         internal const val XML_HERO = "hero"
-
-        private const val XML_HEADING = "heading"
     }
 
     val analyticsEvents: Collection<AnalyticsEvent>
+    private val headingParent by lazy { stylesOverride(textScale = TEXT_SIZE_HERO_HEADING.toDouble() / TEXT_SIZE_BASE) }
     val heading: Text?
     override val content: List<Content>
 
@@ -35,10 +40,17 @@ class Hero : BaseModel, Parent, Styles {
                     AnalyticsEvent.XML_EVENTS -> analyticsEvents += parser.parseAnalyticsEvents(this)
                 }
                 XMLNS_TRACT -> when (parser.name) {
-                    XML_HEADING -> heading = parser.parseTextChild(this, XMLNS_TRACT, XML_HEADING)
+                    XML_HEADING -> heading = parser.parseTextChild(headingParent, XMLNS_TRACT, XML_HEADING)
                 }
             }
         }
         this.heading = heading
+    }
+
+    @RestrictTo(RestrictTo.Scope.TESTS)
+    internal constructor(page: TractPage = TractPage(), heading: (Base) -> Text?) : super(page) {
+        analyticsEvents = emptyList()
+        this.heading = heading(headingParent)
+        content = emptyList()
     }
 }

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Modal.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Modal.kt
@@ -2,6 +2,7 @@ package org.cru.godtools.tool.model.tract
 
 import org.cru.godtools.tool.internal.AndroidColorInt
 import org.cru.godtools.tool.internal.RestrictTo
+import org.cru.godtools.tool.model.Base
 import org.cru.godtools.tool.model.BaseModel
 import org.cru.godtools.tool.model.Button
 import org.cru.godtools.tool.model.Content
@@ -10,6 +11,7 @@ import org.cru.godtools.tool.model.Parent
 import org.cru.godtools.tool.model.Styles
 import org.cru.godtools.tool.model.TEXT_SIZE_BASE
 import org.cru.godtools.tool.model.TEXT_SIZE_MODAL
+import org.cru.godtools.tool.model.TEXT_SIZE_MODAL_TITLE
 import org.cru.godtools.tool.model.TRANSPARENT
 import org.cru.godtools.tool.model.Text
 import org.cru.godtools.tool.model.WHITE
@@ -17,6 +19,7 @@ import org.cru.godtools.tool.model.XML_DISMISS_LISTENERS
 import org.cru.godtools.tool.model.XML_LISTENERS
 import org.cru.godtools.tool.model.parseContent
 import org.cru.godtools.tool.model.parseTextChild
+import org.cru.godtools.tool.model.stylesOverride
 import org.cru.godtools.tool.model.textScale
 import org.cru.godtools.tool.model.toEventIds
 import org.cru.godtools.tool.xml.XmlPullParser
@@ -32,6 +35,7 @@ class Modal : BaseModel, Parent, Styles {
     val id get() = "${page.id}-$position"
     private val position get() = page.modals.indexOf(this)
 
+    private val titleParent by lazy { stylesOverride(TEXT_SIZE_MODAL_TITLE.toDouble() / TEXT_SIZE_MODAL) }
     val title: Text?
     override val content: List<Content>
 
@@ -65,7 +69,7 @@ class Modal : BaseModel, Parent, Styles {
         content = parseContent(parser) {
             when (parser.namespace) {
                 XMLNS_TRACT -> when (parser.name) {
-                    XML_TITLE -> title = parser.parseTextChild(this@Modal, XMLNS_TRACT, XML_TITLE)
+                    XML_TITLE -> title = parser.parseTextChild(titleParent, XMLNS_TRACT, XML_TITLE)
                 }
             }
         }
@@ -73,9 +77,9 @@ class Modal : BaseModel, Parent, Styles {
     }
 
     @RestrictTo(RestrictTo.Scope.TESTS)
-    internal constructor(page: TractPage = TractPage()) : super(page) {
+    internal constructor(page: TractPage = TractPage(), title: (Base) -> Text?) : super(page) {
         this.page = page
-        title = null
+        this.title = title.invoke(titleParent)
         content = emptyList()
         listeners = emptySet()
         dismissListeners = emptySet()

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Modal.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Modal.kt
@@ -1,12 +1,15 @@
 package org.cru.godtools.tool.model.tract
 
 import org.cru.godtools.tool.internal.AndroidColorInt
+import org.cru.godtools.tool.internal.RestrictTo
 import org.cru.godtools.tool.model.BaseModel
 import org.cru.godtools.tool.model.Button
 import org.cru.godtools.tool.model.Content
 import org.cru.godtools.tool.model.EventId
 import org.cru.godtools.tool.model.Parent
 import org.cru.godtools.tool.model.Styles
+import org.cru.godtools.tool.model.TEXT_SIZE_BASE
+import org.cru.godtools.tool.model.TEXT_SIZE_MODAL
 import org.cru.godtools.tool.model.TRANSPARENT
 import org.cru.godtools.tool.model.Text
 import org.cru.godtools.tool.model.WHITE
@@ -14,6 +17,7 @@ import org.cru.godtools.tool.model.XML_DISMISS_LISTENERS
 import org.cru.godtools.tool.model.XML_LISTENERS
 import org.cru.godtools.tool.model.parseContent
 import org.cru.godtools.tool.model.parseTextChild
+import org.cru.godtools.tool.model.textScale
 import org.cru.godtools.tool.model.toEventIds
 import org.cru.godtools.tool.xml.XmlPullParser
 
@@ -46,6 +50,7 @@ class Modal : BaseModel, Parent, Styles {
     override val textAlign get() = Text.Align.CENTER
     @get:AndroidColorInt
     override val textColor get() = WHITE
+    override val textScale get() = stylesParent.textScale * TEXT_SIZE_MODAL / TEXT_SIZE_BASE
 
     internal constructor(parent: TractPage, parser: XmlPullParser) : super(parent) {
         page = parent
@@ -65,5 +70,14 @@ class Modal : BaseModel, Parent, Styles {
             }
         }
         this.title = title
+    }
+
+    @RestrictTo(RestrictTo.Scope.TESTS)
+    internal constructor(page: TractPage = TractPage()) : super(page) {
+        this.page = page
+        title = null
+        content = emptyList()
+        listeners = emptySet()
+        dismissListeners = emptySet()
     }
 }

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/TractPage.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/TractPage.kt
@@ -12,6 +12,7 @@ import org.cru.godtools.tool.model.ImageScaleType
 import org.cru.godtools.tool.model.ImageScaleType.Companion.toImageScaleTypeOrNull
 import org.cru.godtools.tool.model.Manifest
 import org.cru.godtools.tool.model.Styles
+import org.cru.godtools.tool.model.Styles.Companion.DEFAULT_TEXT_SCALE
 import org.cru.godtools.tool.model.XML_BACKGROUND_COLOR
 import org.cru.godtools.tool.model.XML_BACKGROUND_IMAGE
 import org.cru.godtools.tool.model.XML_BACKGROUND_IMAGE_GRAVITY
@@ -46,9 +47,6 @@ class TractPage : BaseModel, Styles {
         internal val DEFAULT_BACKGROUND_COLOR = color(0, 0, 0, 0.0)
         internal val DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE = ImageScaleType.FILL_X
         internal val DEFAULT_BACKGROUND_IMAGE_GRAVITY = ImageGravity.CENTER
-
-        @VisibleForTesting
-        internal const val DEFAULT_TEXT_SCALE = 1.0
     }
 
     val id get() = fileName ?: "${manifest.code}-$position"

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/CategoryTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/CategoryTest.kt
@@ -13,11 +13,26 @@ class CategoryTest : UsesResources() {
     fun testParseCategory() {
         val category = Manifest.parse("categories.xml") { getTestXmlParser(it) }.categories.single()
         assertEquals("testParseCategory", category.id)
-        assertNotNull(category.banner).also { banner ->
-            assertEquals("banner.jpg", banner.name)
-            assertEquals("bannersha1.jpg", banner.localName)
+        assertNotNull(category.banner).also {
+            assertEquals("banner.jpg", it.name)
+            assertEquals("bannersha1.jpg", it.localName)
         }
         assertEquals(setOf("tag1", "tag2"), category.aemTags)
         assertEquals("Category", category.label?.text)
+    }
+
+    @Test
+    fun testLabelTextSize() {
+        with(Category(label = { Text(it) })) {
+            assertEquals(TEXT_SIZE_CATEGORY, (TEXT_SIZE_BASE * label!!.textScale).toInt())
+        }
+
+        with(Category(Manifest(textScale = 2.0), label = { Text(it) })) {
+            assertEquals(2 * TEXT_SIZE_CATEGORY, (TEXT_SIZE_BASE * label!!.textScale).toInt())
+        }
+
+        with(Category(label = { Text(it, textScale = 2.0) })) {
+            assertEquals(2 * TEXT_SIZE_CATEGORY, (TEXT_SIZE_BASE * label!!.textScale).toInt())
+        }
     }
 }

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/ManifestTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/ManifestTest.kt
@@ -5,6 +5,7 @@ import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
 import org.cru.godtools.tool.internal.fluidlocale.toCommon
+import org.cru.godtools.tool.model.Styles.Companion.DEFAULT_TEXT_SCALE
 import org.cru.godtools.tool.model.lesson.DEFAULT_LESSON_CONTROL_COLOR
 import org.cru.godtools.tool.model.lesson.DEFAULT_LESSON_NAV_BAR_COLOR
 import kotlin.test.Test
@@ -36,7 +37,7 @@ class ManifestTest : UsesResources() {
         assertEquals(DEFAULT_LESSON_CONTROL_COLOR, manifest.lessonControlColor)
 
         assertEquals(Manifest.DEFAULT_TEXT_COLOR, manifest.textColor)
-        assertEquals(Manifest.DEFAULT_TEXT_SCALE, manifest.textScale, 0.0001)
+        assertEquals(DEFAULT_TEXT_SCALE, manifest.textScale, 0.0001)
         assertEquals(0, manifest.aemImports.size)
         assertTrue(manifest.lessonPages.isEmpty())
         assertTrue(manifest.tractPages.isEmpty())

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/StylesTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/StylesTest.kt
@@ -2,6 +2,7 @@ package org.cru.godtools.tool.model
 
 import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
+import org.cru.godtools.tool.model.Styles.Companion.DEFAULT_TEXT_SCALE
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -74,6 +75,6 @@ class StylesTest {
         assertEquals(Manifest.DEFAULT_BUTTON_STYLE, styles.buttonStyle)
         assertEquals(Manifest.DEFAULT_TEXT_ALIGN, styles.textAlign)
         assertEquals(Manifest.DEFAULT_TEXT_COLOR, styles.textColor)
-        assertEquals(Manifest.DEFAULT_TEXT_SCALE, styles.textScale)
+        assertEquals(DEFAULT_TEXT_SCALE, styles.textScale)
     }
 }

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/TextTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/TextTest.kt
@@ -3,7 +3,7 @@ package org.cru.godtools.tool.model
 import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
-import org.cru.godtools.tool.model.Manifest.Companion.DEFAULT_TEXT_SCALE
+import org.cru.godtools.tool.model.Styles.Companion.DEFAULT_TEXT_SCALE
 import org.cru.godtools.tool.model.Text.Align.Companion.toTextAlignOrNull
 import org.cru.godtools.tool.model.Text.Style.Companion.toTextStyles
 import kotlin.test.Test

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/lesson/LessonPageTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/lesson/LessonPageTest.kt
@@ -6,13 +6,13 @@ import org.cru.godtools.tool.internal.UsesResources
 import org.cru.godtools.tool.model.ImageScaleType
 import org.cru.godtools.tool.model.Manifest
 import org.cru.godtools.tool.model.Resource
+import org.cru.godtools.tool.model.Styles.Companion.DEFAULT_TEXT_SCALE
 import org.cru.godtools.tool.model.TEST_GRAVITY
 import org.cru.godtools.tool.model.TestColors
 import org.cru.godtools.tool.model.Text
 import org.cru.godtools.tool.model.lesson.LessonPage.Companion.DEFAULT_BACKGROUND_COLOR
 import org.cru.godtools.tool.model.lesson.LessonPage.Companion.DEFAULT_BACKGROUND_IMAGE_GRAVITY
 import org.cru.godtools.tool.model.lesson.LessonPage.Companion.DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE
-import org.cru.godtools.tool.model.lesson.LessonPage.Companion.DEFAULT_TEXT_SCALE
 import org.cru.godtools.tool.model.toEventIds
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/CardTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/CardTest.kt
@@ -8,7 +8,10 @@ import org.cru.godtools.tool.model.Manifest
 import org.cru.godtools.tool.model.Paragraph
 import org.cru.godtools.tool.model.Resource
 import org.cru.godtools.tool.model.TEST_GRAVITY
+import org.cru.godtools.tool.model.TEXT_SIZE_BASE
+import org.cru.godtools.tool.model.TEXT_SIZE_CARD_LABEL
 import org.cru.godtools.tool.model.TestColors
+import org.cru.godtools.tool.model.Text
 import org.cru.godtools.tool.model.tips.InlineTip
 import org.cru.godtools.tool.model.tips.Tip
 import org.cru.godtools.tool.model.toEventIds
@@ -98,5 +101,20 @@ class CardTest : UsesResources("model/tract") {
         val page = TractPage(cardBackgroundColor = TestColors.GREEN)
         assertEquals(TestColors.GREEN, Card(page).backgroundColor)
         assertEquals(TestColors.BLUE, Card(page, backgroundColor = TestColors.BLUE).backgroundColor)
+    }
+
+    @Test
+    fun testLabelTextSize() {
+        with(Card(label = { Text(it) })) {
+            assertEquals(TEXT_SIZE_CARD_LABEL, (label!!.textScale * TEXT_SIZE_BASE).toInt())
+        }
+
+        with(Card(TractPage(textScale = 2.0), label = { Text(it) })) {
+            assertEquals(2 * TEXT_SIZE_CARD_LABEL, (label!!.textScale * TEXT_SIZE_BASE).toInt())
+        }
+
+        with(Card(label = { Text(it, textScale = 2.0) })) {
+            assertEquals(2 * TEXT_SIZE_CARD_LABEL, (label!!.textScale * TEXT_SIZE_BASE).toInt())
+        }
     }
 }

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/HeaderTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/HeaderTest.kt
@@ -4,7 +4,11 @@ import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
 import org.cru.godtools.tool.model.Manifest
+import org.cru.godtools.tool.model.TEXT_SIZE_BASE
+import org.cru.godtools.tool.model.TEXT_SIZE_HEADER
+import org.cru.godtools.tool.model.TEXT_SIZE_HEADER_NUMBER
 import org.cru.godtools.tool.model.TestColors
+import org.cru.godtools.tool.model.Text
 import org.cru.godtools.tool.model.primaryColor
 import org.cru.godtools.tool.model.stylesParent
 import org.cru.godtools.tool.model.tips.Tip
@@ -43,6 +47,24 @@ class HeaderTest : UsesResources("model/tract") {
         with(null as Header?) { assertEquals(stylesParent.primaryColor, backgroundColor) }
         with(header as Header?) { assertEquals(TestColors.GREEN, backgroundColor) }
         with(header) { assertEquals(TestColors.GREEN, backgroundColor) }
+    }
+
+    @Test
+    fun testTextScale() {
+        with(Header(number = { Text(it) }, title = { Text(it) })) {
+            assertEquals(TEXT_SIZE_HEADER, (TEXT_SIZE_BASE * title!!.textScale).toInt())
+            assertEquals(TEXT_SIZE_HEADER_NUMBER, (TEXT_SIZE_BASE * number!!.textScale).toInt())
+        }
+
+        with(Header(TractPage(textScale = 2.0), number = { Text(it) }, title = { Text(it) })) {
+            assertEquals(2 * TEXT_SIZE_HEADER, (TEXT_SIZE_BASE * title!!.textScale).toInt())
+            assertEquals(2 * TEXT_SIZE_HEADER_NUMBER, (TEXT_SIZE_BASE * number!!.textScale).toInt())
+        }
+
+        with(Header(number = { Text(it, textScale = 3.0) }, title = { Text(it, textScale = 2.0) })) {
+            assertEquals(2 * TEXT_SIZE_HEADER, (TEXT_SIZE_BASE * title!!.textScale).toInt())
+            assertEquals(3 * TEXT_SIZE_HEADER_NUMBER, (TEXT_SIZE_BASE * number!!.textScale).toInt())
+        }
     }
 
     @Test

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/HeroTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/HeroTest.kt
@@ -9,7 +9,10 @@ import org.cru.godtools.tool.model.DeviceType
 import org.cru.godtools.tool.model.Image
 import org.cru.godtools.tool.model.Manifest
 import org.cru.godtools.tool.model.Paragraph
+import org.cru.godtools.tool.model.TEXT_SIZE_BASE
+import org.cru.godtools.tool.model.TEXT_SIZE_HERO_HEADING
 import org.cru.godtools.tool.model.Tabs
+import org.cru.godtools.tool.model.Text
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -46,5 +49,20 @@ class HeroTest : UsesResources("model/tract") {
         assertEquals(2, hero.content.size)
         assertIs<Paragraph>(hero.content[0])
         assertIs<Tabs>(hero.content[1])
+    }
+
+    @Test
+    fun testHeadingTextScale() {
+        with(Hero(heading = { Text(it) })) {
+            assertEquals(TEXT_SIZE_HERO_HEADING, (TEXT_SIZE_BASE * heading!!.textScale).toInt())
+        }
+
+        with(Hero(TractPage(textScale = 2.0), heading = { Text(it) })) {
+            assertEquals(2 * TEXT_SIZE_HERO_HEADING, (TEXT_SIZE_BASE * heading!!.textScale).toInt())
+        }
+
+        with(Hero(heading = { Text(it, textScale = 2.0) })) {
+            assertEquals(2 * TEXT_SIZE_HERO_HEADING, (TEXT_SIZE_BASE * heading!!.textScale).toInt())
+        }
     }
 }

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/ModalTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/ModalTest.kt
@@ -8,6 +8,7 @@ import org.cru.godtools.tool.model.Manifest
 import org.cru.godtools.tool.model.Paragraph
 import org.cru.godtools.tool.model.TEXT_SIZE_BASE
 import org.cru.godtools.tool.model.TEXT_SIZE_MODAL
+import org.cru.godtools.tool.model.TEXT_SIZE_MODAL_TITLE
 import org.cru.godtools.tool.model.TRANSPARENT
 import org.cru.godtools.tool.model.Text
 import org.cru.godtools.tool.model.WHITE
@@ -33,8 +34,20 @@ class ModalTest : UsesResources("model/tract") {
 
     @Test
     fun testTextScale() {
-        assertEquals(TEXT_SIZE_MODAL, (TEXT_SIZE_BASE * Modal().textScale).toInt())
-        assertEquals(2 * TEXT_SIZE_MODAL, (TEXT_SIZE_BASE * Modal(TractPage(textScale = 2.0)).textScale).toInt())
+        with(Modal(title = { Text(it) })) {
+            assertEquals(TEXT_SIZE_MODAL, (TEXT_SIZE_BASE * textScale).toInt())
+            assertEquals(TEXT_SIZE_MODAL_TITLE, (TEXT_SIZE_BASE * title!!.textScale).toInt())
+        }
+
+        with(Modal(TractPage(textScale = 2.0), title = { Text(it) })) {
+            assertEquals(2 * TEXT_SIZE_MODAL, (TEXT_SIZE_BASE * textScale).toInt())
+            assertEquals(2 * TEXT_SIZE_MODAL_TITLE, (TEXT_SIZE_BASE * title!!.textScale).toInt())
+        }
+
+        with(Modal(title = { Text(it, textScale = 2.0) })) {
+            assertEquals(TEXT_SIZE_MODAL, (TEXT_SIZE_BASE * textScale).toInt())
+            assertEquals(2 * TEXT_SIZE_MODAL_TITLE, (TEXT_SIZE_BASE * title!!.textScale).toInt())
+        }
     }
 
     private fun assertFixedAttributes(modal: Modal) {

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/ModalTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/ModalTest.kt
@@ -6,6 +6,8 @@ import org.cru.godtools.tool.internal.UsesResources
 import org.cru.godtools.tool.model.Button
 import org.cru.godtools.tool.model.Manifest
 import org.cru.godtools.tool.model.Paragraph
+import org.cru.godtools.tool.model.TEXT_SIZE_BASE
+import org.cru.godtools.tool.model.TEXT_SIZE_MODAL
 import org.cru.godtools.tool.model.TRANSPARENT
 import org.cru.godtools.tool.model.Text
 import org.cru.godtools.tool.model.WHITE
@@ -27,6 +29,12 @@ class ModalTest : UsesResources("model/tract") {
         assertIs<Paragraph>(modal.content[0])
         assertIs<Paragraph>(modal.content[1])
         assertEquals("Thank you", modal.title!!.text)
+    }
+
+    @Test
+    fun testTextScale() {
+        assertEquals(TEXT_SIZE_MODAL, (TEXT_SIZE_BASE * Modal().textScale).toInt())
+        assertEquals(2 * TEXT_SIZE_MODAL, (TEXT_SIZE_BASE * Modal(TractPage(textScale = 2.0)).textScale).toInt())
     }
 
     private fun assertFixedAttributes(modal: Modal) {

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/TractPageTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/TractPageTest.kt
@@ -6,6 +6,7 @@ import org.cru.godtools.tool.internal.UsesResources
 import org.cru.godtools.tool.model.ImageScaleType
 import org.cru.godtools.tool.model.Manifest
 import org.cru.godtools.tool.model.Resource
+import org.cru.godtools.tool.model.Styles.Companion.DEFAULT_TEXT_SCALE
 import org.cru.godtools.tool.model.TEST_GRAVITY
 import org.cru.godtools.tool.model.TestColors
 import org.cru.godtools.tool.model.textColor
@@ -113,7 +114,7 @@ class TractPageTest : UsesResources("model/tract") {
 
     @Test
     fun testTextScale() {
-        assertEquals(TractPage.DEFAULT_TEXT_SCALE, TractPage(Manifest()).textScale, 0.001)
+        assertEquals(DEFAULT_TEXT_SCALE, TractPage(Manifest()).textScale, 0.001)
         assertEquals(2.0, TractPage(textScale = 2.0).textScale, 0.001)
 
         val manifest = Manifest(textScale = 3.0)


### PR DESCRIPTION
This PR utilizes the textScale Styles property to define base relative text sizes for various components.