### PR TITLE
tweaks

### DIFF
--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/Image.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/Image.kt
@@ -28,7 +28,7 @@ class Image : Content {
     }
 
     @RestrictTo(RestrictTo.Scope.TESTS)
-    internal constructor(parent: Base, resource: String? = null) : super(parent) {
+    constructor(parent: Base, resource: String? = null) : super(parent) {
         resourceName = resource
         events = emptyList()
     }

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
@@ -186,7 +186,7 @@ class Manifest : BaseModel, Styles {
     }
 
     @RestrictTo(RestrictTo.Scope.TESTS)
-    internal constructor(
+    constructor(
         type: Type = Type.DEFAULT,
         code: String? = null,
         primaryColor: Color = DEFAULT_PRIMARY_COLOR,

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/Paragraph.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/Paragraph.kt
@@ -18,7 +18,7 @@ class Paragraph : Content, Parent {
     }
 
     @RestrictTo(RestrictTo.Scope.TESTS)
-    internal constructor(parent: Base, content: (Paragraph) -> List<Content>) : super(parent) {
+    constructor(parent: Base, content: (Paragraph) -> List<Content>) : super(parent) {
         this.content = content(this)
     }
 }


### PR DESCRIPTION
- make the Image and Paragraph test constructors visible
- make the Manifest test constructor visible publicly for usage from external tests
