### PR TITLE
Revert hard-coded text-scales

### DIFF
--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/Category.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/Category.kt
@@ -22,7 +22,6 @@ class Category : BaseModel, Styles {
     val banner get() = getResource(_banner)
 
     override val textColor get() = manifest.categoryLabelColor
-    override val textScale get() = super.textScale * TEXT_SIZE_CATEGORY / TEXT_SIZE_BASE
 
     internal constructor(manifest: Manifest, parser: XmlPullParser) : super(manifest) {
         parser.require(XmlPullParser.START_TAG, XMLNS_MANIFEST, XML_CATEGORY)

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/Constants.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/Constants.kt
@@ -34,7 +34,6 @@ internal val WHITE = color(255, 255, 255, 1.0)
 internal const val TEXT_SIZE_BASE = 16
 internal const val TEXT_SIZE_HEADER = 18
 internal const val TEXT_SIZE_HEADER_NUMBER = 54
-internal const val TEXT_SIZE_HERO_HEADING = 30
 internal const val TEXT_SIZE_MODAL = 18
 internal const val TEXT_SIZE_MODAL_TITLE = 54
 // endregion Text Sizes

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/Constants.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/Constants.kt
@@ -32,7 +32,6 @@ internal val WHITE = color(255, 255, 255, 1.0)
 // region Text Sizes
 // these text sizes are exposed publicly via relative textScale properties based off the base text size
 internal const val TEXT_SIZE_BASE = 16
-internal const val TEXT_SIZE_CATEGORY = 30
 internal const val TEXT_SIZE_HEADER = 18
 internal const val TEXT_SIZE_HEADER_NUMBER = 54
 internal const val TEXT_SIZE_HERO_HEADING = 30

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/Constants.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/Constants.kt
@@ -33,5 +33,4 @@ internal val WHITE = color(255, 255, 255, 1.0)
 // these text sizes are exposed publicly via relative textScale properties based off the base text size
 internal const val TEXT_SIZE_BASE = 16
 internal const val TEXT_SIZE_MODAL = 18
-internal const val TEXT_SIZE_MODAL_TITLE = 54
 // endregion Text Sizes

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/Constants.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/Constants.kt
@@ -35,7 +35,6 @@ internal const val TEXT_SIZE_BASE = 16
 internal const val TEXT_SIZE_HEADER = 18
 internal const val TEXT_SIZE_HEADER_NUMBER = 54
 internal const val TEXT_SIZE_HERO_HEADING = 30
-internal const val TEXT_SIZE_CARD_LABEL = 18
 internal const val TEXT_SIZE_MODAL = 18
 internal const val TEXT_SIZE_MODAL_TITLE = 54
 // endregion Text Sizes

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/Constants.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/Constants.kt
@@ -28,9 +28,3 @@ internal const val XML_LISTENERS = "listeners"
 internal val TRANSPARENT = color(0, 0, 0, 0.0)
 @SharedImmutable
 internal val WHITE = color(255, 255, 255, 1.0)
-
-// region Text Sizes
-// these text sizes are exposed publicly via relative textScale properties based off the base text size
-internal const val TEXT_SIZE_BASE = 16
-internal const val TEXT_SIZE_MODAL = 18
-// endregion Text Sizes

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/Constants.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/Constants.kt
@@ -32,8 +32,6 @@ internal val WHITE = color(255, 255, 255, 1.0)
 // region Text Sizes
 // these text sizes are exposed publicly via relative textScale properties based off the base text size
 internal const val TEXT_SIZE_BASE = 16
-internal const val TEXT_SIZE_HEADER = 18
-internal const val TEXT_SIZE_HEADER_NUMBER = 54
 internal const val TEXT_SIZE_MODAL = 18
 internal const val TEXT_SIZE_MODAL_TITLE = 54
 // endregion Text Sizes

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Card.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Card.kt
@@ -15,8 +15,6 @@ import org.cru.godtools.tool.model.ImageScaleType
 import org.cru.godtools.tool.model.ImageScaleType.Companion.toImageScaleTypeOrNull
 import org.cru.godtools.tool.model.Parent
 import org.cru.godtools.tool.model.Styles
-import org.cru.godtools.tool.model.TEXT_SIZE_BASE
-import org.cru.godtools.tool.model.TEXT_SIZE_CARD_LABEL
 import org.cru.godtools.tool.model.Text
 import org.cru.godtools.tool.model.XMLNS_ANALYTICS
 import org.cru.godtools.tool.model.XML_BACKGROUND_COLOR
@@ -76,12 +74,7 @@ class Card : BaseModel, Styles, Parent {
     @get:AndroidColorInt
     override val textColor get() = _textColor ?: page.cardTextColor
 
-    private val labelParent by lazy {
-        stylesOverride(
-            textColor = { primaryColor },
-            textScale = TEXT_SIZE_CARD_LABEL.toDouble() / TEXT_SIZE_BASE
-        )
-    }
+    private val labelParent by lazy { stylesOverride(textColor = { primaryColor }) }
     val label: Text?
     override val content: List<Content>
     val tips get() = contentTips

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Header.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Header.kt
@@ -3,18 +3,13 @@ package org.cru.godtools.tool.model.tract
 import org.cru.godtools.tool.internal.AndroidColorInt
 import org.cru.godtools.tool.internal.RestrictTo
 import org.cru.godtools.tool.internal.VisibleForTesting
-import org.cru.godtools.tool.model.Base
 import org.cru.godtools.tool.model.BaseModel
 import org.cru.godtools.tool.model.Color
 import org.cru.godtools.tool.model.Styles
-import org.cru.godtools.tool.model.TEXT_SIZE_BASE
-import org.cru.godtools.tool.model.TEXT_SIZE_HEADER
-import org.cru.godtools.tool.model.TEXT_SIZE_HEADER_NUMBER
 import org.cru.godtools.tool.model.Text
 import org.cru.godtools.tool.model.XML_BACKGROUND_COLOR
 import org.cru.godtools.tool.model.parseTextChild
 import org.cru.godtools.tool.model.primaryColor
-import org.cru.godtools.tool.model.stylesOverride
 import org.cru.godtools.tool.model.stylesParent
 import org.cru.godtools.tool.model.tips.XMLNS_TRAINING
 import org.cru.godtools.tool.model.toColorOrNull
@@ -37,11 +32,7 @@ class Header : BaseModel, Styles {
 
     @get:AndroidColorInt
     override val textColor get() = primaryTextColor
-    override val textScale get() = super.textScale * TEXT_SIZE_HEADER / TEXT_SIZE_BASE
 
-    private val numberParent by lazy {
-        stylesOverride(textScale = TEXT_SIZE_HEADER_NUMBER.toDouble() / TEXT_SIZE_HEADER)
-    }
     val number: Text?
     val title: Text?
 
@@ -60,7 +51,7 @@ class Header : BaseModel, Styles {
         parser.parseChildren {
             when (parser.namespace) {
                 XMLNS_TRACT -> when (parser.name) {
-                    XML_NUMBER -> number = parser.parseTextChild(numberParent, XMLNS_TRACT, XML_NUMBER)
+                    XML_NUMBER -> number = parser.parseTextChild(this, XMLNS_TRACT, XML_NUMBER)
                     XML_TITLE -> title = parser.parseTextChild(this, XMLNS_TRACT, XML_TITLE)
                 }
             }
@@ -73,14 +64,12 @@ class Header : BaseModel, Styles {
     internal constructor(
         page: TractPage = TractPage(),
         backgroundColor: Color? = null,
-        tip: String? = null,
-        number: ((Base) -> Text?)? = null,
-        title: ((Base) -> Text?)? = null,
+        tip: String? = null
     ) : super(page) {
         _backgroundColor = backgroundColor
 
-        this.number = number?.invoke(numberParent)
-        this.title = title?.invoke(this)
+        number = null
+        title = null
 
         tipId = tip
     }

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Hero.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Hero.kt
@@ -7,8 +7,6 @@ import org.cru.godtools.tool.model.Base
 import org.cru.godtools.tool.model.BaseModel
 import org.cru.godtools.tool.model.Content
 import org.cru.godtools.tool.model.Parent
-import org.cru.godtools.tool.model.TEXT_SIZE_BASE
-import org.cru.godtools.tool.model.TEXT_SIZE_HERO_HEADING
 import org.cru.godtools.tool.model.Text
 import org.cru.godtools.tool.model.XMLNS_ANALYTICS
 import org.cru.godtools.tool.model.parseContent
@@ -25,12 +23,7 @@ class Hero : BaseModel, Parent {
     }
 
     val analyticsEvents: List<AnalyticsEvent>
-    private val headingParent by lazy {
-        stylesOverride(
-            textColor = { stylesParent.primaryColor },
-            textScale = TEXT_SIZE_HERO_HEADING.toDouble() / TEXT_SIZE_BASE
-        )
-    }
+    private val headingParent by lazy { stylesOverride(textColor = { stylesParent.primaryColor }) }
     val heading: Text?
     override val content: List<Content>
 

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Modal.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Modal.kt
@@ -2,7 +2,6 @@ package org.cru.godtools.tool.model.tract
 
 import org.cru.godtools.tool.internal.AndroidColorInt
 import org.cru.godtools.tool.internal.RestrictTo
-import org.cru.godtools.tool.model.Base
 import org.cru.godtools.tool.model.BaseModel
 import org.cru.godtools.tool.model.Button
 import org.cru.godtools.tool.model.Content
@@ -11,7 +10,6 @@ import org.cru.godtools.tool.model.Parent
 import org.cru.godtools.tool.model.Styles
 import org.cru.godtools.tool.model.TEXT_SIZE_BASE
 import org.cru.godtools.tool.model.TEXT_SIZE_MODAL
-import org.cru.godtools.tool.model.TEXT_SIZE_MODAL_TITLE
 import org.cru.godtools.tool.model.TRANSPARENT
 import org.cru.godtools.tool.model.Text
 import org.cru.godtools.tool.model.WHITE
@@ -19,7 +17,6 @@ import org.cru.godtools.tool.model.XML_DISMISS_LISTENERS
 import org.cru.godtools.tool.model.XML_LISTENERS
 import org.cru.godtools.tool.model.parseContent
 import org.cru.godtools.tool.model.parseTextChild
-import org.cru.godtools.tool.model.stylesOverride
 import org.cru.godtools.tool.model.textScale
 import org.cru.godtools.tool.model.toEventIds
 import org.cru.godtools.tool.xml.XmlPullParser
@@ -35,7 +32,6 @@ class Modal : BaseModel, Parent, Styles {
     val id get() = "${page.id}-$position"
     private val position get() = page.modals.indexOf(this)
 
-    private val titleParent by lazy { stylesOverride(textScale = TEXT_SIZE_MODAL_TITLE.toDouble() / TEXT_SIZE_MODAL) }
     val title: Text?
     override val content: List<Content>
 
@@ -69,7 +65,7 @@ class Modal : BaseModel, Parent, Styles {
         content = parseContent(parser) {
             when (parser.namespace) {
                 XMLNS_TRACT -> when (parser.name) {
-                    XML_TITLE -> title = parser.parseTextChild(titleParent, XMLNS_TRACT, XML_TITLE)
+                    XML_TITLE -> title = parser.parseTextChild(this@Modal, XMLNS_TRACT, XML_TITLE)
                 }
             }
         }
@@ -77,9 +73,9 @@ class Modal : BaseModel, Parent, Styles {
     }
 
     @RestrictTo(RestrictTo.Scope.TESTS)
-    internal constructor(page: TractPage = TractPage(), title: (Base) -> Text?) : super(page) {
+    internal constructor(page: TractPage = TractPage()) : super(page) {
         this.page = page
-        this.title = title.invoke(titleParent)
+        title = null
         content = emptyList()
         listeners = emptySet()
         dismissListeners = emptySet()

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Modal.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Modal.kt
@@ -1,15 +1,12 @@
 package org.cru.godtools.tool.model.tract
 
 import org.cru.godtools.tool.internal.AndroidColorInt
-import org.cru.godtools.tool.internal.RestrictTo
 import org.cru.godtools.tool.model.BaseModel
 import org.cru.godtools.tool.model.Button
 import org.cru.godtools.tool.model.Content
 import org.cru.godtools.tool.model.EventId
 import org.cru.godtools.tool.model.Parent
 import org.cru.godtools.tool.model.Styles
-import org.cru.godtools.tool.model.TEXT_SIZE_BASE
-import org.cru.godtools.tool.model.TEXT_SIZE_MODAL
 import org.cru.godtools.tool.model.TRANSPARENT
 import org.cru.godtools.tool.model.Text
 import org.cru.godtools.tool.model.WHITE
@@ -17,7 +14,6 @@ import org.cru.godtools.tool.model.XML_DISMISS_LISTENERS
 import org.cru.godtools.tool.model.XML_LISTENERS
 import org.cru.godtools.tool.model.parseContent
 import org.cru.godtools.tool.model.parseTextChild
-import org.cru.godtools.tool.model.textScale
 import org.cru.godtools.tool.model.toEventIds
 import org.cru.godtools.tool.xml.XmlPullParser
 
@@ -50,7 +46,6 @@ class Modal : BaseModel, Parent, Styles {
     override val textAlign get() = Text.Align.CENTER
     @get:AndroidColorInt
     override val textColor get() = WHITE
-    override val textScale get() = stylesParent.textScale * TEXT_SIZE_MODAL / TEXT_SIZE_BASE
 
     internal constructor(parent: TractPage, parser: XmlPullParser) : super(parent) {
         page = parent
@@ -70,14 +65,5 @@ class Modal : BaseModel, Parent, Styles {
             }
         }
         this.title = title
-    }
-
-    @RestrictTo(RestrictTo.Scope.TESTS)
-    internal constructor(page: TractPage = TractPage()) : super(page) {
-        this.page = page
-        title = null
-        content = emptyList()
-        listeners = emptySet()
-        dismissListeners = emptySet()
     }
 }

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/CategoryTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/CategoryTest.kt
@@ -37,19 +37,4 @@ class CategoryTest : UsesResources() {
             assertNotEquals(manifest.textColor, label!!.textColor)
         }
     }
-
-    @Test
-    fun testLabelTextSize() {
-        with(Category(label = { Text(it) })) {
-            assertEquals(TEXT_SIZE_CATEGORY, (TEXT_SIZE_BASE * label!!.textScale).toInt())
-        }
-
-        with(Category(Manifest(textScale = 2.0), label = { Text(it) })) {
-            assertEquals(2 * TEXT_SIZE_CATEGORY, (TEXT_SIZE_BASE * label!!.textScale).toInt())
-        }
-
-        with(Category(label = { Text(it, textScale = 2.0) })) {
-            assertEquals(2 * TEXT_SIZE_CATEGORY, (TEXT_SIZE_BASE * label!!.textScale).toInt())
-        }
-    }
 }

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/CardTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/CardTest.kt
@@ -8,8 +8,6 @@ import org.cru.godtools.tool.model.Manifest
 import org.cru.godtools.tool.model.Paragraph
 import org.cru.godtools.tool.model.Resource
 import org.cru.godtools.tool.model.TEST_GRAVITY
-import org.cru.godtools.tool.model.TEXT_SIZE_BASE
-import org.cru.godtools.tool.model.TEXT_SIZE_CARD_LABEL
 import org.cru.godtools.tool.model.TestColors
 import org.cru.godtools.tool.model.Text
 import org.cru.godtools.tool.model.tips.InlineTip
@@ -117,21 +115,6 @@ class CardTest : UsesResources("model/tract") {
             assertEquals(TestColors.GREEN, label!!.textColor)
             assertNotEquals(primaryColor, label!!.textColor)
             assertNotEquals(textColor, label!!.textColor)
-        }
-    }
-
-    @Test
-    fun testLabelTextSize() {
-        with(Card(label = { Text(it) })) {
-            assertEquals(TEXT_SIZE_CARD_LABEL, (label!!.textScale * TEXT_SIZE_BASE).toInt())
-        }
-
-        with(Card(TractPage(textScale = 2.0), label = { Text(it) })) {
-            assertEquals(2 * TEXT_SIZE_CARD_LABEL, (label!!.textScale * TEXT_SIZE_BASE).toInt())
-        }
-
-        with(Card(label = { Text(it, textScale = 2.0) })) {
-            assertEquals(2 * TEXT_SIZE_CARD_LABEL, (label!!.textScale * TEXT_SIZE_BASE).toInt())
         }
     }
 }

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/HeaderTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/HeaderTest.kt
@@ -4,11 +4,7 @@ import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
 import org.cru.godtools.tool.model.Manifest
-import org.cru.godtools.tool.model.TEXT_SIZE_BASE
-import org.cru.godtools.tool.model.TEXT_SIZE_HEADER
-import org.cru.godtools.tool.model.TEXT_SIZE_HEADER_NUMBER
 import org.cru.godtools.tool.model.TestColors
-import org.cru.godtools.tool.model.Text
 import org.cru.godtools.tool.model.primaryColor
 import org.cru.godtools.tool.model.stylesParent
 import org.cru.godtools.tool.model.tips.Tip
@@ -47,24 +43,6 @@ class HeaderTest : UsesResources("model/tract") {
         with(null as Header?) { assertEquals(stylesParent.primaryColor, backgroundColor) }
         with(header as Header?) { assertEquals(TestColors.GREEN, backgroundColor) }
         with(header) { assertEquals(TestColors.GREEN, backgroundColor) }
-    }
-
-    @Test
-    fun testTextScale() {
-        with(Header(number = { Text(it) }, title = { Text(it) })) {
-            assertEquals(TEXT_SIZE_HEADER, (TEXT_SIZE_BASE * title!!.textScale).toInt())
-            assertEquals(TEXT_SIZE_HEADER_NUMBER, (TEXT_SIZE_BASE * number!!.textScale).toInt())
-        }
-
-        with(Header(TractPage(textScale = 2.0), number = { Text(it) }, title = { Text(it) })) {
-            assertEquals(2 * TEXT_SIZE_HEADER, (TEXT_SIZE_BASE * title!!.textScale).toInt())
-            assertEquals(2 * TEXT_SIZE_HEADER_NUMBER, (TEXT_SIZE_BASE * number!!.textScale).toInt())
-        }
-
-        with(Header(number = { Text(it, textScale = 3.0) }, title = { Text(it, textScale = 2.0) })) {
-            assertEquals(2 * TEXT_SIZE_HEADER, (TEXT_SIZE_BASE * title!!.textScale).toInt())
-            assertEquals(3 * TEXT_SIZE_HEADER_NUMBER, (TEXT_SIZE_BASE * number!!.textScale).toInt())
-        }
     }
 
     @Test

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/HeroTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/HeroTest.kt
@@ -9,8 +9,6 @@ import org.cru.godtools.tool.model.DeviceType
 import org.cru.godtools.tool.model.Image
 import org.cru.godtools.tool.model.Manifest
 import org.cru.godtools.tool.model.Paragraph
-import org.cru.godtools.tool.model.TEXT_SIZE_BASE
-import org.cru.godtools.tool.model.TEXT_SIZE_HERO_HEADING
 import org.cru.godtools.tool.model.Tabs
 import org.cru.godtools.tool.model.TestColors
 import org.cru.godtools.tool.model.Text
@@ -65,21 +63,6 @@ class HeroTest : UsesResources("model/tract") {
         with(Hero(page, heading = { Text(it, textColor = TestColors.GREEN) })) {
             assertEquals(TestColors.GREEN, heading!!.textColor)
             assertNotEquals(page.primaryColor, heading!!.textColor)
-        }
-    }
-
-    @Test
-    fun testHeadingTextScale() {
-        with(Hero(heading = { Text(it) })) {
-            assertEquals(TEXT_SIZE_HERO_HEADING, (TEXT_SIZE_BASE * heading!!.textScale).toInt())
-        }
-
-        with(Hero(TractPage(textScale = 2.0), heading = { Text(it) })) {
-            assertEquals(2 * TEXT_SIZE_HERO_HEADING, (TEXT_SIZE_BASE * heading!!.textScale).toInt())
-        }
-
-        with(Hero(heading = { Text(it, textScale = 2.0) })) {
-            assertEquals(2 * TEXT_SIZE_HERO_HEADING, (TEXT_SIZE_BASE * heading!!.textScale).toInt())
         }
     }
 }

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/ModalTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/ModalTest.kt
@@ -8,7 +8,6 @@ import org.cru.godtools.tool.model.Manifest
 import org.cru.godtools.tool.model.Paragraph
 import org.cru.godtools.tool.model.TEXT_SIZE_BASE
 import org.cru.godtools.tool.model.TEXT_SIZE_MODAL
-import org.cru.godtools.tool.model.TEXT_SIZE_MODAL_TITLE
 import org.cru.godtools.tool.model.TRANSPARENT
 import org.cru.godtools.tool.model.Text
 import org.cru.godtools.tool.model.WHITE
@@ -34,20 +33,8 @@ class ModalTest : UsesResources("model/tract") {
 
     @Test
     fun testTextScale() {
-        with(Modal(title = { Text(it) })) {
-            assertEquals(TEXT_SIZE_MODAL, (TEXT_SIZE_BASE * textScale).toInt())
-            assertEquals(TEXT_SIZE_MODAL_TITLE, (TEXT_SIZE_BASE * title!!.textScale).toInt())
-        }
-
-        with(Modal(TractPage(textScale = 2.0), title = { Text(it) })) {
-            assertEquals(2 * TEXT_SIZE_MODAL, (TEXT_SIZE_BASE * textScale).toInt())
-            assertEquals(2 * TEXT_SIZE_MODAL_TITLE, (TEXT_SIZE_BASE * title!!.textScale).toInt())
-        }
-
-        with(Modal(title = { Text(it, textScale = 2.0) })) {
-            assertEquals(TEXT_SIZE_MODAL, (TEXT_SIZE_BASE * textScale).toInt())
-            assertEquals(2 * TEXT_SIZE_MODAL_TITLE, (TEXT_SIZE_BASE * title!!.textScale).toInt())
-        }
+        assertEquals(TEXT_SIZE_MODAL, (TEXT_SIZE_BASE * Modal().textScale).toInt())
+        assertEquals(2 * TEXT_SIZE_MODAL, (TEXT_SIZE_BASE * Modal(TractPage(textScale = 2.0)).textScale).toInt())
     }
 
     private fun assertFixedAttributes(modal: Modal) {

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/ModalTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/ModalTest.kt
@@ -6,8 +6,6 @@ import org.cru.godtools.tool.internal.UsesResources
 import org.cru.godtools.tool.model.Button
 import org.cru.godtools.tool.model.Manifest
 import org.cru.godtools.tool.model.Paragraph
-import org.cru.godtools.tool.model.TEXT_SIZE_BASE
-import org.cru.godtools.tool.model.TEXT_SIZE_MODAL
 import org.cru.godtools.tool.model.TRANSPARENT
 import org.cru.godtools.tool.model.Text
 import org.cru.godtools.tool.model.WHITE
@@ -29,12 +27,6 @@ class ModalTest : UsesResources("model/tract") {
         assertIs<Paragraph>(modal.content[0])
         assertIs<Paragraph>(modal.content[1])
         assertEquals("Thank you", modal.title!!.text)
-    }
-
-    @Test
-    fun testTextScale() {
-        assertEquals(TEXT_SIZE_MODAL, (TEXT_SIZE_BASE * Modal().textScale).toInt())
-        assertEquals(2 * TEXT_SIZE_MODAL, (TEXT_SIZE_BASE * Modal(TractPage(textScale = 2.0)).textScale).toInt())
     }
 
     private fun assertFixedAttributes(modal: Modal) {


### PR DESCRIPTION
- Revert "use textScale to automatically size the Category label"
- Revert "scale the card label"
- Revert "use a custom textScale for the hero heading"
- Revert "use textScale to represent the relative size of Header text children"
- Revert "set a textScale for the Modal title text"
- Revert "apply a text scale to modals"
