### PR TITLE
Reflect default text colors in the model

### DIFF
--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/Category.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/Category.kt
@@ -21,6 +21,7 @@ class Category : BaseModel, Styles {
     private val _banner: String?
     val banner get() = getResource(_banner)
 
+    override val textColor get() = manifest.categoryLabelColor
     override val textScale get() = super.textScale * TEXT_SIZE_CATEGORY / TEXT_SIZE_BASE
 
     internal constructor(manifest: Manifest, parser: XmlPullParser) : super(manifest) {

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/StylesOverride.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/StylesOverride.kt
@@ -4,9 +4,14 @@ import org.cru.godtools.tool.model.Styles.Companion.DEFAULT_TEXT_SCALE
 
 private class StylesOverride(
     parent: Base,
+    private val _textColor: (() -> Color?)?,
     private val _textScale: Double
 ) : BaseModel(parent), Styles {
+    override val textColor get() = _textColor?.invoke() ?: super.textColor
     override val textScale get() = super.textScale * _textScale
 }
 
-internal fun Base.stylesOverride(textScale: Double = DEFAULT_TEXT_SCALE): Base = StylesOverride(this, textScale)
+internal fun Base.stylesOverride(
+    textColor: (() -> Color?)? = null,
+    textScale: Double = DEFAULT_TEXT_SCALE
+): Base = StylesOverride(this, textColor, textScale)

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/Text.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/Text.kt
@@ -95,6 +95,7 @@ class Text : Content {
         endImageSize = DEFAULT_IMAGE_SIZE
     }
 
+    @Deprecated("Once we correctly override text color in the model this method should no longer be necessary")
     @AndroidColorInt
     fun getTextColor(@AndroidColorInt defaultColor: Color) = _textColor ?: defaultColor
 

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Card.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Card.kt
@@ -76,7 +76,12 @@ class Card : BaseModel, Styles, Parent {
     @get:AndroidColorInt
     override val textColor get() = _textColor ?: page.cardTextColor
 
-    private val labelParent by lazy { stylesOverride(textScale = TEXT_SIZE_CARD_LABEL.toDouble() / TEXT_SIZE_BASE) }
+    private val labelParent by lazy {
+        stylesOverride(
+            textColor = { primaryColor },
+            textScale = TEXT_SIZE_CARD_LABEL.toDouble() / TEXT_SIZE_BASE
+        )
+    }
     val label: Text?
     override val content: List<Content>
     val tips get() = contentTips

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Header.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Header.kt
@@ -39,7 +39,9 @@ class Header : BaseModel, Styles {
     override val textColor get() = primaryTextColor
     override val textScale get() = super.textScale * TEXT_SIZE_HEADER / TEXT_SIZE_BASE
 
-    private val numberParent by lazy { stylesOverride(TEXT_SIZE_HEADER_NUMBER.toDouble() / TEXT_SIZE_HEADER) }
+    private val numberParent by lazy {
+        stylesOverride(textScale = TEXT_SIZE_HEADER_NUMBER.toDouble() / TEXT_SIZE_HEADER)
+    }
     val number: Text?
     val title: Text?
 

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Hero.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Hero.kt
@@ -13,6 +13,7 @@ import org.cru.godtools.tool.model.Text
 import org.cru.godtools.tool.model.XMLNS_ANALYTICS
 import org.cru.godtools.tool.model.parseContent
 import org.cru.godtools.tool.model.parseTextChild
+import org.cru.godtools.tool.model.primaryColor
 import org.cru.godtools.tool.model.stylesOverride
 import org.cru.godtools.tool.xml.XmlPullParser
 
@@ -24,7 +25,12 @@ class Hero : BaseModel, Parent {
     }
 
     val analyticsEvents: List<AnalyticsEvent>
-    private val headingParent by lazy { stylesOverride(textScale = TEXT_SIZE_HERO_HEADING.toDouble() / TEXT_SIZE_BASE) }
+    private val headingParent by lazy {
+        stylesOverride(
+            textColor = { stylesParent.primaryColor },
+            textScale = TEXT_SIZE_HERO_HEADING.toDouble() / TEXT_SIZE_BASE
+        )
+    }
     val heading: Text?
     override val content: List<Content>
 

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Modal.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Modal.kt
@@ -35,7 +35,7 @@ class Modal : BaseModel, Parent, Styles {
     val id get() = "${page.id}-$position"
     private val position get() = page.modals.indexOf(this)
 
-    private val titleParent by lazy { stylesOverride(TEXT_SIZE_MODAL_TITLE.toDouble() / TEXT_SIZE_MODAL) }
+    private val titleParent by lazy { stylesOverride(textScale = TEXT_SIZE_MODAL_TITLE.toDouble() / TEXT_SIZE_MODAL) }
     val title: Text?
     override val content: List<Content>
 

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/TractPage.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/TractPage.kt
@@ -148,6 +148,7 @@ class TractPage : BaseModel, Styles {
         fileName: String? = null,
         backgroundColor: Color = DEFAULT_BACKGROUND_COLOR,
         backgroundImage: String? = null,
+        @AndroidColorInt primaryColor: Color? = null,
         backgroundImageGravity: ImageGravity = DEFAULT_BACKGROUND_IMAGE_GRAVITY,
         backgroundImageScaleType: ImageScaleType = DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE,
         textColor: Color? = null,
@@ -161,7 +162,7 @@ class TractPage : BaseModel, Styles {
 
         listeners = emptySet()
 
-        _primaryColor = null
+        _primaryColor = primaryColor
         _primaryTextColor = null
 
         this.backgroundColor = backgroundColor

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/CategoryTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/CategoryTest.kt
@@ -5,6 +5,7 @@ import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 
 @RunOnAndroidWith(AndroidJUnit4::class)
@@ -18,7 +19,23 @@ class CategoryTest : UsesResources() {
             assertEquals("bannersha1.jpg", it.localName)
         }
         assertEquals(setOf("tag1", "tag2"), category.aemTags)
-        assertEquals("Category", category.label?.text)
+        assertEquals("Category", category.label!!.text)
+        assertEquals(TestColors.RED, category.label!!.textColor)
+    }
+
+    @Test
+    fun testLabelTextColor() {
+        val manifest = Manifest(categoryLabelColor = TestColors.BLUE)
+        with(Category(manifest, label = { Text(it) })) {
+            assertEquals(manifest.categoryLabelColor, label!!.textColor)
+            assertNotEquals(manifest.textColor, label!!.textColor)
+        }
+
+        with(Category(manifest, label = { Text(it, textColor = TestColors.GREEN) })) {
+            assertEquals(TestColors.GREEN, label!!.textColor)
+            assertNotEquals(manifest.categoryLabelColor, label!!.textColor)
+            assertNotEquals(manifest.textColor, label!!.textColor)
+        }
     }
 
     @Test

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/CardTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/CardTest.kt
@@ -19,6 +19,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
+import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
 @RunOnAndroidWith(AndroidJUnit4::class)
@@ -28,6 +29,8 @@ class CardTest : UsesResources("model/tract") {
         val card = TractPage(Manifest(code = "test"), "page.xml", getTestXmlParser("card.xml")).cards.single()
         assertEquals("page.xml-0", card.id)
         assertEquals("Card 1", card.label!!.text)
+        assertEquals(card.primaryColor, card.label!!.textColor)
+        assertNotEquals(card.textColor, card.label!!.textColor)
         assertEquals(TestColors.RED, card.backgroundColor)
         assertEquals("listener1 listener2".toEventIds().toSet(), card.listeners)
         assertEquals("dismiss-listener1 dismiss-listener2".toEventIds().toSet(), card.dismissListeners)
@@ -101,6 +104,20 @@ class CardTest : UsesResources("model/tract") {
         val page = TractPage(cardBackgroundColor = TestColors.GREEN)
         assertEquals(TestColors.GREEN, Card(page).backgroundColor)
         assertEquals(TestColors.BLUE, Card(page, backgroundColor = TestColors.BLUE).backgroundColor)
+    }
+
+    @Test
+    fun testLabelTextColor() {
+        with(Card(label = { Text(it) })) {
+            assertEquals(primaryColor, label!!.textColor)
+            assertNotEquals(textColor, label!!.textColor)
+        }
+
+        with(Card(label = { Text(it, textColor = TestColors.GREEN) })) {
+            assertEquals(TestColors.GREEN, label!!.textColor)
+            assertNotEquals(primaryColor, label!!.textColor)
+            assertNotEquals(textColor, label!!.textColor)
+        }
     }
 
     @Test

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/HeroTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/HeroTest.kt
@@ -12,12 +12,14 @@ import org.cru.godtools.tool.model.Paragraph
 import org.cru.godtools.tool.model.TEXT_SIZE_BASE
 import org.cru.godtools.tool.model.TEXT_SIZE_HERO_HEADING
 import org.cru.godtools.tool.model.Tabs
+import org.cru.godtools.tool.model.TestColors
 import org.cru.godtools.tool.model.Text
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 
 @RunOnAndroidWith(AndroidJUnit4::class)
@@ -37,6 +39,8 @@ class HeroTest : UsesResources("model/tract") {
         val hero = assertNotNull(TractPage(Manifest(), null, getTestXmlParser("hero.xml")).hero)
         assertEquals(1, hero.analyticsEvents.size)
         assertEquals("Heading", hero.heading!!.text)
+        assertEquals(hero.stylesParent!!.primaryColor, hero.heading!!.textColor)
+        assertNotEquals(hero.stylesParent!!.textColor, hero.heading!!.textColor)
         assertEquals(3, hero.content.size)
         assertIs<Image>(hero.content[0])
         assertIs<Paragraph>(hero.content[1])
@@ -49,6 +53,19 @@ class HeroTest : UsesResources("model/tract") {
         assertEquals(2, hero.content.size)
         assertIs<Paragraph>(hero.content[0])
         assertIs<Tabs>(hero.content[1])
+    }
+
+    @Test
+    fun testHeadingTextColor() {
+        val page = TractPage(primaryColor = TestColors.BLUE)
+        with(Hero(page, heading = { Text(it) })) {
+            assertEquals(page.primaryColor, heading!!.textColor)
+        }
+
+        with(Hero(page, heading = { Text(it, textColor = TestColors.GREEN) })) {
+            assertEquals(TestColors.GREEN, heading!!.textColor)
+            assertNotEquals(page.primaryColor, heading!!.textColor)
+        }
     }
 
     @Test

--- a/src/commonTest/resources/org/cru/godtools/tool/model/categories.xml
+++ b/src/commonTest/resources/org/cru/godtools/tool/model/categories.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <manifest xmlns:article="https://mobile-content-api.cru.org/xmlns/article"
     xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
-    xmlns="https://mobile-content-api.cru.org/xmlns/manifest">
+    xmlns="https://mobile-content-api.cru.org/xmlns/manifest" category-label-color="rgba(255,0,0,1)">
     <resources>
         <resource filename="banner.jpg" src="bannersha1.jpg" />
     </resources>


### PR DESCRIPTION
This PR makes it possible for the following properties to properly reflect fallback colors:
```kotlin
card.label.textColor
hero.heading.textColor
category.label.textColor
```