### PR TITLE
Make the ManifestParser suspendable

### DIFF
--- a/src/androidTest/java/org/cru/godtools/tool/internal/-AndroidTestingPlatform.kt
+++ b/src/androidTest/java/org/cru/godtools/tool/internal/-AndroidTestingPlatform.kt
@@ -1,6 +1,8 @@
 package org.cru.godtools.tool.internal
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.runBlocking
 import org.cru.godtools.tool.xml.AndroidXmlPullParserFactory
 import org.cru.godtools.tool.xml.XmlPullParserFactory
 
@@ -15,3 +17,7 @@ actual typealias RunOnAndroidWith = org.junit.runner.RunWith
 actual typealias Runner = org.junit.runner.Runner
 actual typealias AndroidJUnit4 = AndroidJUnit4
 // endregion Android Robolectric
+
+// region Kotlin Coroutines
+actual fun runBlockingTest(block: suspend CoroutineScope.() -> Unit) = runBlocking { block() }
+// endregion Kotlin Coroutines

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
@@ -63,7 +63,7 @@ class Manifest : BaseModel, Styles {
         internal val DEFAULT_TEXT_COLOR = color(90, 90, 90, 1.0)
         internal val DEFAULT_TEXT_ALIGN = Text.Align.START
 
-        internal fun parse(fileName: String, parseFile: (String) -> XmlPullParser) =
+        internal suspend fun parse(fileName: String, parseFile: (String) -> XmlPullParser) =
             Manifest(parseFile(fileName), parseFile)
     }
 

--- a/src/commonMain/kotlin/org/cru/godtools/tool/service/ManifestParser.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/service/ManifestParser.kt
@@ -6,7 +6,7 @@ import org.cru.godtools.tool.xml.XmlPullParserException
 import org.cru.godtools.tool.xml.XmlPullParserFactory
 
 class ManifestParser(private val parserFactory: XmlPullParserFactory) {
-    fun parseManifest(fileName: String): Result = try {
+    suspend fun parseManifest(fileName: String): Result = try {
         val manifest = Manifest.parse(fileName) {
             parserFactory.getXmlParser(it)?.apply { nextTag() } ?: throw FileNotFoundException()
         }

--- a/src/commonMain/kotlin/org/cru/godtools/tool/util/SetOnceProperty.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/util/SetOnceProperty.kt
@@ -1,0 +1,23 @@
+package org.cru.godtools.tool.util
+
+import kotlin.properties.ReadWriteProperty
+import kotlin.reflect.KProperty
+
+private class SetOnceProperty<T> : ReadWriteProperty<Any, T> {
+    private object EMPTY
+
+    private var value: Any? = EMPTY
+
+    @Suppress("UNCHECKED_CAST")
+    override fun getValue(thisRef: Any, property: KProperty<*>): T {
+        check(value !== EMPTY) { "Value isn't initialized" }
+        return value as T
+    }
+
+    override fun setValue(thisRef: Any, property: KProperty<*>, value: T) {
+        check(this.value === EMPTY) { "Value is initialized" }
+        this.value = value
+    }
+}
+
+internal fun <T> setOnce(): ReadWriteProperty<Any, T> = SetOnceProperty()

--- a/src/commonTest/kotlin/org/cru/godtools/tool/internal/-CommonTestingPlatform.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/internal/-CommonTestingPlatform.kt
@@ -1,5 +1,6 @@
 package org.cru.godtools.tool.internal
 
+import kotlinx.coroutines.CoroutineScope
 import org.cru.godtools.tool.xml.XmlPullParserFactory
 import kotlin.reflect.KClass
 
@@ -17,3 +18,8 @@ expect annotation class RunOnAndroidWith(val value: KClass<out Runner>)
 expect abstract class Runner
 expect class AndroidJUnit4 : Runner
 // endregion Android Robolectric
+
+// region Kotlin Coroutines
+// Copied w/ modifications from: https://github.com/Kotlin/kotlinx.coroutines/issues/1996#issuecomment-728562784
+expect fun runBlockingTest(block: suspend CoroutineScope.() -> Unit)
+// endregion Kotlin Coroutines

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/CategoryTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/CategoryTest.kt
@@ -3,6 +3,7 @@ package org.cru.godtools.tool.model
 import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
+import org.cru.godtools.tool.internal.runBlockingTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
@@ -11,7 +12,7 @@ import kotlin.test.assertNotNull
 @RunOnAndroidWith(AndroidJUnit4::class)
 class CategoryTest : UsesResources() {
     @Test
-    fun testParseCategory() {
+    fun testParseCategory() = runBlockingTest {
         val category = Manifest.parse("categories.xml") { getTestXmlParser(it) }.categories.single()
         assertEquals("testParseCategory", category.id)
         assertNotNull(category.banner).also {

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/ManifestTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/ManifestTest.kt
@@ -5,6 +5,7 @@ import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
 import org.cru.godtools.tool.internal.fluidlocale.toCommon
+import org.cru.godtools.tool.internal.runBlockingTest
 import org.cru.godtools.tool.model.Styles.Companion.DEFAULT_TEXT_SCALE
 import org.cru.godtools.tool.model.lesson.DEFAULT_LESSON_CONTROL_COLOR
 import org.cru.godtools.tool.model.lesson.DEFAULT_LESSON_NAV_BAR_COLOR
@@ -20,7 +21,7 @@ import kotlin.test.assertTrue
 class ManifestTest : UsesResources() {
     // region parse Manifest
     @Test
-    fun testParseManifestEmpty() {
+    fun testParseManifestEmpty() = runBlockingTest {
         val manifest = parseManifest("manifest_empty.xml")
         assertNull(manifest.title)
         assertNull(manifest.code)
@@ -48,7 +49,7 @@ class ManifestTest : UsesResources() {
     }
 
     @Test
-    fun testParseManifestArticle() {
+    fun testParseManifestArticle() = runBlockingTest {
         val manifest = parseManifest("manifest_article.xml")
         assertEquals(Manifest.Type.ARTICLE, manifest.type)
         assertEquals(TestColors.GREEN, manifest.categoryLabelColor)
@@ -66,7 +67,7 @@ class ManifestTest : UsesResources() {
     }
 
     @Test
-    fun testParseManifestLesson() {
+    fun testParseManifestLesson() = runBlockingTest {
         val manifest = parseManifest("manifest_lesson.xml")
         assertEquals("title", manifest.title)
         assertEquals("lesson1", manifest.code)
@@ -80,7 +81,7 @@ class ManifestTest : UsesResources() {
     }
 
     @Test
-    fun testParseManifestTract() {
+    fun testParseManifestTract() = runBlockingTest {
         val manifest = parseManifest("manifest_tract.xml")
         assertEquals("title", manifest.title)
         assertEquals(Manifest.Type.TRACT, manifest.type)
@@ -98,7 +99,7 @@ class ManifestTest : UsesResources() {
     }
 
     @Test
-    fun testParseManifestBackgroundAttrs() {
+    fun testParseManifestBackgroundAttrs() = runBlockingTest {
         val manifest = parseManifest("manifest_background.xml")
         assertEquals(TestColors.GREEN, manifest.backgroundColor)
         assertEquals(TestColors.BLUE, manifest.cardBackgroundColor)
@@ -111,7 +112,7 @@ class ManifestTest : UsesResources() {
     }
 
     @Test
-    fun testParseManifestContainingTips() {
+    fun testParseManifestContainingTips() = runBlockingTest {
         val manifest = parseManifest("manifest_tips.xml")
         assertEquals(0, manifest.tractPages.size)
         assertEquals(0, manifest.resources.size)
@@ -120,14 +121,14 @@ class ManifestTest : UsesResources() {
     }
 
     @Test
-    fun testParseManifestInvalidTips() {
+    fun testParseManifestInvalidTips() = runBlockingTest {
         val manifest = parseManifest("manifest_tips_invalid.xml")
         assertEquals(0, manifest.tractPages.size)
         assertEquals(0, manifest.resources.size)
         assertEquals(0, manifest.tips.size)
     }
 
-    private fun parseManifest(name: String) = Manifest.parse(name) { getTestXmlParser(it) }
+    private suspend fun parseManifest(name: String) = Manifest.parse(name) { getTestXmlParser(it) }
     // endregion parse Manifest
 
     @Test

--- a/src/commonTest/kotlin/org/cru/godtools/tool/service/ManifestParserTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/service/ManifestParserTest.kt
@@ -4,6 +4,7 @@ import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.TEST_XML_PULL_PARSER_FACTORY
 import org.cru.godtools.tool.internal.UsesResources
+import org.cru.godtools.tool.internal.runBlockingTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -13,28 +14,28 @@ class ManifestParserTest : UsesResources("service") {
     private val parser = ManifestParser(TEST_XML_PULL_PARSER_FACTORY)
 
     @Test
-    fun testParseManifest() {
+    fun testParseManifest() = runBlockingTest {
         val result = assertIs<Result.Data>(parser.parseManifest("manifest_valid.xml"))
         assertEquals(2, result.manifest.tractPages.size)
     }
 
     @Test
-    fun testParseManifestMissingManifest() {
+    fun testParseManifestMissingManifest() = runBlockingTest {
         assertIs<Result.Error.NotFound>(parser.parseManifest("missing.xml"))
     }
 
     @Test
-    fun testParseManifestInvalidManifest() {
+    fun testParseManifestInvalidManifest() = runBlockingTest {
         assertIs<Result.Error.Corrupted>(parser.parseManifest("../model/accordion.xml"))
     }
 
     @Test
-    fun testParseManifestMissingPage() {
+    fun testParseManifestMissingPage() = runBlockingTest {
         assertIs<Result.Error.NotFound>(parser.parseManifest("manifest_missing_page.xml"))
     }
 
     @Test
-    fun testParseManifestInvalidPage() {
+    fun testParseManifestInvalidPage() = runBlockingTest {
         assertIs<Result.Error.Corrupted>(parser.parseManifest("manifest_invalid_page.xml"))
     }
 }

--- a/src/iosTest/kotlin/org/cru/godtools/tool/internal/-IosTestingPlatform.kt
+++ b/src/iosTest/kotlin/org/cru/godtools/tool/internal/-IosTestingPlatform.kt
@@ -1,5 +1,7 @@
 package org.cru.godtools.tool.internal
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.runBlocking
 import org.cru.godtools.tool.xml.IosXmlPullParserFactory
 import org.cru.godtools.tool.xml.XmlPullParserFactory
 import platform.Foundation.NSBundle
@@ -18,3 +20,7 @@ internal actual val UsesResources.TEST_XML_PULL_PARSER_FACTORY: XmlPullParserFac
 actual abstract class Runner
 actual class AndroidJUnit4 : Runner()
 // endregion Android Robolectric
+
+// region Kotlin Coroutines
+actual fun runBlockingTest(block: suspend CoroutineScope.() -> Unit) = runBlocking { block() }
+// endregion Kotlin Coroutines

--- a/src/jsTest/kotlin/org/cru/godtools/tool/internal/-JsTestingPlatform.kt
+++ b/src/jsTest/kotlin/org/cru/godtools/tool/internal/-JsTestingPlatform.kt
@@ -1,5 +1,8 @@
 package org.cru.godtools.tool.internal
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.promise
 import okio.ExperimentalFileSystem
 import okio.FileNotFoundException
 import okio.NodeJsFileSystem
@@ -28,3 +31,8 @@ internal actual val UsesResources.TEST_XML_PULL_PARSER_FACTORY: XmlPullParserFac
 actual abstract class Runner
 actual class AndroidJUnit4 : Runner()
 // endregion Android Robolectric
+
+// region Kotlin Coroutines
+val testScope = MainScope()
+actual fun runBlockingTest(block: suspend CoroutineScope.() -> Unit): dynamic = testScope.promise { block() }
+// endregion Kotlin Coroutines


### PR DESCRIPTION
- add a coroutines testing method
- make parseManifest suspendable
- make parse suspendable
- create a setOnce property that can be set only once
- update manifest parsing to parse pages and tips in parallel
