### PR TITLE
GT-1165 Create Multiselect model

### DIFF
--- a/src/commonMain/kotlin/org/cru/godtools/tool/ParserConfig.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/ParserConfig.kt
@@ -2,12 +2,16 @@ package org.cru.godtools.tool
 
 import org.cru.godtools.tool.model.DeviceType
 
+const val FEATURE_MULTISELECT = "multiselect"
+
 expect object ParserConfig {
     var supportedDeviceTypes: Set<DeviceType>
+    var supportedFeatures: Set<String>
 }
 
 object SimpleParserConfig {
     var supportedDeviceTypes = DEFAULT_SUPPORTED_DEVICE_TYPES
+    var supportedFeatures = emptySet<String>()
 }
 
 internal expect val DEFAULT_SUPPORTED_DEVICE_TYPES: Set<DeviceType>

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/Content.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/Content.kt
@@ -49,6 +49,7 @@ abstract class Content : BaseModel {
                     Image.XML_IMAGE -> Image(parent, this)
                     Input.XML_INPUT -> Input(parent, this)
                     Link.XML_LINK -> Link(parent, this)
+                    Multiselect.XML_MULTISELECT -> Multiselect(parent, this)
                     Paragraph.XML_PARAGRAPH ->
                         when (getAttributeValue(Paragraph.XML_FALLBACK)?.toBoolean()) {
                             true -> Fallback(parent, this)

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/EventId.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/EventId.kt
@@ -1,8 +1,11 @@
 package org.cru.godtools.tool.model
 
 import org.cru.godtools.tool.REGEX_SEQUENCE_SEPARATOR
+import org.cru.godtools.tool.internal.VisibleForTesting
+import org.cru.godtools.tool.state.State
 
 private const val EVENT_NAMESPACE_FOLLOWUP = "followup"
+@VisibleForTesting
 internal const val EVENT_NAMESPACE_STATE = "state"
 
 class EventId internal constructor(val namespace: String? = null, val name: String) {
@@ -19,6 +22,11 @@ class EventId internal constructor(val namespace: String? = null, val name: Stri
                     else -> EventId(components[0], components[1])
                 }
             }.orEmpty()
+    }
+
+    fun resolve(state: State) = when (namespace) {
+        EVENT_NAMESPACE_STATE -> state.getAll(name).map { EventId(name = it) }
+        else -> listOf(this)
     }
 
     override fun equals(other: Any?) = other is EventId &&

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/Multiselect.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/Multiselect.kt
@@ -1,5 +1,7 @@
 package org.cru.godtools.tool.model
 
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import org.cru.godtools.tool.FEATURE_MULTISELECT
 import org.cru.godtools.tool.ParserConfig
 import org.cru.godtools.tool.internal.RestrictTo
@@ -80,6 +82,9 @@ class Multiselect : Content {
         }
 
         fun isSelected(state: State) = value in state.getAll(multiselect.stateName)
+        fun isSelectedFlow(state: State) = state.changeFlow(multiselect.stateName)
+            .map { isSelected(state) }
+            .distinctUntilChanged()
         fun toggleSelected(state: State): Boolean {
             val current = state.getAll(multiselect.stateName)
             when {

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/Multiselect.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/Multiselect.kt
@@ -43,11 +43,12 @@ class Multiselect : Content {
 
     @RestrictTo(RestrictTo.Scope.TESTS)
     internal constructor(
-        parent: Base,
+        parent: Base = Manifest(),
+        stateName: String = "",
         selectionLimit: Int = 1,
         options: ((Multiselect) -> List<Option>)? = null
     ) : super(parent) {
-        stateName = ""
+        this.stateName = stateName
         this.selectionLimit = selectionLimit
         this.options = options?.invoke(this).orEmpty()
     }

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/Multiselect.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/Multiselect.kt
@@ -1,0 +1,74 @@
+package org.cru.godtools.tool.model
+
+import org.cru.godtools.tool.FEATURE_MULTISELECT
+import org.cru.godtools.tool.ParserConfig
+import org.cru.godtools.tool.internal.VisibleForTesting
+import org.cru.godtools.tool.state.State
+import org.cru.godtools.tool.xml.XmlPullParser
+import org.cru.godtools.tool.xml.parseChildren
+
+private const val XML_STATE = "state"
+private const val XML_SELECTION_LIMIT = "selection-limit"
+private const val XML_OPTION = "option"
+private const val XML_OPTION_VALUE = "value"
+
+class Multiselect : Content {
+    internal companion object {
+        internal const val XML_MULTISELECT = "multiselect"
+    }
+
+    @VisibleForTesting
+    internal val state: String
+    @VisibleForTesting
+    internal val selectionLimit: Int
+
+    val options: List<Option>
+
+    internal constructor(parent: Base, parser: XmlPullParser) : super(parent, parser) {
+        parser.require(XmlPullParser.START_TAG, XMLNS_CONTENT, XML_MULTISELECT)
+
+        state = parser.getAttributeValue(XML_STATE).orEmpty()
+        selectionLimit = (parser.getAttributeValue(XML_SELECTION_LIMIT)?.toIntOrNull() ?: 1).coerceAtLeast(1)
+
+        options = mutableListOf()
+        parser.parseChildren {
+            when (parser.namespace) {
+                XMLNS_CONTENT -> when (parser.name) {
+                    XML_OPTION -> options += Option(this, parser)
+                }
+            }
+        }
+    }
+
+    override val isIgnored get() = FEATURE_MULTISELECT !in ParserConfig.supportedFeatures || super.isIgnored
+
+    class Option : Content, Parent {
+        private val multiselect: Multiselect
+
+        @VisibleForTesting
+        internal val value: String
+
+        override val content: List<Content>
+
+        internal constructor(multiselect: Multiselect, parser: XmlPullParser) : super(multiselect, parser) {
+            this.multiselect = multiselect
+            parser.require(XmlPullParser.START_TAG, XMLNS_CONTENT, XML_OPTION)
+
+            value = parser.getAttributeValue(XML_OPTION_VALUE).orEmpty()
+
+            content = parseContent(parser)
+        }
+
+        fun isSelected(state: State) = value in state.getAll(multiselect.state)
+        fun toggleSelected(state: State): Boolean {
+            val current = state.getAll(multiselect.state)
+            when {
+                value in current -> state.removeValue(multiselect.state, value)
+                current.size < multiselect.selectionLimit -> state.addValue(multiselect.state, value)
+                multiselect.selectionLimit == 1 -> state[multiselect.state] = value
+                else -> return false
+            }
+            return true
+        }
+    }
+}

--- a/src/commonMain/kotlin/org/cru/godtools/tool/state/State.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/state/State.kt
@@ -13,4 +13,7 @@ class State internal constructor(private val state: MutableMap<String, List<Stri
     internal operator fun set(key: String, value: String?) = state.set(key, listOfNotNull(value))
     internal operator fun set(key: String, values: List<String>?) = state.set(key, values.orEmpty())
     internal fun set(key: String, vararg values: String) = state.set(key, values.toList())
+
+    internal fun addValue(key: String, value: String) = state.set(key, (state[key].orEmpty() + value).distinct())
+    internal fun removeValue(key: String, value: String) = state.set(key, state[key]?.filterNot { it == value })
 }

--- a/src/commonMain/kotlin/org/cru/godtools/tool/state/State.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/state/State.kt
@@ -2,8 +2,6 @@ package org.cru.godtools.tool.state
 
 import org.cru.godtools.tool.internal.Parcelable
 import org.cru.godtools.tool.internal.Parcelize
-import org.cru.godtools.tool.model.EVENT_NAMESPACE_STATE
-import org.cru.godtools.tool.model.EventId
 
 @Parcelize
 class State internal constructor(private val state: MutableMap<String, List<String>>) : Parcelable {
@@ -15,9 +13,4 @@ class State internal constructor(private val state: MutableMap<String, List<Stri
     internal operator fun set(key: String, value: String?) = state.set(key, listOfNotNull(value))
     internal operator fun set(key: String, values: List<String>?) = state.set(key, values.orEmpty())
     internal fun set(key: String, vararg values: String) = state.set(key, values.toList())
-
-    fun resolveEventId(id: EventId) = when (id.namespace) {
-        EVENT_NAMESPACE_STATE -> getAll(id.name).map { EventId(name = it) }
-        else -> listOf(id)
-    }
 }

--- a/src/commonMain/kotlin/org/cru/godtools/tool/state/State.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/state/State.kt
@@ -9,12 +9,12 @@ import org.cru.godtools.tool.model.EventId
 class State internal constructor(private val state: MutableMap<String, List<String>>) : Parcelable {
     constructor() : this(mutableMapOf<String, List<String>>())
 
-    operator fun get(key: String) = state[key]?.firstOrNull()
-    fun getAll(key: String) = state[key].orEmpty()
+    internal operator fun get(key: String) = state[key]?.firstOrNull()
+    internal fun getAll(key: String) = state[key].orEmpty()
 
-    operator fun set(key: String, value: String?) = state.set(key, listOfNotNull(value))
-    operator fun set(key: String, values: List<String>?) = state.set(key, values.orEmpty())
-    fun set(key: String, vararg values: String) = state.set(key, values.toList())
+    internal operator fun set(key: String, value: String?) = state.set(key, listOfNotNull(value))
+    internal operator fun set(key: String, values: List<String>?) = state.set(key, values.orEmpty())
+    internal fun set(key: String, vararg values: String) = state.set(key, values.toList())
 
     fun resolveEventId(id: EventId) = when (id.namespace) {
         EVENT_NAMESPACE_STATE -> getAll(id.name).map { EventId(name = it) }

--- a/src/commonMain/kotlin/org/cru/godtools/tool/state/State.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/state/State.kt
@@ -1,19 +1,28 @@
 package org.cru.godtools.tool.state
 
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.conflate
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.onStart
 import org.cru.godtools.tool.internal.Parcelable
 import org.cru.godtools.tool.internal.Parcelize
 
 @Parcelize
-class State internal constructor(private val state: MutableMap<String, List<String>>) : Parcelable {
-    constructor() : this(mutableMapOf<String, List<String>>())
+class State internal constructor(private val state: MutableMap<String, List<String>?>) : Parcelable {
+    constructor() : this(mutableMapOf<String, List<String>?>())
+
+    private val changeFlow = MutableSharedFlow<String>(extraBufferCapacity = Int.MAX_VALUE)
+    internal fun changeFlow(key: String) = changeFlow.filter { it == key }.onStart { emit(key) }.conflate()
 
     internal operator fun get(key: String) = state[key]?.firstOrNull()
     internal fun getAll(key: String) = state[key].orEmpty()
 
-    internal operator fun set(key: String, value: String?) = state.set(key, listOfNotNull(value))
-    internal operator fun set(key: String, values: List<String>?) = state.set(key, values.orEmpty())
-    internal fun set(key: String, vararg values: String) = state.set(key, values.toList())
+    internal operator fun set(key: String, value: String?) = set(key, listOfNotNull(value))
+    internal operator fun set(key: String, values: List<String>?) {
+        state[key] = values
+        changeFlow.tryEmit(key)
+    }
 
-    internal fun addValue(key: String, value: String) = state.set(key, (state[key].orEmpty() + value).distinct())
-    internal fun removeValue(key: String, value: String) = state.set(key, state[key]?.filterNot { it == value })
+    internal fun addValue(key: String, value: String) = set(key, (getAll(key) + value).distinct())
+    internal fun removeValue(key: String, value: String) = set(key, getAll(key).filterNot { it == value })
 }

--- a/src/commonTest/kotlin/org/cru/godtools/tool/internal/Channel.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/internal/Channel.kt
@@ -1,0 +1,6 @@
+package org.cru.godtools.tool.internal
+
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.withTimeout
+
+suspend inline fun <T : Any?> Channel<T>.receive(timeout: Long) = withTimeout(timeout) { receive() }

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/ContentTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/ContentTest.kt
@@ -105,6 +105,12 @@ class ContentTest : UsesResources() {
     }
 
     @Test
+    fun verifyParseContentElementMultiselect() = runBlockingTest {
+        assertIs<Multiselect>(getTestXmlParser("multiselect.xml").parseContentElement(Manifest()))
+        assertIs<Multiselect>(getTestXmlParser("multiselect_defaults.xml").parseContentElement(Manifest()))
+    }
+
+    @Test
     fun verifyParseContentElementParagraph() = runBlockingTest {
         assertIs<Paragraph>(getTestXmlParser("paragraph.xml").parseContentElement(Manifest()))
     }

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/EventIdTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/EventIdTest.kt
@@ -1,9 +1,11 @@
 package org.cru.godtools.tool.model
 
+import org.cru.godtools.tool.state.State
 import kotlin.native.concurrent.SharedImmutable
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
 
 @SharedImmutable
 private val ID1 = EventId("followup", "seND")
@@ -36,4 +38,29 @@ class EventTest {
         assertEquals(0, EventId.parse("").size)
         assertEquals(0, EventId.parse(null).size)
     }
+
+    // region resolve(State)
+    @Test
+    fun testResolve() {
+        val state = State()
+        state["selectorState"] = listOf("a", "b")
+        val events = EventId(EVENT_NAMESPACE_STATE, "selectorState").resolve(state)
+        assertEquals(2, events.size)
+        assertEquals(EventId(name = "a"), events[0])
+        assertEquals(EventId(name = "b"), events[1])
+    }
+
+    @Test
+    fun testResolveUnset() {
+        assertTrue(EventId(EVENT_NAMESPACE_STATE, "missing").resolve(State()).isEmpty())
+    }
+
+    @Test
+    fun testResolveDifferentNamespace() {
+        val state = State()
+        val event = EventId(name = "event")
+        state["event"] = listOf("a", "b")
+        assertEquals(event, event.resolve(state).single())
+    }
+    // endregion resolve(State)
 }

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/MultiselectTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/MultiselectTest.kt
@@ -44,7 +44,7 @@ class MultiselectTest : UsesResources() {
 
     @Test
     fun testOptionIsSelected() {
-        val multiselect = Multiselect(Manifest()) { it.options(2) }
+        val multiselect = Multiselect() { it.options(2) }
 
         multiselect.options[0].toggleSelected(state)
         assertTrue(multiselect.options[0].isSelected(state))
@@ -53,7 +53,7 @@ class MultiselectTest : UsesResources() {
 
     @Test
     fun testOptionToggleSelectedSingleSelection() {
-        with(Multiselect(Manifest(), selectionLimit = 1) { it.options(2) }) {
+        with(Multiselect(selectionLimit = 1) { it.options(2) }) {
             // initial state
             assertFalse(options[0].isSelected(state))
             assertFalse(options[1].isSelected(state))
@@ -77,7 +77,7 @@ class MultiselectTest : UsesResources() {
 
     @Test
     fun testOptionToggleSelectedMultipleSelections() {
-        with(Multiselect(Manifest(), selectionLimit = 2) { it.options(3) }) {
+        with(Multiselect(selectionLimit = 2) { it.options(3) }) {
             // initial state
             assertFalse(options[0].isSelected(state))
             assertFalse(options[1].isSelected(state))
@@ -109,5 +109,15 @@ class MultiselectTest : UsesResources() {
         }
     }
 
-    private fun Multiselect.options(count: Int = 2) = List(count) { Multiselect.Option(this, it.toString()) }
+    @Test
+    fun testMultiselectAffectsEventIdResolution() {
+        val eventId = EventId(EVENT_NAMESPACE_STATE, "test")
+        val multiselect = Multiselect(stateName = eventId.name, selectionLimit = 2) { it.options(3) }
+
+        multiselect.options[2].toggleSelected(state)
+        multiselect.options[0].toggleSelected(state)
+        assertEquals(listOf(EventId(name = "2"), EventId(name = "0")), eventId.resolve(state))
+    }
+
+    private fun Multiselect.options(count: Int = 2) = List(count) { Multiselect.Option(this, "$it") }
 }

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/MultiselectTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/MultiselectTest.kt
@@ -1,10 +1,16 @@
 package org.cru.godtools.tool.model
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import org.cru.godtools.tool.FEATURE_MULTISELECT
 import org.cru.godtools.tool.ParserConfig
 import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
+import org.cru.godtools.tool.internal.receive
 import org.cru.godtools.tool.internal.runBlockingTest
 import org.cru.godtools.tool.state.State
 import kotlin.test.Test
@@ -57,11 +63,40 @@ class MultiselectTest : UsesResources() {
 
     @Test
     fun testOptionIsSelected() {
-        val multiselect = Multiselect() { it.options(2) }
+        val multiselect = Multiselect { it.options(2) }
 
         multiselect.options[0].toggleSelected(state)
         assertTrue(multiselect.options[0].isSelected(state))
         assertFalse(multiselect.options[1].isSelected(state))
+    }
+
+    @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun testOptionIsSelectedFlow() = runBlockingTest {
+        val multiselect = Multiselect { it.options(2) }
+
+        val flowOutput = Channel<Boolean>(1)
+        val flow = multiselect.options[0].isSelectedFlow(state)
+            .onEach { flowOutput.send(it) }
+            .launchIn(this)
+        assertFalse("Initially not selected") { flowOutput.receive(100) }
+
+        multiselect.options[0].toggleSelected(state)
+        println("Toggled this option to true")
+        assertTrue(flowOutput.receive(100))
+
+        multiselect.options[1].toggleSelected(state)
+        assertFalse(flowOutput.receive(100), "Toggled other option to true")
+
+        multiselect.options[1].toggleSelected(state)
+        delay(100)
+        assertTrue(flowOutput.isEmpty, "Toggled other option to false")
+
+        state["other"] = "test"
+        delay(100)
+        assertTrue(flowOutput.isEmpty, "Set different state value")
+
+        flow.cancel()
     }
 
     @Test

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/MultiselectTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/MultiselectTest.kt
@@ -4,17 +4,21 @@ import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
 import org.cru.godtools.tool.internal.runBlockingTest
+import org.cru.godtools.tool.state.State
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 @RunOnAndroidWith(AndroidJUnit4::class)
 class MultiselectTest : UsesResources() {
+    private val state by lazy { State() }
+
     @Test
     fun testParseMultiselect() = runBlockingTest {
         val multiselect = Multiselect(Manifest(), getTestXmlParser("multiselect.xml"))
-        assertEquals("quiz1", multiselect.state)
+        assertEquals("quiz1", multiselect.stateName)
         assertEquals(2, multiselect.selectionLimit)
         assertEquals(3, multiselect.options.size)
         with(multiselect.options[1]) {
@@ -29,7 +33,7 @@ class MultiselectTest : UsesResources() {
     @Test
     fun testParseMultiselectDefaults() = runBlockingTest {
         val multiselect = Multiselect(Manifest(), getTestXmlParser("multiselect_defaults.xml"))
-        assertEquals("", multiselect.state)
+        assertEquals("", multiselect.stateName)
         assertEquals(1, multiselect.selectionLimit)
         assertEquals(1, multiselect.options.size)
         with(multiselect.options.single()) {
@@ -37,4 +41,73 @@ class MultiselectTest : UsesResources() {
             assertTrue(content.isEmpty())
         }
     }
+
+    @Test
+    fun testOptionIsSelected() {
+        val multiselect = Multiselect(Manifest()) { it.options(2) }
+
+        multiselect.options[0].toggleSelected(state)
+        assertTrue(multiselect.options[0].isSelected(state))
+        assertFalse(multiselect.options[1].isSelected(state))
+    }
+
+    @Test
+    fun testOptionToggleSelectedSingleSelection() {
+        with(Multiselect(Manifest(), selectionLimit = 1) { it.options(2) }) {
+            // initial state
+            assertFalse(options[0].isSelected(state))
+            assertFalse(options[1].isSelected(state))
+
+            // select first
+            assertTrue(options[0].toggleSelected(state))
+            assertTrue(options[0].isSelected(state))
+            assertFalse(options[1].isSelected(state))
+
+            // select second
+            assertTrue(options[1].toggleSelected(state))
+            assertFalse(options[0].isSelected(state))
+            assertTrue(options[1].isSelected(state))
+
+            // unselect second
+            assertTrue(options[1].toggleSelected(state))
+            assertFalse(options[0].isSelected(state))
+            assertFalse(options[1].isSelected(state))
+        }
+    }
+
+    @Test
+    fun testOptionToggleSelectedMultipleSelections() {
+        with(Multiselect(Manifest(), selectionLimit = 2) { it.options(3) }) {
+            // initial state
+            assertFalse(options[0].isSelected(state))
+            assertFalse(options[1].isSelected(state))
+            assertFalse(options[2].isSelected(state))
+
+            // select first
+            assertTrue(options[0].toggleSelected(state))
+            assertTrue(options[0].isSelected(state))
+            assertFalse(options[1].isSelected(state))
+            assertFalse(options[2].isSelected(state))
+
+            // select second
+            assertTrue(options[1].toggleSelected(state))
+            assertTrue(options[0].isSelected(state))
+            assertTrue(options[1].isSelected(state))
+            assertFalse(options[2].isSelected(state))
+
+            // try to select third
+            assertFalse(options[2].toggleSelected(state))
+            assertTrue(options[0].isSelected(state))
+            assertTrue(options[1].isSelected(state))
+            assertFalse(options[2].isSelected(state))
+
+            // unselect first
+            assertTrue(options[0].toggleSelected(state))
+            assertFalse(options[0].isSelected(state))
+            assertTrue(options[1].isSelected(state))
+            assertFalse(options[2].isSelected(state))
+        }
+    }
+
+    private fun Multiselect.options(count: Int = 2) = List(count) { Multiselect.Option(this, it.toString()) }
 }

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/MultiselectTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/MultiselectTest.kt
@@ -1,5 +1,7 @@
 package org.cru.godtools.tool.model
 
+import org.cru.godtools.tool.FEATURE_MULTISELECT
+import org.cru.godtools.tool.ParserConfig
 import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
@@ -40,6 +42,17 @@ class MultiselectTest : UsesResources() {
             assertEquals("valueAttr", value)
             assertTrue(content.isEmpty())
         }
+    }
+
+    @Test
+    fun testIsIgnored() {
+        val multiselect = Multiselect()
+
+        ParserConfig.supportedFeatures = setOf(FEATURE_MULTISELECT)
+        assertFalse(multiselect.isIgnored)
+
+        ParserConfig.supportedFeatures = emptySet()
+        assertTrue(multiselect.isIgnored)
     }
 
     @Test

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/MultiselectTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/MultiselectTest.kt
@@ -1,0 +1,40 @@
+package org.cru.godtools.tool.model
+
+import org.cru.godtools.tool.internal.AndroidJUnit4
+import org.cru.godtools.tool.internal.RunOnAndroidWith
+import org.cru.godtools.tool.internal.UsesResources
+import org.cru.godtools.tool.internal.runBlockingTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+@RunOnAndroidWith(AndroidJUnit4::class)
+class MultiselectTest : UsesResources() {
+    @Test
+    fun testParseMultiselect() = runBlockingTest {
+        val multiselect = Multiselect(Manifest(), getTestXmlParser("multiselect.xml"))
+        assertEquals("quiz1", multiselect.state)
+        assertEquals(2, multiselect.selectionLimit)
+        assertEquals(3, multiselect.options.size)
+        with(multiselect.options[1]) {
+            assertEquals("answer2", value)
+            assertEquals(1, content.size)
+            with(assertIs<Text>(content.single())) {
+                assertEquals("Answer 2", text)
+            }
+        }
+    }
+
+    @Test
+    fun testParseMultiselectDefaults() = runBlockingTest {
+        val multiselect = Multiselect(Manifest(), getTestXmlParser("multiselect_defaults.xml"))
+        assertEquals("", multiselect.state)
+        assertEquals(1, multiselect.selectionLimit)
+        assertEquals(1, multiselect.options.size)
+        with(multiselect.options.single()) {
+            assertEquals("valueAttr", value)
+            assertTrue(content.isEmpty())
+        }
+    }
+}

--- a/src/commonTest/kotlin/org/cru/godtools/tool/state/StateTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/state/StateTest.kt
@@ -1,7 +1,5 @@
 package org.cru.godtools.tool.state
 
-import org.cru.godtools.tool.model.EVENT_NAMESPACE_STATE
-import org.cru.godtools.tool.model.EventId
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -26,26 +24,5 @@ class StateTest {
         assertEquals(listOf("value"), state.getAll("single"))
         state["multiple"] = listOf("a", "b", "c")
         assertEquals(listOf("a", "b", "c"), state.getAll("multiple"))
-    }
-
-    @Test
-    fun testResolveEventId() {
-        state["selectorState"] = listOf("a", "b")
-        val events = state.resolveEventId(EventId(EVENT_NAMESPACE_STATE, "selectorState"))
-        assertEquals(2, events.size)
-        assertEquals(EventId(name = "a"), events[0])
-        assertEquals(EventId(name = "b"), events[1])
-    }
-
-    @Test
-    fun testResolveEventIdUnset() {
-        assertTrue(state.resolveEventId(EventId(EVENT_NAMESPACE_STATE, "missing")).isEmpty())
-    }
-
-    @Test
-    fun testResolveEventIdDifferentNamespace() {
-        val event = EventId(name = "event")
-        state["event"] = listOf("a", "b")
-        assertEquals(event, state.resolveEventId(event).single())
     }
 }

--- a/src/commonTest/kotlin/org/cru/godtools/tool/state/StateTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/state/StateTest.kt
@@ -1,5 +1,11 @@
 package org.cru.godtools.tool.state
 
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import org.cru.godtools.tool.internal.receive
+import org.cru.godtools.tool.internal.runBlockingTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -24,5 +30,28 @@ class StateTest {
         assertEquals(listOf("value"), state.getAll("single"))
         state["multiple"] = listOf("a", "b", "c")
         assertEquals(listOf("a", "b", "c"), state.getAll("multiple"))
+    }
+
+    @Test
+    fun testChangeFlow() = runBlockingTest {
+        val channel = Channel<String>()
+        val flow = state.changeFlow("test")
+            .onEach { channel.send(it) }
+            .launchIn(this)
+
+        // initial value
+        assertEquals("test", channel.receive(100))
+
+        // update state for monitored key
+        state["test"] = "a"
+        assertEquals("test", channel.receive(100))
+
+        // update state for a different key
+        state["other"] = "a"
+        delay(100)
+        assertTrue(channel.isEmpty)
+
+        // shut down flow
+        flow.cancel()
     }
 }

--- a/src/commonTest/resources/org/cru/godtools/tool/model/multiselect.xml
+++ b/src/commonTest/resources/org/cru/godtools/tool/model/multiselect.xml
@@ -1,0 +1,12 @@
+<content:multiselect xmlns:content="https://mobile-content-api.cru.org/xmlns/content" state="quiz1" selection-limit="2">
+    <content:option value="answer1">
+        <content:text>Answer 1</content:text>
+    </content:option>
+    <content:option value="answer2">
+        <unrecognized />
+        <content:text>Answer 2</content:text>
+    </content:option>
+    <content:option value="answer3">
+        <content:text>Answer 3</content:text>
+    </content:option>
+</content:multiselect>

--- a/src/commonTest/resources/org/cru/godtools/tool/model/multiselect_defaults.xml
+++ b/src/commonTest/resources/org/cru/godtools/tool/model/multiselect_defaults.xml
@@ -1,0 +1,3 @@
+<content:multiselect xmlns:content="https://mobile-content-api.cru.org/xmlns/content">
+    <content:option value="valueAttr" />
+</content:multiselect>

--- a/src/iosMain/kotlin/org/cru/godtools/tool/IosParserConfig.kt
+++ b/src/iosMain/kotlin/org/cru/godtools/tool/IosParserConfig.kt
@@ -13,6 +13,13 @@ actual object ParserConfig {
         set(value) {
             _supportedDeviceTypes.value = if (value.isFrozen) value else value.toSet().freeze()
         }
+
+    private val _supportedFeatures = AtomicReference(emptySet<String>())
+    actual var supportedFeatures: Set<String>
+        get() = _supportedFeatures.value
+        set(value) {
+            _supportedFeatures.value = if (value.isFrozen) value else value.toSet().freeze()
+        }
 }
 
 @SharedImmutable


### PR DESCRIPTION
Create a Multiselect model in the shared tool parser. This model can be enabled by adding it to the list of supported features.
```kotlin
ParserConfig.supportedFeatures = setOf(FEATURE_MULTISELECT)
```

Once enabled you can manage the state of the Multiselect model using the following methods:
```kotlin
multiselect.options[0].isSelected(state)
multiselect.options[0].isSelectedFlow(state)
multiselect.options[0].toggleSelected(state)
```

TODO:
- [x] Expose `isSelected` via a coroutines flow so that Android and iOS can reactively render multiselect options