### PR TITLE
Utilize colormath library

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,10 +65,12 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation(kotlin("stdlib"))
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.0")
+
+                implementation(libs.colormath)
                 implementation(libs.fluidLocale)
                 implementation(libs.napier)
                 implementation(libs.splitties.bitflags)
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.0")
             }
         }
         val commonTest by getting {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 androidx-annotation = "1.2.0"
+colormath = "2.1.0"
 fluidLocale = "0.9.6"
 jacoco = "0.8.7"
 ktlint = "0.41.0"
@@ -9,6 +10,7 @@ splitties = "3.0.0-beta01"
 
 [libraries]
 androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "androidx-annotation" }
+colormath = { module = "com.github.ajalt.colormath:colormath", version.ref = "colormath" }
 fluidLocale = { module = "io.fluidsonic.locale:fluid-locale", version.ref = "fluidLocale" }
 napier = { module = "io.github.aakira:napier", version.ref = "napier" }
 okio-js = { module = "com.squareup.okio:okio-js", version.ref = "okio" }

--- a/src/androidMain/java/org/cru/godtools/tool/model/AndroidColor.kt
+++ b/src/androidMain/java/org/cru/godtools/tool/model/AndroidColor.kt
@@ -6,7 +6,5 @@ import com.github.ajalt.colormath.RGB
 actual typealias Color = Int
 
 @ColorInt
-internal actual inline fun color(red: Int, green: Int, blue: Int, alpha: Double) =
-    android.graphics.Color.argb((alpha * 255).toInt(), red, green, blue)
-
+internal actual fun RGB.toColor() = toPackedInt()
 internal actual fun Color.toRGB() = RGB.fromInt(this)

--- a/src/androidMain/java/org/cru/godtools/tool/model/AndroidColor.kt
+++ b/src/androidMain/java/org/cru/godtools/tool/model/AndroidColor.kt
@@ -3,8 +3,8 @@ package org.cru.godtools.tool.model
 import androidx.annotation.ColorInt
 import com.github.ajalt.colormath.RGB
 
-actual typealias Color = Int
+actual typealias PlatformColor = Int
 
 @ColorInt
-internal actual fun RGB.toColor() = toPackedInt()
-internal actual fun Color.toRGB() = RGB.fromInt(this)
+internal actual fun RGB.toPlatformColor() = toPackedInt()
+internal actual fun PlatformColor.toRGB() = RGB.fromInt(this)

--- a/src/androidMain/java/org/cru/godtools/tool/model/AndroidColor.kt
+++ b/src/androidMain/java/org/cru/godtools/tool/model/AndroidColor.kt
@@ -1,9 +1,12 @@
 package org.cru.godtools.tool.model
 
 import androidx.annotation.ColorInt
+import com.github.ajalt.colormath.RGB
 
 actual typealias Color = Int
 
 @ColorInt
 internal actual inline fun color(red: Int, green: Int, blue: Int, alpha: Double) =
     android.graphics.Color.argb((alpha * 255).toInt(), red, green, blue)
+
+internal actual fun Color.toRGB() = RGB.fromInt(this)

--- a/src/androidTest/java/org/cru/godtools/tool/model/AndroidColorTest.kt
+++ b/src/androidTest/java/org/cru/godtools/tool/model/AndroidColorTest.kt
@@ -10,8 +10,8 @@ import kotlin.test.assertEquals
 @RunWith(AndroidJUnit4::class)
 class AndroidColorTest {
     @Test
-    fun testColorGeneration() {
-        val color = RGB(1, 2, 3, .5f).toColor()
+    fun testToPlatformColor() {
+        val color = RGB(1, 2, 3, .5f).toPlatformColor()
 
         assertEquals(1, Color.red(color))
         assertEquals(2, Color.green(color))

--- a/src/androidTest/java/org/cru/godtools/tool/model/AndroidColorTest.kt
+++ b/src/androidTest/java/org/cru/godtools/tool/model/AndroidColorTest.kt
@@ -1,0 +1,21 @@
+package org.cru.godtools.tool.model
+
+import android.graphics.Color
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.ajalt.colormath.RGB
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.test.assertEquals
+
+@RunWith(AndroidJUnit4::class)
+class AndroidColorTest {
+    @Test
+    fun testColorGeneration() {
+        val color = RGB(1, 2, 3, .5f).toColor()
+
+        assertEquals(1, Color.red(color))
+        assertEquals(2, Color.green(color))
+        assertEquals(3, Color.blue(color))
+        assertEquals(128, Color.alpha(color))
+    }
+}

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/Button.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/Button.kt
@@ -29,7 +29,7 @@ class Button : Content, Styles {
     val style: Style get() = _style ?: stylesParent.buttonStyle
 
     @AndroidColorInt
-    private val _buttonColor: Color?
+    private val _buttonColor: PlatformColor?
     @get:AndroidColorInt
     override val buttonColor get() = _buttonColor ?: stylesParent.let { it?.buttonColor ?: it.primaryColor }
 
@@ -70,7 +70,7 @@ class Button : Content, Styles {
         parent: Base,
         type: Type = Type.DEFAULT,
         style: Style? = null,
-        @AndroidColorInt color: Color? = null,
+        @AndroidColorInt color: PlatformColor? = null,
         text: ((Button) -> Text?)? = null
     ) : super(parent) {
         this.type = type

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/Color.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/Color.kt
@@ -14,19 +14,10 @@ expect class Color
 internal fun String.toColorOrNull(): Color? = COLOR_REGEX.matchEntire(this)?.let {
     try {
         val (red, green, blue, alpha) = it.destructured
-        unsafeColor(red.toInt(), green.toInt(), blue.toInt(), alpha.toDouble())
-    } catch (ignored: Exception) {
+        RGB(red.toInt(), green.toInt(), blue.toInt(), alpha.toFloat()).toColor()
+    } catch (ignored: IllegalArgumentException) {
         null
     }
-}
-
-@AndroidColorInt
-private fun unsafeColor(red: Int, green: Int, blue: Int, alpha: Double): Color {
-    require(red in 0..255) { "Invalid red value" }
-    require(green in 0..255) { "Invalid green value" }
-    require(blue in 0..255) { "Invalid green value" }
-    require(alpha in 0.0..1.0) { "Invalid alpha value" }
-    return color(red, green, blue, alpha)
 }
 
 @AndroidColorInt

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/Color.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/Color.kt
@@ -21,7 +21,8 @@ internal fun String.toColorOrNull(): Color? = COLOR_REGEX.matchEntire(this)?.let
 }
 
 @AndroidColorInt
-internal expect inline fun color(red: Int, green: Int, blue: Int, alpha: Double): Color
+internal inline fun color(red: Int, green: Int, blue: Int, alpha: Double) =
+    RGB(red, green, blue, alpha.toFloat()).toColor()
 
 internal expect fun Color.toRGB(): RGB
-internal fun RGB.toColor() = color(r, g, b, a.toDouble())
+internal expect fun RGB.toColor(): Color

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/Color.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/Color.kt
@@ -5,7 +5,7 @@ import org.cru.godtools.tool.internal.AndroidColorInt
 import kotlin.native.concurrent.SharedImmutable
 
 @SharedImmutable
-internal val COLOR_REGEX =
+private val COLOR_REGEX =
     Regex("^\\s*rgba\\(\\s*([0-9]+)\\s*,\\s*([0-9]+)\\s*,\\s*([0-9]+)\\s*,\\s*([0-9.]+)\\s*\\)\\s*$")
 
 expect class Color

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/Color.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/Color.kt
@@ -1,5 +1,6 @@
 package org.cru.godtools.tool.model
 
+import com.github.ajalt.colormath.RGB
 import org.cru.godtools.tool.internal.AndroidColorInt
 import kotlin.native.concurrent.SharedImmutable
 
@@ -30,3 +31,6 @@ private fun unsafeColor(red: Int, green: Int, blue: Int, alpha: Double): Color {
 
 @AndroidColorInt
 internal expect inline fun color(red: Int, green: Int, blue: Int, alpha: Double): Color
+
+internal expect fun Color.toRGB(): RGB
+internal fun RGB.toColor() = color(r, g, b, a.toDouble())

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
@@ -100,43 +100,43 @@ class Manifest : BaseModel, Styles {
     val dismissListeners: Set<EventId>
 
     @AndroidColorInt
-    override val primaryColor: Color
+    override val primaryColor: PlatformColor
     @AndroidColorInt
-    override val primaryTextColor: Color
+    override val primaryTextColor: PlatformColor
 
     @AndroidColorInt
-    private val _navBarColor: Color?
+    private val _navBarColor: PlatformColor?
     @get:AndroidColorInt
     val navBarColor get() = _navBarColor ?: if (type == Type.LESSON) DEFAULT_LESSON_NAV_BAR_COLOR else primaryColor
     @AndroidColorInt
-    private val _navBarControlColor: Color?
+    private val _navBarControlColor: PlatformColor?
     @get:AndroidColorInt
     val navBarControlColor get() = _navBarControlColor ?: if (type == Type.LESSON) primaryColor else primaryTextColor
 
     @AndroidColorInt
-    val backgroundColor: Color
+    val backgroundColor: PlatformColor
     private val _backgroundImage: String?
     val backgroundImage get() = getResource(_backgroundImage)
     val backgroundImageGravity: ImageGravity
     val backgroundImageScaleType: ImageScaleType
 
     @AndroidColorInt
-    private val _cardBackgroundColor: Color?
+    private val _cardBackgroundColor: PlatformColor?
     @get:AndroidColorInt
     val cardBackgroundColor get() = _cardBackgroundColor ?: backgroundColor
 
     @AndroidColorInt
-    private val _categoryLabelColor: Color?
+    private val _categoryLabelColor: PlatformColor?
     @get:AndroidColorInt
     internal val categoryLabelColor get() = _categoryLabelColor ?: textColor
 
     @AndroidColorInt
-    internal val lessonControlColor: Color
+    internal val lessonControlColor: PlatformColor
 
     override val buttonStyle get() = DEFAULT_BUTTON_STYLE
 
     @AndroidColorInt
-    override val textColor: Color
+    override val textColor: PlatformColor
     override val textScale: Double
 
     private val _title: Text?
@@ -219,15 +219,15 @@ class Manifest : BaseModel, Styles {
         type: Type = Type.DEFAULT,
         code: String? = null,
         locale: PlatformLocale? = null,
-        primaryColor: Color = DEFAULT_PRIMARY_COLOR,
-        primaryTextColor: Color = DEFAULT_PRIMARY_TEXT_COLOR,
-        navBarColor: Color? = null,
-        navBarControlColor: Color? = null,
-        backgroundColor: Color = DEFAULT_BACKGROUND_COLOR,
-        cardBackgroundColor: Color? = null,
-        categoryLabelColor: Color? = null,
-        lessonControlColor: Color = DEFAULT_LESSON_CONTROL_COLOR,
-        textColor: Color = DEFAULT_TEXT_COLOR,
+        primaryColor: PlatformColor = DEFAULT_PRIMARY_COLOR,
+        primaryTextColor: PlatformColor = DEFAULT_PRIMARY_TEXT_COLOR,
+        navBarColor: PlatformColor? = null,
+        navBarControlColor: PlatformColor? = null,
+        backgroundColor: PlatformColor = DEFAULT_BACKGROUND_COLOR,
+        cardBackgroundColor: PlatformColor? = null,
+        categoryLabelColor: PlatformColor? = null,
+        lessonControlColor: PlatformColor = DEFAULT_LESSON_CONTROL_COLOR,
+        textColor: PlatformColor = DEFAULT_TEXT_COLOR,
         textScale: Double = DEFAULT_TEXT_SCALE,
         resources: ((Manifest) -> List<Resource>)? = null,
         tips: ((Manifest) -> List<Tip>)? = null,

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/PlatformColor.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/PlatformColor.kt
@@ -8,13 +8,13 @@ import kotlin.native.concurrent.SharedImmutable
 private val COLOR_REGEX =
     Regex("^\\s*rgba\\(\\s*([0-9]+)\\s*,\\s*([0-9]+)\\s*,\\s*([0-9]+)\\s*,\\s*([0-9.]+)\\s*\\)\\s*$")
 
-expect class Color
+expect class PlatformColor
 
 @AndroidColorInt
-internal fun String.toColorOrNull(): Color? = COLOR_REGEX.matchEntire(this)?.let {
+internal fun String.toColorOrNull(): PlatformColor? = COLOR_REGEX.matchEntire(this)?.let {
     try {
         val (red, green, blue, alpha) = it.destructured
-        RGB(red.toInt(), green.toInt(), blue.toInt(), alpha.toFloat()).toColor()
+        RGB(red.toInt(), green.toInt(), blue.toInt(), alpha.toFloat()).toPlatformColor()
     } catch (ignored: IllegalArgumentException) {
         null
     }
@@ -22,7 +22,7 @@ internal fun String.toColorOrNull(): Color? = COLOR_REGEX.matchEntire(this)?.let
 
 @AndroidColorInt
 internal inline fun color(red: Int, green: Int, blue: Int, alpha: Double) =
-    RGB(red, green, blue, alpha.toFloat()).toColor()
+    RGB(red, green, blue, alpha.toFloat()).toPlatformColor()
 
-internal expect fun Color.toRGB(): RGB
-internal expect fun RGB.toColor(): Color
+internal expect fun PlatformColor.toRGB(): RGB
+internal expect fun RGB.toPlatformColor(): PlatformColor

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/Styles.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/Styles.kt
@@ -9,19 +9,19 @@ interface Styles : Base {
     }
 
     @get:AndroidColorInt
-    val primaryColor: Color get() = stylesParent.primaryColor
+    val primaryColor: PlatformColor get() = stylesParent.primaryColor
     @get:AndroidColorInt
-    val primaryTextColor: Color get() = stylesParent.primaryTextColor
+    val primaryTextColor: PlatformColor get() = stylesParent.primaryTextColor
 
     // region Button styles
     val buttonStyle: Button.Style get() = stylesParent.buttonStyle
     @get:AndroidColorInt
-    val buttonColor: Color? get() = stylesParent?.buttonColor
+    val buttonColor: PlatformColor? get() = stylesParent?.buttonColor
     // endregion Button styles
 
     // region Text styles
     @get:AndroidColorInt
-    val textColor: Color get() = stylesParent.textColor
+    val textColor: PlatformColor get() = stylesParent.textColor
     val textScale: Double get() = stylesParent.textScale
     val textAlign: Text.Align get() = stylesParent.textAlign
     // endregion Text styles

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/StylesOverride.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/StylesOverride.kt
@@ -4,7 +4,7 @@ import org.cru.godtools.tool.model.Styles.Companion.DEFAULT_TEXT_SCALE
 
 private class StylesOverride(
     parent: Base,
-    private val _textColor: (() -> Color?)?,
+    private val _textColor: (() -> PlatformColor?)?,
     private val _textScale: Double
 ) : BaseModel(parent), Styles {
     override val textColor get() = _textColor?.invoke() ?: super.textColor
@@ -12,6 +12,6 @@ private class StylesOverride(
 }
 
 internal fun Base.stylesOverride(
-    textColor: (() -> Color?)? = null,
+    textColor: (() -> PlatformColor?)? = null,
     textScale: Double = DEFAULT_TEXT_SCALE
 ): Base = StylesOverride(this, textColor, textScale)

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/Text.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/Text.kt
@@ -39,7 +39,7 @@ class Text : Content {
     private val _textAlign: Align?
     val textAlign get() = _textAlign ?: stylesParent.textAlign
     @AndroidColorInt
-    private val _textColor: Color?
+    private val _textColor: PlatformColor?
     @get:AndroidColorInt
     val textColor get() = _textColor ?: stylesParent.textColor
     private val _textScale: Double
@@ -78,7 +78,7 @@ class Text : Content {
         parent: Base,
         text: String? = null,
         textScale: Double = DEFAULT_TEXT_SCALE,
-        @AndroidColorInt textColor: Color? = null,
+        @AndroidColorInt textColor: PlatformColor? = null,
         textAlign: Align? = null,
         textStyles: Set<Style> = emptySet(),
         startImage: String? = null,

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/lesson/LessonPage.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/lesson/LessonPage.kt
@@ -4,7 +4,6 @@ import org.cru.godtools.tool.internal.AndroidColorInt
 import org.cru.godtools.tool.internal.RestrictTo
 import org.cru.godtools.tool.internal.VisibleForTesting
 import org.cru.godtools.tool.model.BaseModel
-import org.cru.godtools.tool.model.Color
 import org.cru.godtools.tool.model.Content
 import org.cru.godtools.tool.model.EventId
 import org.cru.godtools.tool.model.ImageGravity
@@ -13,6 +12,7 @@ import org.cru.godtools.tool.model.ImageScaleType
 import org.cru.godtools.tool.model.ImageScaleType.Companion.toImageScaleTypeOrNull
 import org.cru.godtools.tool.model.Manifest
 import org.cru.godtools.tool.model.Parent
+import org.cru.godtools.tool.model.PlatformColor
 import org.cru.godtools.tool.model.Styles
 import org.cru.godtools.tool.model.Styles.Companion.DEFAULT_TEXT_SCALE
 import org.cru.godtools.tool.model.XML_BACKGROUND_COLOR
@@ -58,7 +58,7 @@ class LessonPage : BaseModel, Parent, Styles {
     val listeners: Set<EventId>
 
     @AndroidColorInt
-    val backgroundColor: Color
+    val backgroundColor: PlatformColor
 
     @VisibleForTesting
     internal val _backgroundImage: String?
@@ -67,7 +67,7 @@ class LessonPage : BaseModel, Parent, Styles {
     val backgroundImageScaleType: ImageScaleType
 
     @AndroidColorInt
-    private val _controlColor: Color?
+    private val _controlColor: PlatformColor?
     @get:AndroidColorInt
     val controlColor get() = _controlColor ?: manifest.lessonControlColor
 
@@ -114,11 +114,11 @@ class LessonPage : BaseModel, Parent, Styles {
     internal constructor(
         manifest: Manifest,
         fileName: String? = null,
-        backgroundColor: Color = DEFAULT_BACKGROUND_COLOR,
+        backgroundColor: PlatformColor = DEFAULT_BACKGROUND_COLOR,
         backgroundImage: String? = null,
         backgroundImageGravity: ImageGravity = DEFAULT_BACKGROUND_IMAGE_GRAVITY,
         backgroundImageScaleType: ImageScaleType = DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE,
-        controlColor: Color? = null,
+        controlColor: PlatformColor? = null,
         textScale: Double = DEFAULT_TEXT_SCALE
     ) : super(manifest) {
         this.fileName = fileName

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/CallToAction.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/CallToAction.kt
@@ -4,8 +4,8 @@ import org.cru.godtools.tool.internal.AndroidColorInt
 import org.cru.godtools.tool.internal.RestrictTo
 import org.cru.godtools.tool.internal.VisibleForTesting
 import org.cru.godtools.tool.model.BaseModel
-import org.cru.godtools.tool.model.Color
 import org.cru.godtools.tool.model.EventId
+import org.cru.godtools.tool.model.PlatformColor
 import org.cru.godtools.tool.model.Text
 import org.cru.godtools.tool.model.XML_EVENTS
 import org.cru.godtools.tool.model.parseTextChild
@@ -30,7 +30,7 @@ class CallToAction : BaseModel {
     val events: List<EventId>
 
     @AndroidColorInt
-    private val _controlColor: Color?
+    private val _controlColor: PlatformColor?
     @get:AndroidColorInt
     val controlColor get() = _controlColor ?: stylesParent.primaryColor
 
@@ -62,7 +62,7 @@ class CallToAction : BaseModel {
         page: TractPage = TractPage(),
         label: ((CallToAction) -> Text)? = null,
         events: List<EventId> = emptyList(),
-        @AndroidColorInt controlColor: Color? = null,
+        @AndroidColorInt controlColor: PlatformColor? = null,
         tip: String? = null
     ) : super(page) {
         this.page = page

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Card.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Card.kt
@@ -6,7 +6,6 @@ import org.cru.godtools.tool.model.AnalyticsEvent
 import org.cru.godtools.tool.model.AnalyticsEvent.Companion.parseAnalyticsEvents
 import org.cru.godtools.tool.model.Base
 import org.cru.godtools.tool.model.BaseModel
-import org.cru.godtools.tool.model.Color
 import org.cru.godtools.tool.model.Content
 import org.cru.godtools.tool.model.EventId
 import org.cru.godtools.tool.model.ImageGravity
@@ -14,6 +13,7 @@ import org.cru.godtools.tool.model.ImageGravity.Companion.toImageGravityOrNull
 import org.cru.godtools.tool.model.ImageScaleType
 import org.cru.godtools.tool.model.ImageScaleType.Companion.toImageScaleTypeOrNull
 import org.cru.godtools.tool.model.Parent
+import org.cru.godtools.tool.model.PlatformColor
 import org.cru.godtools.tool.model.Styles
 import org.cru.godtools.tool.model.Text
 import org.cru.godtools.tool.model.XMLNS_ANALYTICS
@@ -61,7 +61,7 @@ class Card : BaseModel, Styles, Parent {
     val analyticsEvents: Collection<AnalyticsEvent>
 
     @AndroidColorInt
-    private val _backgroundColor: Color?
+    private val _backgroundColor: PlatformColor?
     @get:AndroidColorInt
     internal val backgroundColor get() = _backgroundColor ?: page.cardBackgroundColor
     private val _backgroundImage: String?
@@ -70,7 +70,7 @@ class Card : BaseModel, Styles, Parent {
     val backgroundImageScaleType: ImageScaleType
 
     @AndroidColorInt
-    private val _textColor: Color?
+    private val _textColor: PlatformColor?
     @get:AndroidColorInt
     override val textColor get() = _textColor ?: page.cardTextColor
 
@@ -117,7 +117,7 @@ class Card : BaseModel, Styles, Parent {
     @RestrictTo(RestrictTo.Scope.TESTS)
     internal constructor(
         page: TractPage = TractPage(),
-        backgroundColor: Color? = null,
+        backgroundColor: PlatformColor? = null,
         backgroundImage: String? = null,
         backgroundImageGravity: ImageGravity = DEFAULT_BACKGROUND_IMAGE_GRAVITY,
         backgroundImageScaleType: ImageScaleType = DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE,

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Header.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Header.kt
@@ -4,7 +4,7 @@ import org.cru.godtools.tool.internal.AndroidColorInt
 import org.cru.godtools.tool.internal.RestrictTo
 import org.cru.godtools.tool.internal.VisibleForTesting
 import org.cru.godtools.tool.model.BaseModel
-import org.cru.godtools.tool.model.Color
+import org.cru.godtools.tool.model.PlatformColor
 import org.cru.godtools.tool.model.Styles
 import org.cru.godtools.tool.model.Text
 import org.cru.godtools.tool.model.XML_BACKGROUND_COLOR
@@ -26,7 +26,7 @@ class Header : BaseModel, Styles {
     }
 
     @AndroidColorInt
-    private val _backgroundColor: Color?
+    private val _backgroundColor: PlatformColor?
     @get:AndroidColorInt
     internal val backgroundColor get() = _backgroundColor ?: primaryColor
 
@@ -63,7 +63,7 @@ class Header : BaseModel, Styles {
     @RestrictTo(RestrictTo.Scope.TESTS)
     internal constructor(
         page: TractPage = TractPage(),
-        backgroundColor: Color? = null,
+        backgroundColor: PlatformColor? = null,
         tip: String? = null
     ) : super(page) {
         _backgroundColor = backgroundColor

--- a/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/TractPage.kt
+++ b/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/TractPage.kt
@@ -4,13 +4,13 @@ import org.cru.godtools.tool.internal.AndroidColorInt
 import org.cru.godtools.tool.internal.RestrictTo
 import org.cru.godtools.tool.internal.VisibleForTesting
 import org.cru.godtools.tool.model.BaseModel
-import org.cru.godtools.tool.model.Color
 import org.cru.godtools.tool.model.EventId
 import org.cru.godtools.tool.model.ImageGravity
 import org.cru.godtools.tool.model.ImageGravity.Companion.toImageGravityOrNull
 import org.cru.godtools.tool.model.ImageScaleType
 import org.cru.godtools.tool.model.ImageScaleType.Companion.toImageScaleTypeOrNull
 import org.cru.godtools.tool.model.Manifest
+import org.cru.godtools.tool.model.PlatformColor
 import org.cru.godtools.tool.model.Styles
 import org.cru.godtools.tool.model.Styles.Companion.DEFAULT_TEXT_SCALE
 import org.cru.godtools.tool.model.XML_BACKGROUND_COLOR
@@ -58,7 +58,7 @@ class TractPage : BaseModel, Styles {
     val listeners: Set<EventId>
 
     @AndroidColorInt
-    val backgroundColor: Color
+    val backgroundColor: PlatformColor
     private val _backgroundImage: String?
     val backgroundImage get() = getResource(_backgroundImage)
     val backgroundImageGravity: ImageGravity
@@ -72,29 +72,29 @@ class TractPage : BaseModel, Styles {
     val callToAction: CallToAction
 
     @AndroidColorInt
-    private val _primaryColor: Color?
+    private val _primaryColor: PlatformColor?
     @get:AndroidColorInt
     override val primaryColor get() = _primaryColor ?: stylesParent.primaryColor
 
     @AndroidColorInt
-    private val _primaryTextColor: Color?
+    private val _primaryTextColor: PlatformColor?
     @get:AndroidColorInt
     override val primaryTextColor get() = _primaryTextColor ?: stylesParent.primaryTextColor
 
     @AndroidColorInt
-    private val _textColor: Color?
+    private val _textColor: PlatformColor?
     @get:AndroidColorInt
     override val textColor get() = _textColor ?: stylesParent.textColor
     private val _textScale: Double
     override val textScale get() = _textScale * stylesParent.textScale
 
     @AndroidColorInt
-    private val _cardTextColor: Color?
+    private val _cardTextColor: PlatformColor?
     @get:AndroidColorInt
     val cardTextColor get() = _cardTextColor ?: textColor
 
     @AndroidColorInt
-    private val _cardBackgroundColor: Color?
+    private val _cardBackgroundColor: PlatformColor?
     @get:AndroidColorInt
     val cardBackgroundColor get() = _cardBackgroundColor ?: manifest.cardBackgroundColor
 
@@ -146,15 +146,15 @@ class TractPage : BaseModel, Styles {
     constructor(
         manifest: Manifest = Manifest(),
         fileName: String? = null,
-        backgroundColor: Color = DEFAULT_BACKGROUND_COLOR,
+        backgroundColor: PlatformColor = DEFAULT_BACKGROUND_COLOR,
         backgroundImage: String? = null,
-        @AndroidColorInt primaryColor: Color? = null,
+        @AndroidColorInt primaryColor: PlatformColor? = null,
         backgroundImageGravity: ImageGravity = DEFAULT_BACKGROUND_IMAGE_GRAVITY,
         backgroundImageScaleType: ImageScaleType = DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE,
-        textColor: Color? = null,
+        textColor: PlatformColor? = null,
         textScale: Double = DEFAULT_TEXT_SCALE,
-        cardBackgroundColor: Color? = null,
-        cardTextColor: Color? = null,
+        cardBackgroundColor: PlatformColor? = null,
+        cardTextColor: PlatformColor? = null,
         cards: ((TractPage) -> List<Card>?)? = null,
         callToAction: ((TractPage) -> CallToAction?)? = null
     ) : super(manifest) {

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/ColorTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/ColorTest.kt
@@ -30,4 +30,13 @@ class ColorTest {
         assertNull("rgba(0,0,0,-0.1)".toColorOrNull())
         assertNull("rgba(0,0,0,1.1)".toColorOrNull())
     }
+
+    @Test
+    fun testToRGB() {
+        assertEquals(TestColors.RED, TestColors.RED.toRGB().toColor())
+        assertEquals(TestColors.GREEN, TestColors.GREEN.toRGB().toColor())
+        assertEquals(TestColors.BLUE, TestColors.BLUE.toRGB().toColor())
+        assertEquals(TestColors.BLACK, TestColors.BLACK.toRGB().toColor())
+        assertEquals(TRANSPARENT, TRANSPARENT.toRGB().toColor())
+    }
 }

--- a/src/commonTest/kotlin/org/cru/godtools/tool/model/ColorTest.kt
+++ b/src/commonTest/kotlin/org/cru/godtools/tool/model/ColorTest.kt
@@ -33,10 +33,10 @@ class ColorTest {
 
     @Test
     fun testToRGB() {
-        assertEquals(TestColors.RED, TestColors.RED.toRGB().toColor())
-        assertEquals(TestColors.GREEN, TestColors.GREEN.toRGB().toColor())
-        assertEquals(TestColors.BLUE, TestColors.BLUE.toRGB().toColor())
-        assertEquals(TestColors.BLACK, TestColors.BLACK.toRGB().toColor())
-        assertEquals(TRANSPARENT, TRANSPARENT.toRGB().toColor())
+        assertEquals(TestColors.RED, TestColors.RED.toRGB().toPlatformColor())
+        assertEquals(TestColors.GREEN, TestColors.GREEN.toRGB().toPlatformColor())
+        assertEquals(TestColors.BLUE, TestColors.BLUE.toRGB().toPlatformColor())
+        assertEquals(TestColors.BLACK, TestColors.BLACK.toRGB().toPlatformColor())
+        assertEquals(TRANSPARENT, TRANSPARENT.toRGB().toPlatformColor())
     }
 }

--- a/src/iosMain/kotlin/org/cru/godtools/tool/model/IosColor.kt
+++ b/src/iosMain/kotlin/org/cru/godtools/tool/model/IosColor.kt
@@ -1,5 +1,11 @@
 package org.cru.godtools.tool.model
 
+import com.github.ajalt.colormath.RGB
+import kotlinx.cinterop.DoubleVar
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.value
 import platform.UIKit.UIColor
 
 @Suppress("CONFLICTING_OVERLOADS")
@@ -11,3 +17,12 @@ internal actual inline fun color(red: Int, green: Int, blue: Int, alpha: Double)
     blue = blue.toDouble() / 255.0,
     alpha = alpha
 )
+
+internal actual fun Color.toRGB(): RGB = memScoped {
+    val red = alloc<DoubleVar>()
+    val green = alloc<DoubleVar>()
+    val blue = alloc<DoubleVar>()
+    val alpha = alloc<DoubleVar>()
+    getRed(red.ptr, green.ptr, blue.ptr, alpha.ptr)
+    return RGB(red.value, green.value, blue.value, alpha.value)
+}

--- a/src/iosMain/kotlin/org/cru/godtools/tool/model/IosColor.kt
+++ b/src/iosMain/kotlin/org/cru/godtools/tool/model/IosColor.kt
@@ -9,15 +9,15 @@ import kotlinx.cinterop.value
 import platform.UIKit.UIColor
 
 @Suppress("CONFLICTING_OVERLOADS")
-actual typealias Color = UIColor
+actual typealias PlatformColor = UIColor
 
-internal actual fun RGB.toColor() = UIColor(
+internal actual fun RGB.toPlatformColor() = UIColor(
     red = r.toDouble() / 255.0,
     green = g.toDouble() / 255.0,
     blue = b.toDouble() / 255.0,
     alpha = a.toDouble()
 )
-internal actual fun Color.toRGB(): RGB = memScoped {
+internal actual fun PlatformColor.toRGB(): RGB = memScoped {
     val red = alloc<DoubleVar>()
     val green = alloc<DoubleVar>()
     val blue = alloc<DoubleVar>()

--- a/src/iosMain/kotlin/org/cru/godtools/tool/model/IosColor.kt
+++ b/src/iosMain/kotlin/org/cru/godtools/tool/model/IosColor.kt
@@ -11,13 +11,12 @@ import platform.UIKit.UIColor
 @Suppress("CONFLICTING_OVERLOADS")
 actual typealias Color = UIColor
 
-internal actual inline fun color(red: Int, green: Int, blue: Int, alpha: Double) = UIColor(
-    red = red.toDouble() / 255.0,
-    green = green.toDouble() / 255.0,
-    blue = blue.toDouble() / 255.0,
-    alpha = alpha
+internal actual fun RGB.toColor() = UIColor(
+    red = r.toDouble() / 255.0,
+    green = g.toDouble() / 255.0,
+    blue = b.toDouble() / 255.0,
+    alpha = a.toDouble()
 )
-
 internal actual fun Color.toRGB(): RGB = memScoped {
     val red = alloc<DoubleVar>()
     val green = alloc<DoubleVar>()

--- a/src/jsMain/kotlin/org/cru/godtools/tool/model/JsColor.kt
+++ b/src/jsMain/kotlin/org/cru/godtools/tool/model/JsColor.kt
@@ -8,4 +8,4 @@ actual typealias Color = String
 internal actual inline fun color(red: Int, green: Int, blue: Int, alpha: Double) =
     "rgba($red,$green,$blue,$alpha)"
 
-internal actual fun Color.toRGB(): RGB  = com.github.ajalt.colormath.Color.fromCss(this).toRGB()
+internal actual fun Color.toRGB(): RGB = com.github.ajalt.colormath.Color.fromCss(this).toRGB()

--- a/src/jsMain/kotlin/org/cru/godtools/tool/model/JsColor.kt
+++ b/src/jsMain/kotlin/org/cru/godtools/tool/model/JsColor.kt
@@ -1,6 +1,11 @@
 package org.cru.godtools.tool.model
 
+import com.github.ajalt.colormath.RGB
+import com.github.ajalt.colormath.fromCss
+
 actual typealias Color = String
 
 internal actual inline fun color(red: Int, green: Int, blue: Int, alpha: Double) =
     "rgba($red,$green,$blue,$alpha)"
+
+internal actual fun Color.toRGB(): RGB  = com.github.ajalt.colormath.Color.fromCss(this).toRGB()

--- a/src/jsMain/kotlin/org/cru/godtools/tool/model/JsColor.kt
+++ b/src/jsMain/kotlin/org/cru/godtools/tool/model/JsColor.kt
@@ -1,11 +1,11 @@
 package org.cru.godtools.tool.model
 
 import com.github.ajalt.colormath.RGB
+import com.github.ajalt.colormath.RenderCondition
 import com.github.ajalt.colormath.fromCss
+import com.github.ajalt.colormath.toCssRgb
 
 actual typealias Color = String
 
-internal actual inline fun color(red: Int, green: Int, blue: Int, alpha: Double) =
-    "rgba($red,$green,$blue,$alpha)"
-
+internal actual fun RGB.toColor() = toCssRgb(namedRgba = true, renderAlpha = RenderCondition.ALWAYS)
 internal actual fun Color.toRGB(): RGB = com.github.ajalt.colormath.Color.fromCss(this).toRGB()

--- a/src/jsMain/kotlin/org/cru/godtools/tool/model/JsColor.kt
+++ b/src/jsMain/kotlin/org/cru/godtools/tool/model/JsColor.kt
@@ -1,11 +1,12 @@
 package org.cru.godtools.tool.model
 
+import com.github.ajalt.colormath.Color
 import com.github.ajalt.colormath.RGB
 import com.github.ajalt.colormath.RenderCondition
 import com.github.ajalt.colormath.fromCss
 import com.github.ajalt.colormath.toCssRgb
 
-actual typealias Color = String
+actual typealias PlatformColor = String
 
-internal actual fun RGB.toColor() = toCssRgb(namedRgba = true, renderAlpha = RenderCondition.ALWAYS)
-internal actual fun Color.toRGB(): RGB = com.github.ajalt.colormath.Color.fromCss(this).toRGB()
+internal actual fun RGB.toPlatformColor() = toCssRgb(namedRgba = true, renderAlpha = RenderCondition.ALWAYS)
+internal actual fun PlatformColor.toRGB() = Color.fromCss(this).toRGB()


### PR DESCRIPTION
Adding support for this library will allow us to more easily define dynamic default colors for tools.

The first use of this will be the default background selected color for multiselect options which will be a lighter version of the current primary color