### PR TITLE
Extract some common build logic out

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.Framework
 plugins {
     kotlin("multiplatform") version "1.5.20"
     kotlin("native.cocoapods") version "1.5.20"
+    `maven-publish`
     id("com.android.library") apply false
     id("org.jetbrains.kotlin.plugin.parcelize") version "1.5.20" apply false
     id("org.ajoberstar.grgit") version "4.1.0"
@@ -146,3 +147,25 @@ ktlint {
     version.set(libs.versions.ktlint)
 }
 // endregion KtLint
+
+// region Publishing
+subprojects {
+    apply(plugin = "maven-publish")
+    publishing {
+        repositories {
+            maven {
+                name = "cruGlobalMavenRepository"
+                setUrl(
+                    when {
+                        isSnapshotVersion ->
+                            "https://cruglobal.jfrog.io/cruglobal/list/maven-cru-android-public-snapshots-local/"
+                        else -> "https://cruglobal.jfrog.io/cruglobal/list/maven-cru-android-public-releases-local/"
+                    }
+                )
+
+                credentials(PasswordCredentials::class)
+            }
+        }
+    }
+}
+// endregion Publishing

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,11 +2,9 @@ import org.ajoberstar.grgit.Grgit
 import org.jetbrains.kotlin.gradle.plugin.mpp.Framework
 
 plugins {
-    kotlin("multiplatform") version "1.5.20"
-    kotlin("native.cocoapods") version "1.5.20"
+    kotlin("multiplatform")
+    kotlin("native.cocoapods")
     `maven-publish`
-    id("com.android.library") apply false
-    id("org.jetbrains.kotlin.plugin.parcelize") version "1.5.20" apply false
     id("org.ajoberstar.grgit") version "4.1.0"
     id("org.jlleitschuh.gradle.ktlint") version "10.1.0"
     id("com.vanniktech.android.junit.jacoco") version "0.16.0"
@@ -28,14 +26,7 @@ allprojects {
 }
 
 kotlin {
-    // HACK: workaround https://youtrack.jetbrains.com/issue/KT-40975
-    //       See also: https://kotlinlang.org/docs/mobile/add-dependencies.html#workaround-to-enable-ide-support-for-the-shared-ios-source-set
-    //       This should be able to go away when we upgrade to Kotlin 1.5.30
-//    ios()
-    when {
-        System.getenv("SDK_NAME")?.startsWith("iphoneos") == true -> iosArm64("ios")
-        else -> iosX64("ios")
-    }.apply {
+    configureIosTargets {
         binaries {
             withType(Framework::class.java).configureEach {
                 export(project(":godtools-tool-parser"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,8 +12,6 @@ plugins {
     id("com.vanniktech.android.junit.jacoco") version "0.16.0"
 }
 
-val isSnapshotVersion get() = version.toString().endsWith("-SNAPSHOT")
-
 allprojects {
     group = "org.cru.godtools.kotlin"
     version = "0.2.0-SNAPSHOT"

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,6 @@
+plugins {
+    `kotlin-dsl`
+}
+repositories {
+    mavenCentral()
+}

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,6 +1,14 @@
 plugins {
     `kotlin-dsl`
 }
+
 repositories {
+    google()
     mavenCentral()
+}
+
+dependencies {
+    compileOnly(gradleKotlinDsl())
+    implementation("com.android.tools.build:gradle:4.2.2")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21")
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -10,5 +10,5 @@ repositories {
 dependencies {
     compileOnly(gradleKotlinDsl())
     implementation("com.android.tools.build:gradle:4.2.2")
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21")
+    implementation(libs.kotlin.plugin)
 }

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,8 @@
+enableFeaturePreview("VERSION_CATALOGS")
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/AndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfig.kt
@@ -1,0 +1,22 @@
+import com.android.build.gradle.BaseExtension
+
+fun BaseExtension.configureSdk() {
+    compileSdkVersion(30)
+    defaultConfig {
+        minSdkVersion(21)
+        targetSdkVersion(30)
+    }
+}
+
+fun BaseExtension.configureSourceSets() {
+    sourceSets {
+        getByName("main") {
+            setRoot("src/androidMain")
+        }
+        getByName("test") {
+            setRoot("src/androidTest")
+            resources.srcDir("src/commonTest/resources")
+        }
+        getByName("androidTest") { setRoot("src/androidAndroidTest") }
+    }
+}

--- a/buildSrc/src/main/kotlin/TargetsConfig.kt
+++ b/buildSrc/src/main/kotlin/TargetsConfig.kt
@@ -1,0 +1,33 @@
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import org.jetbrains.kotlin.gradle.plugin.mpp.TestExecutable
+
+fun KotlinMultiplatformExtension.configureIosTargets(configure: KotlinNativeTarget.() -> Unit = {}) {
+    // HACK: workaround https://youtrack.jetbrains.com/issue/KT-40975
+    //       See also: https://kotlinlang.org/docs/mobile/add-dependencies.html#workaround-to-enable-ide-support-for-the-shared-ios-source-set
+    //       This should be able to go away when we upgrade to Kotlin 1.5.30
+//    ios { copyTestResources() }
+    val target = when {
+        System.getenv("SDK_NAME")?.startsWith("iphoneos") == true -> iosArm64("ios")
+        else -> iosX64("ios")
+    }
+    target.copyTestResources()
+    target.configure()
+}
+
+// region iOS Test Resources
+// HACK: workaround https://youtrack.jetbrains.com/issue/KT-37818
+//       based on logic found here: https://github.com/icerockdev/moko-resources/pull/107/files
+private fun KotlinNativeTarget.copyTestResources() {
+    binaries
+        .matching { it is TestExecutable }
+        .configureEach {
+            (this as TestExecutable).linkTask.doLast {
+                project.file("src/commonTest/resources").copyRecursively(
+                    target = outputDirectory,
+                    overwrite = true
+                )
+            }
+        }
+}
+// endregion iOS Test Resources

--- a/buildSrc/src/main/kotlin/TargetsConfig.kt
+++ b/buildSrc/src/main/kotlin/TargetsConfig.kt
@@ -2,6 +2,7 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTargetWithTests
 import org.jetbrains.kotlin.gradle.plugin.mpp.TestExecutable
+import org.jetbrains.kotlin.gradle.targets.js.dsl.KotlinJsSubTargetDsl
 
 fun KotlinMultiplatformExtension.configureIosTargets(configure: KotlinNativeTarget.() -> Unit = {}) {
     // HACK: workaround https://youtrack.jetbrains.com/issue/KT-40975
@@ -30,6 +31,12 @@ fun KotlinMultiplatformExtension.configureIosTargets(configure: KotlinNativeTarg
     }
 }
 
+fun KotlinMultiplatformExtension.configureJsTargets() {
+    js {
+        nodejs { copyTestResources() }
+    }
+}
+
 // region iOS Test Resources
 // HACK: workaround https://youtrack.jetbrains.com/issue/KT-37818
 //       based on logic found here: https://github.com/icerockdev/moko-resources/pull/107/files
@@ -46,3 +53,18 @@ private fun KotlinNativeTarget.copyTestResources() {
         }
 }
 // endregion iOS Test Resources
+
+// region Js Test Resources
+private fun KotlinJsSubTargetDsl.copyTestResources() {
+    testTask {
+        val compileTask = compilation.compileKotlinTaskProvider.get()
+        compileTask.doLast {
+            // TODO: copy resources out of processedResources instead.
+            project.file("src/commonTest/resources").copyRecursively(
+                target = compileTask.outputFileProperty.get().resolve("../../resources").normalize(),
+                overwrite = true
+            )
+        }
+    }
+}
+// endregion Js Test Resources

--- a/buildSrc/src/main/kotlin/TargetsConfig.kt
+++ b/buildSrc/src/main/kotlin/TargetsConfig.kt
@@ -1,5 +1,6 @@
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTargetWithTests
 import org.jetbrains.kotlin.gradle.plugin.mpp.TestExecutable
 
 fun KotlinMultiplatformExtension.configureIosTargets(configure: KotlinNativeTarget.() -> Unit = {}) {
@@ -13,6 +14,20 @@ fun KotlinMultiplatformExtension.configureIosTargets(configure: KotlinNativeTarg
     }
     target.copyTestResources()
     target.configure()
+
+    // enable running ios tests on a background thread as well
+    // configuration copied from: https://github.com/square/okio/pull/929
+    targets.withType(KotlinNativeTargetWithTests::class.java) {
+        binaries {
+            // Configure a separate test where code runs in background
+            test("background", setOf(DEBUG)) {
+                freeCompilerArgs += "-trw"
+            }
+        }
+        testRuns.create("background") {
+            setExecutionSourceFrom(binaries.getByName("backgroundDebugTest") as TestExecutable)
+        }
+    }
 }
 
 // region iOS Test Resources

--- a/buildSrc/src/main/kotlin/TargetsConfig.kt
+++ b/buildSrc/src/main/kotlin/TargetsConfig.kt
@@ -4,6 +4,18 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTargetWithTests
 import org.jetbrains.kotlin.gradle.plugin.mpp.TestExecutable
 import org.jetbrains.kotlin.gradle.targets.js.dsl.KotlinJsSubTargetDsl
 
+fun KotlinMultiplatformExtension.configureTargets() {
+    configureAndroidTargets()
+    configureIosTargets()
+    configureJsTargets()
+}
+
+fun KotlinMultiplatformExtension.configureAndroidTargets() {
+    android {
+        publishLibraryVariants("debug", "release")
+    }
+}
+
 fun KotlinMultiplatformExtension.configureIosTargets(configure: KotlinNativeTarget.() -> Unit = {}) {
     // HACK: workaround https://youtrack.jetbrains.com/issue/KT-40975
     //       See also: https://kotlinlang.org/docs/mobile/add-dependencies.html#workaround-to-enable-ide-support-for-the-shared-ios-source-set

--- a/buildSrc/src/main/kotlin/VersionUtils.kt
+++ b/buildSrc/src/main/kotlin/VersionUtils.kt
@@ -1,0 +1,3 @@
+import org.gradle.api.Project
+
+val Project.isSnapshotVersion get() = version.toString().endsWith("-SNAPSHOT")

--- a/godtools-tool-parser/build.gradle.kts
+++ b/godtools-tool-parser/build.gradle.kts
@@ -5,11 +5,7 @@ plugins {
 }
 
 kotlin {
-    android {
-        publishLibraryVariants("debug", "release")
-    }
-    configureIosTargets()
-    configureJsTargets()
+    configureTargets()
 
     sourceSets {
         val commonMain by getting {

--- a/godtools-tool-parser/build.gradle.kts
+++ b/godtools-tool-parser/build.gradle.kts
@@ -9,8 +9,6 @@ plugins {
     id("org.jetbrains.kotlin.plugin.parcelize")
 }
 
-val isSnapshotVersion get() = version.toString().endsWith("-SNAPSHOT")
-
 kotlin {
     android {
         publishLibraryVariants("debug", "release")

--- a/godtools-tool-parser/build.gradle.kts
+++ b/godtools-tool-parser/build.gradle.kts
@@ -6,7 +6,6 @@ import org.jetbrains.kotlin.gradle.targets.js.dsl.KotlinJsSubTargetDsl
 plugins {
     kotlin("multiplatform")
     id("com.android.library")
-    id("maven-publish")
     id("org.jetbrains.kotlin.plugin.parcelize")
 }
 
@@ -81,23 +80,6 @@ kotlin {
             dependencies {
                 implementation(libs.okio.js)
                 implementation(libs.okio.nodefilesystem)
-            }
-        }
-    }
-
-    publishing {
-        repositories {
-            maven {
-                name = "cruGlobalMavenRepository"
-                setUrl(
-                    when {
-                        isSnapshotVersion ->
-                            "https://cruglobal.jfrog.io/cruglobal/list/maven-cru-android-public-snapshots-local/"
-                        else -> "https://cruglobal.jfrog.io/cruglobal/list/maven-cru-android-public-releases-local/"
-                    }
-                )
-
-                credentials(PasswordCredentials::class)
             }
         }
     }

--- a/godtools-tool-parser/build.gradle.kts
+++ b/godtools-tool-parser/build.gradle.kts
@@ -1,4 +1,3 @@
-import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTargetWithTests
 import org.jetbrains.kotlin.gradle.plugin.mpp.TestExecutable
 import org.jetbrains.kotlin.gradle.targets.js.dsl.KotlinJsSubTargetDsl
@@ -13,14 +12,7 @@ kotlin {
     android {
         publishLibraryVariants("debug", "release")
     }
-    // HACK: workaround https://youtrack.jetbrains.com/issue/KT-40975
-    //       See also: https://kotlinlang.org/docs/mobile/add-dependencies.html#workaround-to-enable-ide-support-for-the-shared-ios-source-set
-    //       This should be able to go away when we upgrade to Kotlin 1.5.30
-//    ios { copyTestResources() }
-    when {
-        System.getenv("SDK_NAME")?.startsWith("iphoneos") == true -> iosArm64("ios")
-        else -> iosX64("ios")
-    }.copyTestResources()
+    configureIosTargets()
     js {
         nodejs { copyTestResources() }
     }
@@ -99,23 +91,6 @@ android {
         val androidTest by getting { setRoot("src/androidAndroidTest") }
     }
 }
-
-// region iOS Test Resources
-// HACK: workaround https://youtrack.jetbrains.com/issue/KT-37818
-//       based on logic found here: https://github.com/icerockdev/moko-resources/pull/107/files
-fun KotlinNativeTarget.copyTestResources() {
-    binaries
-        .matching { it is TestExecutable }
-        .configureEach {
-            (this as TestExecutable).linkTask.doLast {
-                project.file("src/commonTest/resources").copyRecursively(
-                    target = outputDirectory,
-                    overwrite = true
-                )
-            }
-        }
-}
-// endregion iOS Test Resources
 
 // region Js Test Resources
 fun KotlinJsSubTargetDsl.copyTestResources() {

--- a/godtools-tool-parser/build.gradle.kts
+++ b/godtools-tool-parser/build.gradle.kts
@@ -1,7 +1,3 @@
-import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTargetWithTests
-import org.jetbrains.kotlin.gradle.plugin.mpp.TestExecutable
-import org.jetbrains.kotlin.gradle.targets.js.dsl.KotlinJsSubTargetDsl
-
 plugins {
     kotlin("multiplatform")
     id("com.android.library")
@@ -13,9 +9,7 @@ kotlin {
         publishLibraryVariants("debug", "release")
     }
     configureIosTargets()
-    js {
-        nodejs { copyTestResources() }
-    }
+    configureJsTargets()
 
     sourceSets {
         val commonMain by getting {
@@ -75,18 +69,3 @@ android {
         val androidTest by getting { setRoot("src/androidAndroidTest") }
     }
 }
-
-// region Js Test Resources
-fun KotlinJsSubTargetDsl.copyTestResources() {
-    testTask {
-        val compileTask = compilation.compileKotlinTaskProvider.get()
-        compileTask.doLast {
-            // TODO: copy resources out of processedResources instead.
-            project.file("src/commonTest/resources").copyRecursively(
-                target = compileTask.outputFileProperty.get().resolve("../../resources").normalize(),
-                overwrite = true
-            )
-        }
-    }
-}
-// endregion Js Test Resources

--- a/godtools-tool-parser/build.gradle.kts
+++ b/godtools-tool-parser/build.gradle.kts
@@ -4,6 +4,11 @@ plugins {
     id("org.jetbrains.kotlin.plugin.parcelize")
 }
 
+android {
+    configureSdk()
+    configureSourceSets()
+}
+
 kotlin {
     configureTargets()
 
@@ -46,22 +51,5 @@ kotlin {
                 implementation(libs.okio.nodefilesystem)
             }
         }
-    }
-}
-
-android {
-    compileSdkVersion(30)
-    defaultConfig {
-        minSdkVersion(21)
-        targetSdkVersion(30)
-    }
-
-    sourceSets {
-        val main by getting { setRoot("src/androidMain") }
-        val test by getting {
-            setRoot("src/androidTest")
-            resources.srcDir("src/commonTest/resources")
-        }
-        val androidTest by getting { setRoot("src/androidAndroidTest") }
     }
 }

--- a/godtools-tool-parser/build.gradle.kts
+++ b/godtools-tool-parser/build.gradle.kts
@@ -17,22 +17,6 @@ kotlin {
         nodejs { copyTestResources() }
     }
 
-    // enable running ios tests on a background thread as well
-    // configuration copied from: https://github.com/square/okio/pull/929
-    targets.withType<KotlinNativeTargetWithTests<*>> {
-        binaries {
-            // Configure a separate test where code runs in background
-            test("background", setOf(DEBUG)) {
-                freeCompilerArgs += "-trw"
-            }
-        }
-        testRuns {
-            val background by creating {
-                setExecutionSourceFrom(binaries.getByName("backgroundDebugTest") as TestExecutable)
-            }
-        }
-    }
-
     sourceSets {
         val commonMain by getting {
             dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ androidx-annotation = "1.2.0"
 colormath = "2.1.0"
 fluidLocale = "0.9.6"
 jacoco = "0.8.7"
+kotlin = "1.5.21"
 ktlint = "0.41.0"
 napier = "1.5.0"
 okio = "3.0.0-alpha.5"
@@ -12,6 +13,7 @@ splitties = "3.0.0-beta01"
 androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "androidx-annotation" }
 colormath = { module = "com.github.ajalt.colormath:colormath", version.ref = "colormath" }
 fluidLocale = { module = "io.fluidsonic.locale:fluid-locale", version.ref = "fluidLocale" }
+kotlin-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 napier = { module = "io.github.aakira:napier", version.ref = "napier" }
 okio-js = { module = "com.squareup.okio:okio-js", version.ref = "okio" }
 okio-nodefilesystem = { module = "com.squareup.okio:okio-nodefilesystem-js", version.ref = "okio" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,17 +1,3 @@
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        google()
-        mavenCentral()
-    }
-    resolutionStrategy {
-        eachPlugin {
-            if (requested.id.namespace == "com.android") {
-                useModule("com.android.tools.build:gradle:4.2.2")
-            }
-        }
-    }
-}
 rootProject.name = "GodtoolsToolParser"
 enableFeaturePreview("VERSION_CATALOGS")
 


### PR DESCRIPTION
- centralize publishing logic
- centralize the isSnapshotVersion logic into buildSrc
- configure the ios targets via a buildSrc script
- configure the ios background tests in buildSrc
- move js target configuration to buildSrc
- move android target configuration to buildSrc
- enable version catalogs for buildSrc
- extract android config to buildSrc
