### PR TITLE
make changeFlow more robust

### DIFF
--- a/godtools-tool-parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Multiselect.kt
+++ b/godtools-tool-parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Multiselect.kt
@@ -1,7 +1,5 @@
 package org.cru.godtools.tool.model
 
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.map
 import org.cru.godtools.tool.FEATURE_MULTISELECT
 import org.cru.godtools.tool.ParserConfig
 import org.cru.godtools.tool.internal.RestrictTo
@@ -118,9 +116,7 @@ class Multiselect : Content {
         }
 
         fun isSelected(state: State) = value in state.getAll(multiselect.stateName)
-        fun isSelectedFlow(state: State) = state.changeFlow(multiselect.stateName)
-            .map { isSelected(state) }
-            .distinctUntilChanged()
+        fun isSelectedFlow(state: State) = state.changeFlow(multiselect.stateName) { isSelected(it) }
         fun toggleSelected(state: State): Boolean {
             val current = state.getAll(multiselect.stateName)
             when {

--- a/module/state/src/commonMain/kotlin/org/cru/godtools/tool/state/State.kt
+++ b/module/state/src/commonMain/kotlin/org/cru/godtools/tool/state/State.kt
@@ -3,6 +3,7 @@ package org.cru.godtools.tool.state
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import org.cru.godtools.tool.internal.Parcelable
 import org.cru.godtools.tool.internal.Parcelize
@@ -12,7 +13,7 @@ class State internal constructor(private val state: MutableMap<String, List<Stri
     constructor() : this(mutableMapOf<String, List<String>?>())
 
     private val changeFlow = MutableSharedFlow<String>(extraBufferCapacity = Int.MAX_VALUE)
-    fun changeFlow(key: String) = changeFlow.filter { it == key }.onStart { emit(key) }.conflate()
+    fun changeFlow(vararg key: String) = changeFlow.filter { it in key }.map {}.onStart { emit(Unit) }.conflate()
 
     operator fun get(key: String) = state[key]?.firstOrNull()
     fun getAll(key: String) = state[key].orEmpty()

--- a/module/state/src/commonMain/kotlin/org/cru/godtools/tool/state/State.kt
+++ b/module/state/src/commonMain/kotlin/org/cru/godtools/tool/state/State.kt
@@ -2,7 +2,9 @@ package org.cru.godtools.tool.state
 
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.conflate
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import org.cru.godtools.tool.internal.Parcelable
@@ -13,7 +15,11 @@ class State internal constructor(private val state: MutableMap<String, List<Stri
     constructor() : this(mutableMapOf<String, List<String>?>())
 
     private val changeFlow = MutableSharedFlow<String>(extraBufferCapacity = Int.MAX_VALUE)
-    fun changeFlow(vararg key: String) = changeFlow.filter { it in key }.map {}.onStart { emit(Unit) }.conflate()
+    fun <T> changeFlow(vararg key: String, block: (State) -> T) = changeFlow(listOf(*key), block)
+    fun <T> changeFlow(keys: Collection<String>?, block: (State) -> T) = when {
+        keys.isNullOrEmpty() -> flowOf(Unit)
+        else -> changeFlow.filter { it in keys }.map {}.onStart { emit(Unit) }.conflate()
+    }.map { block(this) }.distinctUntilChanged()
 
     operator fun get(key: String) = state[key]?.firstOrNull()
     fun getAll(key: String) = state[key].orEmpty()

--- a/module/state/src/commonTest/kotlin/org/cru/godtools/tool/state/StateTest.kt
+++ b/module/state/src/commonTest/kotlin/org/cru/godtools/tool/state/StateTest.kt
@@ -36,17 +36,17 @@ class StateTest {
 
     @Test
     fun testChangeFlow() = runBlockingTest {
-        val channel = Channel<String>()
+        val channel = Channel<Unit>()
         val flow = state.changeFlow(KEY)
             .onEach { channel.send(it) }
             .launchIn(this)
 
         // initial value
-        assertEquals(KEY, channel.receive(500))
+        assertEquals(Unit, channel.receive(500))
 
         // update state for monitored key
         state[KEY] = "a"
-        assertEquals(KEY, channel.receive(500))
+        assertEquals(Unit, channel.receive(500))
 
         // update state for a different key
         state["other$KEY"] = "a"

--- a/module/state/src/commonTest/kotlin/org/cru/godtools/tool/state/StateTest.kt
+++ b/module/state/src/commonTest/kotlin/org/cru/godtools/tool/state/StateTest.kt
@@ -37,21 +37,22 @@ class StateTest {
 
     @Test
     fun testChangeFlow() = runBlockingTest {
-        val channel = Channel<Unit>()
-        val flow = state.changeFlow(KEY, KEY2)
+        var i = 0
+        val channel = Channel<Int>()
+        val flow = state.changeFlow(KEY, KEY2) { i++ }
             .onEach { channel.send(it) }
             .launchIn(this)
 
         // initial value
-        assertEquals(Unit, channel.receive(500))
+        assertEquals(0, channel.receive(500))
 
         // update state for monitored key
         state[KEY] = "a"
-        assertEquals(Unit, channel.receive(500))
+        assertEquals(1, channel.receive(500))
 
         // update state for other monitored key
         state[KEY2] = "a"
-        assertEquals(Unit, channel.receive(500))
+        assertEquals(2, channel.receive(500))
 
         // update state for a different key
         state["other$KEY"] = "a"
@@ -60,17 +61,19 @@ class StateTest {
 
         // shut down flow
         flow.cancel()
+        assertEquals(3, i)
     }
 
     @Test
     fun testChangeFlowNoKeys() = runBlockingTest {
-        val channel = Channel<Unit>()
-        val flow = state.changeFlow()
+        var i = 0
+        val channel = Channel<Int>()
+        val flow = state.changeFlow { i++ }
             .onEach { channel.send(it) }
             .launchIn(this)
 
         // initial value
-        assertEquals(Unit, channel.receive(500))
+        assertEquals(0, channel.receive(500))
 
         // update state for multiple keys, should never emit a new value
         for (i in 1..10) {
@@ -81,6 +84,7 @@ class StateTest {
 
         // shut down flow
         flow.cancel()
+        assertEquals(1, i)
     }
 
     @Test


### PR DESCRIPTION
- update State.changeFlow to support monitoring multiple keys
- test monitoring multiple keys and monitoring no keys for State.changeFlow
- make `changeFlow` accept a closure to run everytime the monitored keys change
