### PR TITLE
add a HasAnalyticsEvents interface

### DIFF
--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/AnalyticsEvent.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/AnalyticsEvent.kt
@@ -80,6 +80,7 @@ class AnalyticsEvent : BaseModel {
     @RestrictTo(RestrictTo.Scope.TESTS)
     constructor(
         action: String? = null,
+        trigger: Trigger = Trigger.DEFAULT,
         delay: Int = 0,
         systems: Set<System> = emptySet(),
         attributes: Map<String, String> = emptyMap()
@@ -87,7 +88,7 @@ class AnalyticsEvent : BaseModel {
         this.action = action
         this.delay = delay
         this.systems = systems
-        trigger = Trigger.DEFAULT
+        this.trigger = trigger
         this.attributes = attributes
     }
 

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/HasAnalyticsEvents.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/HasAnalyticsEvents.kt
@@ -1,0 +1,5 @@
+package org.cru.godtools.tool.model
+
+interface HasAnalyticsEvents {
+    fun getAnalyticsEvents(type: AnalyticsEvent.Trigger): List<AnalyticsEvent>
+}

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Tabs.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Tabs.kt
@@ -1,6 +1,8 @@
 package org.cru.godtools.tool.model
 
+import org.cru.godtools.tool.internal.RestrictTo
 import org.cru.godtools.tool.model.AnalyticsEvent.Companion.parseAnalyticsEvents
+import org.cru.godtools.tool.model.AnalyticsEvent.Trigger
 import org.cru.godtools.tool.xml.XmlPullParser
 import org.cru.godtools.tool.xml.parseChildren
 
@@ -30,7 +32,12 @@ class Tabs : Content {
         }
     }
 
-    class Tab : BaseModel, Parent {
+    @RestrictTo(RestrictTo.Scope.TESTS)
+    internal constructor(parent: Base = Manifest()) : super(parent) {
+        tabs = emptyList()
+    }
+
+    class Tab : BaseModel, Parent, HasAnalyticsEvents {
         private val tabs: Tabs
         val position get() = tabs.tabs.indexOf(this)
 
@@ -59,6 +66,23 @@ class Tabs : Content {
                 }
             }
             this.label = label
+        }
+
+        @RestrictTo(RestrictTo.Scope.TESTS)
+        internal constructor(
+            parent: Tabs = Tabs(),
+            analyticsEvents: List<AnalyticsEvent> = emptyList()
+        ) : super(parent) {
+            tabs = parent
+            this.analyticsEvents = analyticsEvents
+            listeners = emptySet()
+            label = null
+            content = emptyList()
+        }
+
+        override fun getAnalyticsEvents(type: Trigger) = when (type) {
+            Trigger.SELECTED -> analyticsEvents.filter { it.isTriggerType(Trigger.SELECTED, Trigger.DEFAULT) }
+            else -> error("The $type trigger type is currently unsupported on Tabs")
         }
     }
 }

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Card.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Card.kt
@@ -4,10 +4,12 @@ import org.cru.godtools.tool.internal.AndroidColorInt
 import org.cru.godtools.tool.internal.RestrictTo
 import org.cru.godtools.tool.model.AnalyticsEvent
 import org.cru.godtools.tool.model.AnalyticsEvent.Companion.parseAnalyticsEvents
+import org.cru.godtools.tool.model.AnalyticsEvent.Trigger
 import org.cru.godtools.tool.model.Base
 import org.cru.godtools.tool.model.BaseModel
 import org.cru.godtools.tool.model.Content
 import org.cru.godtools.tool.model.EventId
+import org.cru.godtools.tool.model.HasAnalyticsEvents
 import org.cru.godtools.tool.model.ImageGravity
 import org.cru.godtools.tool.model.ImageGravity.Companion.toImageGravityOrNull
 import org.cru.godtools.tool.model.ImageScaleType
@@ -40,7 +42,7 @@ import org.cru.godtools.tool.xml.XmlPullParser
 private const val XML_LABEL = "label"
 private const val XML_HIDDEN = "hidden"
 
-class Card : BaseModel, Styles, Parent {
+class Card : BaseModel, Styles, Parent, HasAnalyticsEvents {
     internal companion object {
         internal const val XML_CARD = "card"
 
@@ -122,6 +124,7 @@ class Card : BaseModel, Styles, Parent {
         backgroundImageGravity: ImageGravity = DEFAULT_BACKGROUND_IMAGE_GRAVITY,
         backgroundImageScaleType: ImageScaleType = DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE,
         isHidden: Boolean = false,
+        analyticsEvents: List<AnalyticsEvent> = emptyList(),
         label: ((Base) -> Text?)? = null,
         content: ((Card) -> List<Content>?)? = null
     ) : super(page) {
@@ -131,7 +134,7 @@ class Card : BaseModel, Styles, Parent {
         this.isHidden = isHidden
         listeners = emptySet()
         dismissListeners = emptySet()
-        analyticsEvents = emptyList()
+        this.analyticsEvents = analyticsEvents
 
         _backgroundColor = backgroundColor
         _backgroundImage = backgroundImage
@@ -142,6 +145,12 @@ class Card : BaseModel, Styles, Parent {
 
         this.label = label?.invoke(labelParent)
         this.content = content?.invoke(this).orEmpty()
+    }
+
+    override fun getAnalyticsEvents(type: Trigger) = when (type) {
+        Trigger.VISIBLE -> analyticsEvents.filter { it.isTriggerType(Trigger.VISIBLE, Trigger.DEFAULT) }
+        Trigger.HIDDEN -> analyticsEvents.filter { it.isTriggerType(Trigger.HIDDEN) }
+        else -> error("Analytics trigger type $type is not currently supported on Cards")
     }
 }
 

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Hero.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Hero.kt
@@ -3,9 +3,11 @@ package org.cru.godtools.tool.model.tract
 import org.cru.godtools.tool.internal.RestrictTo
 import org.cru.godtools.tool.model.AnalyticsEvent
 import org.cru.godtools.tool.model.AnalyticsEvent.Companion.parseAnalyticsEvents
+import org.cru.godtools.tool.model.AnalyticsEvent.Trigger
 import org.cru.godtools.tool.model.Base
 import org.cru.godtools.tool.model.BaseModel
 import org.cru.godtools.tool.model.Content
+import org.cru.godtools.tool.model.HasAnalyticsEvents
 import org.cru.godtools.tool.model.Parent
 import org.cru.godtools.tool.model.Text
 import org.cru.godtools.tool.model.XMLNS_ANALYTICS
@@ -17,7 +19,7 @@ import org.cru.godtools.tool.xml.XmlPullParser
 
 private const val XML_HEADING = "heading"
 
-class Hero : BaseModel, Parent {
+class Hero : BaseModel, Parent, HasAnalyticsEvents {
     internal companion object {
         internal const val XML_HERO = "hero"
     }
@@ -50,10 +52,16 @@ class Hero : BaseModel, Parent {
     constructor(
         page: TractPage = TractPage(),
         analyticsEvents: List<AnalyticsEvent> = emptyList(),
-        heading: (Base) -> Text?
+        heading: ((Base) -> Text?)? = null
     ) : super(page) {
         this.analyticsEvents = analyticsEvents
-        this.heading = heading(headingParent)
+        this.heading = heading?.invoke(headingParent)
         content = emptyList()
+    }
+
+    override fun getAnalyticsEvents(type: Trigger) = when (type) {
+        Trigger.VISIBLE -> analyticsEvents.filter { it.isTriggerType(Trigger.VISIBLE, Trigger.DEFAULT) }
+        Trigger.HIDDEN -> analyticsEvents.filter { it.isTriggerType(Trigger.HIDDEN) }
+        else -> error("Analytics trigger type $type is not currently supported on Heroes")
     }
 }

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ButtonTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ButtonTest.kt
@@ -6,11 +6,13 @@ import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
 import org.cru.godtools.tool.internal.runBlockingTest
+import org.cru.godtools.tool.model.AnalyticsEvent.Trigger
 import org.cru.godtools.tool.model.Button.Style.Companion.toButtonStyle
 import org.cru.godtools.tool.model.Button.Type.Companion.toButtonTypeOrNull
 import org.cru.godtools.tool.state.State
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
@@ -124,6 +126,18 @@ class ButtonTest : UsesResources() {
     }
 
     @Test
+    fun testButtonGetAnalyticsEvents() {
+        val defaultEvent = AnalyticsEvent(trigger = Trigger.DEFAULT)
+        val selectedEvent = AnalyticsEvent(trigger = Trigger.SELECTED)
+        val visibleEvent = AnalyticsEvent(trigger = Trigger.VISIBLE)
+        val button = Button(analyticsEvents = listOf(defaultEvent, selectedEvent, visibleEvent))
+
+        assertEquals(listOf(defaultEvent, selectedEvent), button.getAnalyticsEvents(Trigger.SELECTED))
+        assertFailsWith(IllegalStateException::class) { button.getAnalyticsEvents(Trigger.DEFAULT) }
+        assertFailsWith(IllegalStateException::class) { button.getAnalyticsEvents(Trigger.VISIBLE) }
+    }
+
+    @Test
     fun testButtonColorFallbackBehavior() {
         val manifest = Manifest()
         assertEquals(manifest.primaryColor, Button(manifest).buttonColor)
@@ -191,6 +205,7 @@ class ButtonTest : UsesResources() {
             assertEquals(TestColors.GREEN, text!!.textColor)
         }
     }
+
     // region Button.Style
     @Test
     fun verifyParseButtonStyle() {

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/TabsTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/TabsTest.kt
@@ -8,6 +8,7 @@ import org.cru.godtools.tool.internal.runBlockingTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 
 @RunOnAndroidWith(AndroidJUnit4::class)
@@ -49,5 +50,17 @@ class TabsTest : UsesResources() {
         val tab = Tabs(Manifest(), getTestXmlParser("tabs_ignored_content.xml")).tabs.single()
         assertEquals(1, tab.content.size)
         assertIs<Paragraph>(tab.content[0])
+    }
+
+    @Test
+    fun testTabGetAnalyticsEvents() {
+        val defaultEvent = AnalyticsEvent(trigger = AnalyticsEvent.Trigger.DEFAULT)
+        val selectedEvent = AnalyticsEvent(trigger = AnalyticsEvent.Trigger.SELECTED)
+        val visibleEvent = AnalyticsEvent(trigger = AnalyticsEvent.Trigger.VISIBLE)
+        val tab = Tabs.Tab(analyticsEvents = listOf(defaultEvent, selectedEvent, visibleEvent))
+
+        assertEquals(listOf(defaultEvent, selectedEvent), tab.getAnalyticsEvents(AnalyticsEvent.Trigger.SELECTED))
+        assertFailsWith(IllegalStateException::class) { tab.getAnalyticsEvents(AnalyticsEvent.Trigger.DEFAULT) }
+        assertFailsWith(IllegalStateException::class) { tab.getAnalyticsEvents(AnalyticsEvent.Trigger.VISIBLE) }
     }
 }

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/CardTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/CardTest.kt
@@ -4,6 +4,7 @@ import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
 import org.cru.godtools.tool.internal.runBlockingTest
+import org.cru.godtools.tool.model.AnalyticsEvent
 import org.cru.godtools.tool.model.ImageScaleType
 import org.cru.godtools.tool.model.Manifest
 import org.cru.godtools.tool.model.Paragraph
@@ -16,6 +17,7 @@ import org.cru.godtools.tool.model.tips.Tip
 import org.cru.godtools.tool.model.toEventIds
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNotEquals
@@ -103,6 +105,20 @@ class CardTest : UsesResources("model/tract") {
         val page = TractPage(cardBackgroundColor = TestColors.GREEN)
         assertEquals(TestColors.GREEN, Card(page).backgroundColor)
         assertEquals(TestColors.BLUE, Card(page, backgroundColor = TestColors.BLUE).backgroundColor)
+    }
+
+    @Test
+    fun testAnalyticsEvents() {
+        val defaultEvent = AnalyticsEvent(trigger = AnalyticsEvent.Trigger.DEFAULT)
+        val visibleEvent = AnalyticsEvent(trigger = AnalyticsEvent.Trigger.VISIBLE)
+        val hiddenEvent = AnalyticsEvent(trigger = AnalyticsEvent.Trigger.HIDDEN)
+        val selectedEvent = AnalyticsEvent(trigger = AnalyticsEvent.Trigger.SELECTED)
+        val card = Card(analyticsEvents = listOf(defaultEvent, visibleEvent, hiddenEvent, selectedEvent))
+
+        assertEquals(listOf(defaultEvent, visibleEvent), card.getAnalyticsEvents(AnalyticsEvent.Trigger.VISIBLE))
+        assertEquals(listOf(hiddenEvent), card.getAnalyticsEvents(AnalyticsEvent.Trigger.HIDDEN))
+        assertFailsWith(IllegalStateException::class) { card.getAnalyticsEvents(AnalyticsEvent.Trigger.DEFAULT) }
+        assertFailsWith(IllegalStateException::class) { card.getAnalyticsEvents(AnalyticsEvent.Trigger.SELECTED) }
     }
 
     @Test

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/HeroTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/HeroTest.kt
@@ -5,6 +5,8 @@ import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
 import org.cru.godtools.tool.internal.runBlockingTest
+import org.cru.godtools.tool.model.AnalyticsEvent
+import org.cru.godtools.tool.model.AnalyticsEvent.Trigger
 import org.cru.godtools.tool.model.DeviceType
 import org.cru.godtools.tool.model.Image
 import org.cru.godtools.tool.model.Manifest
@@ -15,6 +17,7 @@ import org.cru.godtools.tool.model.Text
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
@@ -45,6 +48,20 @@ class HeroTest : UsesResources("model/tract") {
         assertEquals(2, hero.content.size)
         assertIs<Paragraph>(hero.content[0])
         assertIs<Tabs>(hero.content[1])
+    }
+
+    @Test
+    fun testAnalyticsEvents() {
+        val defaultEvent = AnalyticsEvent(trigger = Trigger.DEFAULT)
+        val visibleEvent = AnalyticsEvent(trigger = Trigger.VISIBLE)
+        val hiddenEvent = AnalyticsEvent(trigger = Trigger.HIDDEN)
+        val selectedEvent = AnalyticsEvent(trigger = Trigger.SELECTED)
+        val hero = Hero(analyticsEvents = listOf(defaultEvent, visibleEvent, hiddenEvent, selectedEvent))
+
+        assertEquals(listOf(defaultEvent, visibleEvent), hero.getAnalyticsEvents(Trigger.VISIBLE))
+        assertEquals(listOf(hiddenEvent), hero.getAnalyticsEvents(Trigger.HIDDEN))
+        assertFailsWith(IllegalStateException::class) { hero.getAnalyticsEvents(Trigger.DEFAULT) }
+        assertFailsWith(IllegalStateException::class) { hero.getAnalyticsEvents(Trigger.SELECTED) }
     }
 
     @Test


### PR DESCRIPTION
models that contain AnalyticsEvents will implement the `HasAnalyticsEvents` interface. This will provide a `model.getAnalyticsEvents(triggerType)` method that will return the events that match the specified trigger type. This method will take any default trigger types defined in the spec into account.