### PR TITLE
GT-1268 Replace the SELECTED trigger type with CLICKED

### DIFF
--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/AnalyticsEvent.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/AnalyticsEvent.kt
@@ -20,6 +20,7 @@ private const val XML_SYSTEM_FACEBOOK = "facebook"
 private const val XML_SYSTEM_FIREBASE = "firebase"
 private const val XML_SYSTEM_SNOWPLOW = "snowplow"
 private const val XML_TRIGGER = "trigger"
+private const val XML_TRIGGER_CLICKED = "clicked"
 private const val XML_TRIGGER_SELECTED = "selected"
 private const val XML_TRIGGER_VISIBLE = "visible"
 private const val XML_TRIGGER_HIDDEN = "hidden"
@@ -113,10 +114,16 @@ class AnalyticsEvent : BaseModel {
     }
 
     enum class Trigger {
-        SELECTED, VISIBLE, HIDDEN, DEFAULT, UNKNOWN;
+        @Deprecated(
+            "Since 0.3.0 (9/3/21), use CLICKED instead",
+            ReplaceWith("CLICKED", "org.cru.godtools.tool.model.AnalyticsEvent.Trigger.CLICKED")
+        )
+        SELECTED,
+        VISIBLE, HIDDEN, CLICKED, DEFAULT, UNKNOWN;
 
         internal companion object {
             fun String.toTrigger() = when (this) {
+                XML_TRIGGER_CLICKED -> CLICKED
                 XML_TRIGGER_SELECTED -> SELECTED
                 XML_TRIGGER_VISIBLE -> VISIBLE
                 XML_TRIGGER_HIDDEN -> HIDDEN

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Button.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Button.kt
@@ -1,5 +1,6 @@
 package org.cru.godtools.tool.model
 
+import io.github.aakira.napier.Napier
 import org.cru.godtools.tool.internal.AndroidColorInt
 import org.cru.godtools.tool.internal.RestrictTo
 import org.cru.godtools.tool.model.AnalyticsEvent.Companion.parseAnalyticsEvents
@@ -20,6 +21,8 @@ private const val XML_URL = "url"
 private const val XML_ICON = "icon"
 private const val XML_ICON_GRAVITY = "icon-gravity"
 private const val XML_ICON_SIZE = "icon-size"
+
+private const val TAG = "Button"
 
 class Button : Content, Styles, HasAnalyticsEvents {
     internal companion object {
@@ -84,6 +87,15 @@ class Button : Content, Styles, HasAnalyticsEvents {
                 }
             }
         }
+
+        // Log a non-fatal warning if any analytics event is still using the SELECTED trigger
+        analyticsEvents.forEach {
+            if (it.trigger == Trigger.SELECTED) {
+                val message =
+                    "tool: ${manifest.code} locale: ${manifest.locale} action: ${it.action} trigger: ${it.trigger}"
+                Napier.e(message, UnsupportedOperationException("XML Analytics Event Deprecated trigger $message"), TAG)
+            }
+        }
     }
 
     @RestrictTo(RestrictTo.Scope.TESTS)
@@ -114,7 +126,8 @@ class Button : Content, Styles, HasAnalyticsEvents {
     override val isIgnored get() = super.isIgnored || type == Type.UNKNOWN || style == Style.UNKNOWN
 
     override fun getAnalyticsEvents(type: Trigger) = when (type) {
-        Trigger.SELECTED -> analyticsEvents.filter { it.isTriggerType(Trigger.SELECTED, Trigger.DEFAULT) }
+        Trigger.CLICKED ->
+            analyticsEvents.filter { it.isTriggerType(Trigger.CLICKED, Trigger.SELECTED, Trigger.DEFAULT) }
         else -> error("The $type trigger type is currently unsupported on Buttons")
     }
 

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Link.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Link.kt
@@ -1,9 +1,12 @@
 package org.cru.godtools.tool.model
 
+import io.github.aakira.napier.Napier
 import org.cru.godtools.tool.internal.RestrictTo
 import org.cru.godtools.tool.model.AnalyticsEvent.Companion.parseAnalyticsEvents
 import org.cru.godtools.tool.model.AnalyticsEvent.Trigger
 import org.cru.godtools.tool.xml.XmlPullParser
+
+private const val TAG = "Link"
 
 class Link : Content, Styles, HasAnalyticsEvents {
     internal companion object {
@@ -28,6 +31,15 @@ class Link : Content, Styles, HasAnalyticsEvents {
                     }
             }
         }
+
+        // Log a non-fatal warning if any analytics event is still using the SELECTED trigger
+        analyticsEvents.forEach {
+            if (it.trigger == Trigger.SELECTED) {
+                val message =
+                    "tool: ${manifest.code} locale: ${manifest.locale} action: ${it.action} trigger: ${it.trigger}"
+                Napier.e(message, UnsupportedOperationException("XML Analytics Event Deprecated trigger $message"), TAG)
+            }
+        }
     }
 
     @RestrictTo(RestrictTo.Scope.TESTS)
@@ -42,7 +54,8 @@ class Link : Content, Styles, HasAnalyticsEvents {
     }
 
     override fun getAnalyticsEvents(type: Trigger) = when (type) {
-        Trigger.SELECTED -> analyticsEvents.filter { it.isTriggerType(Trigger.SELECTED, Trigger.DEFAULT) }
+        Trigger.CLICKED ->
+            analyticsEvents.filter { it.isTriggerType(Trigger.CLICKED, Trigger.SELECTED, Trigger.DEFAULT) }
         else -> error("The $type trigger type is currently unsupported on Links")
     }
 }

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Tabs.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Tabs.kt
@@ -1,10 +1,13 @@
 package org.cru.godtools.tool.model
 
+import io.github.aakira.napier.Napier
 import org.cru.godtools.tool.internal.RestrictTo
 import org.cru.godtools.tool.model.AnalyticsEvent.Companion.parseAnalyticsEvents
 import org.cru.godtools.tool.model.AnalyticsEvent.Trigger
 import org.cru.godtools.tool.xml.XmlPullParser
 import org.cru.godtools.tool.xml.parseChildren
+
+private const val TAG = "Tabs"
 
 private const val XML_TAB = "tab"
 private const val XML_LABEL = "label"
@@ -66,6 +69,15 @@ class Tabs : Content {
                 }
             }
             this.label = label
+
+            // Log a non-fatal warning if any analytics event is still using the SELECTED trigger
+            analyticsEvents.forEach {
+                if (it.trigger == Trigger.SELECTED) {
+                    val message =
+                        "tool: ${manifest.code} locale: ${manifest.locale} action: ${it.action} trigger: ${it.trigger}"
+                    Napier.e(message, UnsupportedOperationException("XML Analytics Deprecated trigger $message"), TAG)
+                }
+            }
         }
 
         @RestrictTo(RestrictTo.Scope.TESTS)
@@ -81,7 +93,8 @@ class Tabs : Content {
         }
 
         override fun getAnalyticsEvents(type: Trigger) = when (type) {
-            Trigger.SELECTED -> analyticsEvents.filter { it.isTriggerType(Trigger.SELECTED, Trigger.DEFAULT) }
+            Trigger.CLICKED ->
+                analyticsEvents.filter { it.isTriggerType(Trigger.CLICKED, Trigger.SELECTED, Trigger.DEFAULT) }
             else -> error("The $type trigger type is currently unsupported on Tabs")
         }
     }

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ButtonTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ButtonTest.kt
@@ -128,12 +128,14 @@ class ButtonTest : UsesResources() {
     @Test
     fun testButtonGetAnalyticsEvents() {
         val defaultEvent = AnalyticsEvent(trigger = Trigger.DEFAULT)
+        val clickedEvent = AnalyticsEvent(trigger = Trigger.CLICKED)
         val selectedEvent = AnalyticsEvent(trigger = Trigger.SELECTED)
         val visibleEvent = AnalyticsEvent(trigger = Trigger.VISIBLE)
-        val button = Button(analyticsEvents = listOf(defaultEvent, selectedEvent, visibleEvent))
+        val button = Button(analyticsEvents = listOf(defaultEvent, clickedEvent, selectedEvent, visibleEvent))
 
-        assertEquals(listOf(defaultEvent, selectedEvent), button.getAnalyticsEvents(Trigger.SELECTED))
+        assertEquals(listOf(defaultEvent, clickedEvent, selectedEvent), button.getAnalyticsEvents(Trigger.CLICKED))
         assertFailsWith(IllegalStateException::class) { button.getAnalyticsEvents(Trigger.DEFAULT) }
+        assertFailsWith(IllegalStateException::class) { button.getAnalyticsEvents(Trigger.SELECTED) }
         assertFailsWith(IllegalStateException::class) { button.getAnalyticsEvents(Trigger.VISIBLE) }
     }
 

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/LinkTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/LinkTest.kt
@@ -4,6 +4,7 @@ import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
 import org.cru.godtools.tool.internal.runBlockingTest
+import org.cru.godtools.tool.model.AnalyticsEvent.Trigger
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -45,13 +46,15 @@ class LinkTest : UsesResources() {
 
     @Test
     fun testGetAnalyticsEvents() {
-        val defaultEvent = AnalyticsEvent(trigger = AnalyticsEvent.Trigger.DEFAULT)
-        val selectedEvent = AnalyticsEvent(trigger = AnalyticsEvent.Trigger.SELECTED)
-        val visibleEvent = AnalyticsEvent(trigger = AnalyticsEvent.Trigger.VISIBLE)
-        val link = Link(analyticsEvents = listOf(defaultEvent, selectedEvent, visibleEvent))
+        val defaultEvent = AnalyticsEvent(trigger = Trigger.DEFAULT)
+        val clickedEvent = AnalyticsEvent(trigger = Trigger.CLICKED)
+        val selectedEvent = AnalyticsEvent(trigger = Trigger.SELECTED)
+        val visibleEvent = AnalyticsEvent(trigger = Trigger.VISIBLE)
+        val link = Link(analyticsEvents = listOf(defaultEvent, clickedEvent, selectedEvent, visibleEvent))
 
-        assertEquals(listOf(defaultEvent, selectedEvent), link.getAnalyticsEvents(AnalyticsEvent.Trigger.SELECTED))
-        assertFailsWith(IllegalStateException::class) { link.getAnalyticsEvents(AnalyticsEvent.Trigger.DEFAULT) }
-        assertFailsWith(IllegalStateException::class) { link.getAnalyticsEvents(AnalyticsEvent.Trigger.VISIBLE) }
+        assertEquals(listOf(defaultEvent, clickedEvent, selectedEvent), link.getAnalyticsEvents(Trigger.CLICKED))
+        assertFailsWith(IllegalStateException::class) { link.getAnalyticsEvents(Trigger.DEFAULT) }
+        assertFailsWith(IllegalStateException::class) { link.getAnalyticsEvents(Trigger.SELECTED) }
+        assertFailsWith(IllegalStateException::class) { link.getAnalyticsEvents(Trigger.VISIBLE) }
     }
 }

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/TabsTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/TabsTest.kt
@@ -5,6 +5,7 @@ import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
 import org.cru.godtools.tool.internal.runBlockingTest
+import org.cru.godtools.tool.model.AnalyticsEvent.Trigger
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -54,13 +55,15 @@ class TabsTest : UsesResources() {
 
     @Test
     fun testTabGetAnalyticsEvents() {
-        val defaultEvent = AnalyticsEvent(trigger = AnalyticsEvent.Trigger.DEFAULT)
-        val selectedEvent = AnalyticsEvent(trigger = AnalyticsEvent.Trigger.SELECTED)
-        val visibleEvent = AnalyticsEvent(trigger = AnalyticsEvent.Trigger.VISIBLE)
-        val tab = Tabs.Tab(analyticsEvents = listOf(defaultEvent, selectedEvent, visibleEvent))
+        val defaultEvent = AnalyticsEvent(trigger = Trigger.DEFAULT)
+        val clickedEvent = AnalyticsEvent(trigger = Trigger.CLICKED)
+        val selectedEvent = AnalyticsEvent(trigger = Trigger.SELECTED)
+        val visibleEvent = AnalyticsEvent(trigger = Trigger.VISIBLE)
+        val tab = Tabs.Tab(analyticsEvents = listOf(defaultEvent, clickedEvent, selectedEvent, visibleEvent))
 
-        assertEquals(listOf(defaultEvent, selectedEvent), tab.getAnalyticsEvents(AnalyticsEvent.Trigger.SELECTED))
-        assertFailsWith(IllegalStateException::class) { tab.getAnalyticsEvents(AnalyticsEvent.Trigger.DEFAULT) }
-        assertFailsWith(IllegalStateException::class) { tab.getAnalyticsEvents(AnalyticsEvent.Trigger.VISIBLE) }
+        assertEquals(listOf(defaultEvent, clickedEvent, selectedEvent), tab.getAnalyticsEvents(Trigger.CLICKED))
+        assertFailsWith(IllegalStateException::class) { tab.getAnalyticsEvents(Trigger.DEFAULT) }
+        assertFailsWith(IllegalStateException::class) { tab.getAnalyticsEvents(Trigger.SELECTED) }
+        assertFailsWith(IllegalStateException::class) { tab.getAnalyticsEvents(Trigger.VISIBLE) }
     }
 }


### PR DESCRIPTION
This changes the following usage (which is currently only affects Android):
from: `model.getAnalyticsEvents(SELECTED)` to: `model.getAnalyticsEvents(CLICKED)`