### PR TITLE
Move dependencies to Version Catalog

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,7 +46,7 @@ subprojects {
                 val androidTest by getting {
                     dependencies {
                         implementation("androidx.test.ext:junit:1.1.3")
-                        implementation("org.robolectric:robolectric:4.6.1")
+                        implementation(libs.robolectric)
                     }
                 }
             }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -78,7 +78,9 @@ kotlin {
         license = "MIT"
         homepage = "https://github.com/CruGlobal/kotlin-mpp-godtools-tool-parser"
 
-        frameworkName = "GodToolsToolParser"
+        framework {
+            baseName = "GodToolsToolParser"
+        }
 
         ios.deploymentTarget = "11.0"
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,7 +45,7 @@ subprojects {
                 }
                 val androidTest by getting {
                     dependencies {
-                        implementation("androidx.test.ext:junit:1.1.3")
+                        implementation(libs.androidx.test.junit)
                         implementation(libs.robolectric)
                     }
                 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 android-gradle-plugin = "7.0.2"
 androidx-annotation = "1.2.0"
+androidx-test-junit = "1.1.3"
 antlr-kotlin = "bbd4c72186"
 antlr-kotlin-fork = "0.0.7_265"
 colormath = "2.1.0"
@@ -17,6 +18,7 @@ splitties = "3.0.0"
 [libraries]
 android-gradle = { module = "com.android.tools.build:gradle", version.ref = "android-gradle-plugin" }
 androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "androidx-annotation" }
+androidx-test-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-test-junit" }
 antlr-kotlin-gradle = { module = "com.strumenta.antlr-kotlin:antlr-kotlin-gradle-plugin", version.ref = "antlr-kotlin" }
 #antlr-kotlin-runtime = { module = "com.strumenta.antlr-kotlin:antlr-kotlin-runtime", version.ref = "antlr-kotlin" }
 antlr-kotlin-runtime = { module = "org.cru.mobile.fork.antlr-kotlin:antlr-kotlin-runtime", version.ref = "antlr-kotlin-fork" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ kotlinCoroutines = "1.5.2"
 ktlint = "0.42.1"
 napier = "2.1.0"
 okio = "3.0.0-alpha.9"
+robolectric = "4.6.1"
 splitties = "3.0.0"
 
 [libraries]
@@ -27,4 +28,5 @@ kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.
 napier = { module = "io.github.aakira:napier", version.ref = "napier" }
 okio-js = { module = "com.squareup.okio:okio-js", version.ref = "okio" }
 okio-nodefilesystem = { module = "com.squareup.okio:okio-nodefilesystem-js", version.ref = "okio" }
+robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 splitties-bitflags = { module = "com.louiscad.splitties:splitties-bitflags", version.ref = "splitties" }


### PR DESCRIPTION
- stop using deprecated frameworkName
- move robolectric dependency to the version catalog
- move AndroidX JUnit dependency to version catalog
