### PR TITLE
Make several properties internal to reduce the API surface

### DIFF
--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Button.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Button.kt
@@ -50,8 +50,8 @@ class Button : Content, Styles, HasAnalyticsEvents {
 
     private val iconName: String?
     val icon get() = getResource(iconName)
-    val iconSize: Int
-    val iconGravity: ImageGravity
+    internal val iconSize: Int
+    internal val iconGravity: ImageGravity
 
     val text: Text?
     override val textAlign get() = Text.Align.CENTER

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Input.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Input.kt
@@ -81,5 +81,3 @@ class Input : Content {
         }
     }
 }
-
-val Input?.type get() = this?.type ?: Input.Type.DEFAULT

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
@@ -108,18 +108,20 @@ class Manifest : BaseModel, Styles {
     @AndroidColorInt
     private val _navBarColor: PlatformColor?
     @get:AndroidColorInt
-    val navBarColor get() = _navBarColor ?: if (type == Type.LESSON) DEFAULT_LESSON_NAV_BAR_COLOR else primaryColor
+    internal val navBarColor
+        get() = _navBarColor ?: if (type == Type.LESSON) DEFAULT_LESSON_NAV_BAR_COLOR else primaryColor
     @AndroidColorInt
     private val _navBarControlColor: PlatformColor?
     @get:AndroidColorInt
-    val navBarControlColor get() = _navBarControlColor ?: if (type == Type.LESSON) primaryColor else primaryTextColor
+    internal val navBarControlColor
+        get() = _navBarControlColor ?: if (type == Type.LESSON) primaryColor else primaryTextColor
 
     @AndroidColorInt
-    val backgroundColor: PlatformColor
+    internal val backgroundColor: PlatformColor
     private val _backgroundImage: String?
     val backgroundImage get() = getResource(_backgroundImage)
-    val backgroundImageGravity: ImageGravity
-    val backgroundImageScaleType: ImageScaleType
+    internal val backgroundImageGravity: ImageGravity
+    internal val backgroundImageScaleType: ImageScaleType
 
     @AndroidColorInt
     private val _cardBackgroundColor: PlatformColor?

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Multiselect.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Multiselect.kt
@@ -88,9 +88,10 @@ class Multiselect : Content {
         val multiselect: Multiselect
 
         private val _backgroundColor: PlatformColor?
-        val backgroundColor get() = _backgroundColor ?: multiselect.optionBackgroundColor
+        internal val backgroundColor get() = _backgroundColor ?: multiselect.optionBackgroundColor
         private val _selectedColor: PlatformColor?
-        val selectedColor get() = _selectedColor ?: multiselect.optionSelectedColor ?: stylesParent.defaultSelectedColor
+        internal val selectedColor
+            get() = _selectedColor ?: multiselect.optionSelectedColor ?: stylesParent.defaultSelectedColor
 
         @VisibleForTesting
         internal val value: String

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Text.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Text.kt
@@ -37,13 +37,13 @@ class Text : Content {
     val text: String?
 
     private val _textAlign: Align?
-    val textAlign get() = _textAlign ?: stylesParent.textAlign
+    internal val textAlign get() = _textAlign ?: stylesParent.textAlign
     @AndroidColorInt
     private val _textColor: PlatformColor?
     @get:AndroidColorInt
-    val textColor get() = _textColor ?: stylesParent.textColor
+    internal val textColor get() = _textColor ?: stylesParent.textColor
     private val _textScale: Double
-    val textScale get() = _textScale * stylesParent.textScale
+    internal val textScale get() = _textScale * stylesParent.textScale
     val textStyles: Set<Style>
 
     @VisibleForTesting

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/lesson/LessonPage.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/lesson/LessonPage.kt
@@ -69,18 +69,18 @@ class LessonPage : BaseModel, Parent, Styles, HasAnalyticsEvents {
     internal val analyticsEvents: List<AnalyticsEvent>
 
     @AndroidColorInt
-    val backgroundColor: PlatformColor
+    internal val backgroundColor: PlatformColor
 
     @VisibleForTesting
     internal val _backgroundImage: String?
     val backgroundImage get() = getResource(_backgroundImage)
-    val backgroundImageGravity: ImageGravity
-    val backgroundImageScaleType: ImageScaleType
+    internal val backgroundImageGravity: ImageGravity
+    internal val backgroundImageScaleType: ImageScaleType
 
     @AndroidColorInt
     private val _controlColor: PlatformColor?
     @get:AndroidColorInt
-    val controlColor get() = _controlColor ?: manifest.lessonControlColor
+    internal val controlColor get() = _controlColor ?: manifest.lessonControlColor
 
     private val _multiselectOptionBackgroundColor: PlatformColor?
     override val multiselectOptionBackgroundColor

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/CallToAction.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/CallToAction.kt
@@ -32,7 +32,7 @@ class CallToAction : BaseModel {
     @AndroidColorInt
     private val _controlColor: PlatformColor?
     @get:AndroidColorInt
-    val controlColor get() = _controlColor ?: stylesParent.primaryColor
+    internal val controlColor get() = _controlColor ?: stylesParent.primaryColor
 
     @VisibleForTesting
     internal val tipId: String?

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Card.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Card.kt
@@ -69,7 +69,7 @@ class Card : BaseModel, Styles, Parent, HasAnalyticsEvents {
     private val _backgroundImage: String?
     val backgroundImage get() = getResource(_backgroundImage)
     internal val backgroundImageGravity: ImageGravity
-    val backgroundImageScaleType: ImageScaleType
+    internal val backgroundImageScaleType: ImageScaleType
 
     @AndroidColorInt
     private val _textColor: PlatformColor?

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/TractPage.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/TractPage.kt
@@ -61,11 +61,11 @@ class TractPage : BaseModel, Styles {
     val listeners: Set<EventId>
 
     @AndroidColorInt
-    val backgroundColor: PlatformColor
+    internal val backgroundColor: PlatformColor
     private val _backgroundImage: String?
     val backgroundImage get() = getResource(_backgroundImage)
-    val backgroundImageGravity: ImageGravity
-    val backgroundImageScaleType: ImageScaleType
+    internal val backgroundImageGravity: ImageGravity
+    internal val backgroundImageScaleType: ImageScaleType
 
     private val _multiselectOptionBackgroundColor: PlatformColor?
     override val multiselectOptionBackgroundColor


### PR DESCRIPTION
This marks several properties as internal when there is a null safe extension property available. on iOS this removes some redundant properties from the GodToolsToolParser framework.

I tested this out locally against godtools-swift and everything still compiles and runs.