### PR TITLE
wrap all unhandled exceptions in an Error and log them to Napier

### DIFF
--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/service/ManifestParser.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/service/ManifestParser.kt
@@ -1,5 +1,6 @@
 package org.cru.godtools.tool.service
 
+import io.github.aakira.napier.Napier
 import org.cru.godtools.tool.internal.FileNotFoundException
 import org.cru.godtools.tool.model.Manifest
 import org.cru.godtools.tool.xml.XmlPullParserException
@@ -15,6 +16,9 @@ open class ManifestParser(private val parserFactory: XmlPullParserFactory) {
         ParserResult.Error.NotFound(e)
     } catch (e: XmlPullParserException) {
         ParserResult.Error.Corrupted(e)
+    } catch (e: Exception) {
+        Napier.d("Unexpected Parsing Exception", e, "ManifestParser")
+        ParserResult.Error(e)
     }
 }
 


### PR DESCRIPTION
This should hopefully address the immediate symptom of the iOS crash. We still need to figure out the cause to apply a more correct fix long term.