### PR TITLE
cleanup

### DIFF
--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Content.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Content.kt
@@ -55,7 +55,7 @@ abstract class Content : BaseModel {
     /**
      * @return true if this content element should be completely ignored.
      */
-    open val isIgnored
+    internal open val isIgnored
         get() = version > SCHEMA_VERSION ||
             !ParserConfig.supportedFeatures.containsAll(requiredFeatures) ||
             restrictTo.none { it in DeviceType.SUPPORTED } ||
@@ -103,3 +103,6 @@ abstract class Content : BaseModel {
         }
     }
 }
+
+@RestrictTo(RestrictTo.Scope.TESTS)
+internal val Content.testIsIgnored get() = isIgnored

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/AnimationTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/AnimationTest.kt
@@ -40,9 +40,9 @@ class AnimationTest : UsesResources() {
         val animation = Animation()
 
         ParserConfig.supportedFeatures = setOf(FEATURE_ANIMATION)
-        assertFalse(animation.isIgnored)
+        assertFalse(animation.testIsIgnored)
 
         ParserConfig.supportedFeatures = emptySet()
-        assertTrue(animation.isIgnored)
+        assertTrue(animation.testIsIgnored)
     }
 }

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ButtonTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ButtonTest.kt
@@ -32,7 +32,7 @@ class ButtonTest : UsesResources() {
     fun testParseButtonEvent() = runBlockingTest {
         val manifest = Manifest()
         with(Button(manifest, getTestXmlParser("button_event.xml"))) {
-            assertFalse(isIgnored)
+            assertFalse(testIsIgnored)
             assertFalse(isGone(state))
             assertFalse(isInvisible(state))
             assertEquals(manifest.buttonStyle, style)
@@ -51,7 +51,7 @@ class ButtonTest : UsesResources() {
     @Test
     fun testParseButtonUrl() = runBlockingTest {
         val button = Button(Manifest(), getTestXmlParser("button_url.xml"))
-        assertFalse(button.isIgnored)
+        assertFalse(button.testIsIgnored)
         assertEquals(Button.Style.OUTLINED, button.style)
         assertEquals(Button.Type.URL, button.type)
         assertEquals(TestColors.GREEN, button.backgroundColor)
@@ -65,18 +65,18 @@ class ButtonTest : UsesResources() {
     fun testParseButtonRestrictTo() = runBlockingTest {
         val button = Button(Manifest(), getTestXmlParser("button_restrictTo.xml"))
         ParserConfig.supportedDeviceTypes = setOf(DeviceType.WEB)
-        assertFalse(button.isIgnored)
+        assertFalse(button.testIsIgnored)
         ParserConfig.supportedDeviceTypes = setOf(DeviceType.MOBILE)
-        assertTrue(button.isIgnored)
+        assertTrue(button.testIsIgnored)
     }
 
     @Test
     fun testParseButtonRequiredFeatures() = runBlockingTest {
         val button = Button(Manifest(), getTestXmlParser("button_requiredFeatures.xml"))
         ParserConfig.supportedFeatures = setOf(FEATURE_MULTISELECT)
-        assertFalse(button.isIgnored)
+        assertFalse(button.testIsIgnored)
         ParserConfig.supportedFeatures = emptySet()
-        assertTrue(button.isIgnored)
+        assertTrue(button.testIsIgnored)
     }
 
     @Test
@@ -92,7 +92,7 @@ class ButtonTest : UsesResources() {
     @Test
     fun testParseButtonVisibility() = runBlockingTest {
         with(Button(Manifest(), getTestXmlParser("button_visibility.xml"))) {
-            assertFalse(isIgnored)
+            assertFalse(testIsIgnored)
 
             assertFalse(isInvisible(state))
             state["invisible"] = "true"
@@ -109,24 +109,24 @@ class ButtonTest : UsesResources() {
     fun testIsIgnoredClickable() {
         with(Button()) {
             assertFalse(isClickable)
-            assertTrue(isIgnored)
+            assertTrue(testIsIgnored)
         }
 
         with(Button(events = listOf(EventId.FOLLOWUP))) {
             assertTrue(isClickable)
-            assertFalse(isIgnored)
+            assertFalse(testIsIgnored)
         }
 
         with(Button(url = TEST_URL)) {
             assertTrue(isClickable)
-            assertFalse(isIgnored)
+            assertFalse(testIsIgnored)
         }
     }
 
     @Test
     fun testButtonStyleUnknown() {
         val button = Button(style = Button.Style.UNKNOWN, events = listOf(EventId.FOLLOWUP))
-        assertTrue(button.isIgnored)
+        assertTrue(button.testIsIgnored)
     }
     // endregion isIgnored
 

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ContentTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ContentTest.kt
@@ -1,5 +1,6 @@
 package org.cru.godtools.tool.model
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.launchIn
@@ -23,6 +24,7 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @RunOnAndroidWith(AndroidJUnit4::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 class ContentTest : UsesResources() {
     private val state = State()
 

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ContentTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ContentTest.kt
@@ -30,18 +30,18 @@ class ContentTest : UsesResources() {
     @Test
     fun verifyRequiredFeaturesSupported() {
         ParserConfig.supportedFeatures = setOf(FEATURE_ANIMATION, FEATURE_MULTISELECT)
-        assertFalse(object : Content(requiredFeatures = setOf(FEATURE_ANIMATION, FEATURE_MULTISELECT)) {}.isIgnored)
-        assertFalse(object : Content(requiredFeatures = setOf(FEATURE_ANIMATION)) {}.isIgnored)
-        assertFalse(object : Content(requiredFeatures = setOf(FEATURE_MULTISELECT)) {}.isIgnored)
-        assertFalse(object : Content(requiredFeatures = emptySet()) {}.isIgnored)
+        assertFalse(object : Content(requiredFeatures = setOf(FEATURE_ANIMATION, FEATURE_MULTISELECT)) {}.testIsIgnored)
+        assertFalse(object : Content(requiredFeatures = setOf(FEATURE_ANIMATION)) {}.testIsIgnored)
+        assertFalse(object : Content(requiredFeatures = setOf(FEATURE_MULTISELECT)) {}.testIsIgnored)
+        assertFalse(object : Content(requiredFeatures = emptySet()) {}.testIsIgnored)
     }
 
     @Test
     fun verifyRequiredFeaturesNotSupported() {
         ParserConfig.supportedFeatures = setOf(FEATURE_ANIMATION)
-        assertTrue(object : Content(requiredFeatures = setOf(FEATURE_ANIMATION, FEATURE_MULTISELECT)) {}.isIgnored)
-        assertTrue(object : Content(requiredFeatures = setOf(FEATURE_MULTISELECT)) {}.isIgnored)
-        assertTrue(object : Content(requiredFeatures = setOf("kjlasdf")) {}.isIgnored)
+        assertTrue(object : Content(requiredFeatures = setOf(FEATURE_ANIMATION, FEATURE_MULTISELECT)) {}.testIsIgnored)
+        assertTrue(object : Content(requiredFeatures = setOf(FEATURE_MULTISELECT)) {}.testIsIgnored)
+        assertTrue(object : Content(requiredFeatures = setOf("kjlasdf")) {}.testIsIgnored)
     }
     // endregion required-features
 
@@ -49,28 +49,28 @@ class ContentTest : UsesResources() {
     @Test
     fun verifyRestrictToSupported() {
         ParserConfig.supportedDeviceTypes = setOf(DeviceType.ANDROID)
-        assertFalse(object : Content(Manifest(), restrictTo = DeviceType.ALL) {}.isIgnored)
-        assertFalse(object : Content(Manifest(), restrictTo = DeviceType.SUPPORTED) {}.isIgnored)
-        assertFalse(object : Content(Manifest(), restrictTo = setOf(DeviceType.ANDROID)) {}.isIgnored)
+        assertFalse(object : Content(Manifest(), restrictTo = DeviceType.ALL) {}.testIsIgnored)
+        assertFalse(object : Content(Manifest(), restrictTo = DeviceType.SUPPORTED) {}.testIsIgnored)
+        assertFalse(object : Content(Manifest(), restrictTo = setOf(DeviceType.ANDROID)) {}.testIsIgnored)
     }
 
     @Test
     fun verifyRestrictToNotSupported() {
         ParserConfig.supportedDeviceTypes = setOf(DeviceType.ANDROID)
-        assertTrue(object : Content(Manifest(), restrictTo = setOf(DeviceType.UNKNOWN)) {}.isIgnored)
-        assertTrue(object : Content(Manifest(), restrictTo = setOf(DeviceType.IOS)) {}.isIgnored)
+        assertTrue(object : Content(Manifest(), restrictTo = setOf(DeviceType.UNKNOWN)) {}.testIsIgnored)
+        assertTrue(object : Content(Manifest(), restrictTo = setOf(DeviceType.IOS)) {}.testIsIgnored)
     }
     // endregion restrictTo
 
     // region version
     @Test
     fun verifyVersionSupported() {
-        assertFalse(object : Content(Manifest(), version = SCHEMA_VERSION) {}.isIgnored)
+        assertFalse(object : Content(Manifest(), version = SCHEMA_VERSION) {}.testIsIgnored)
     }
 
     @Test
     fun verifyVersionNotSupported() {
-        assertTrue(object : Content(Manifest(), version = SCHEMA_VERSION + 1) {}.isIgnored)
+        assertTrue(object : Content(Manifest(), version = SCHEMA_VERSION + 1) {}.testIsIgnored)
     }
     // endregion version
 
@@ -78,7 +78,7 @@ class ContentTest : UsesResources() {
     @Test
     fun verifyGoneIfInvalid() {
         with(object : Content(goneIf = "invalid".toExpressionOrNull()) {}) {
-            assertTrue(isIgnored)
+            assertTrue(testIsIgnored)
         }
     }
 
@@ -152,7 +152,7 @@ class ContentTest : UsesResources() {
     @Test
     fun verifyInvisibleIfInvalid() {
         with(object : Content(invisibleIf = "invalid".toExpressionOrNull()) {}) {
-            assertTrue(isIgnored)
+            assertTrue(testIsIgnored)
         }
     }
 

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ImageTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ImageTest.kt
@@ -28,7 +28,7 @@ class ImageTest : UsesResources() {
         ParserConfig.supportedDeviceTypes = setOf(DeviceType.MOBILE)
         val manifest = Manifest(resources = { listOf(Resource(it, "image.png")) })
         val image = Image(manifest, getTestXmlParser("image_restricted.xml"))
-        assertTrue(image.isIgnored)
+        assertTrue(image.testIsIgnored)
     }
 
     @Test
@@ -45,9 +45,9 @@ class ImageTest : UsesResources() {
     @Test
     fun testIsIgnoredMissingResource() {
         val manifest = Manifest(resources = { listOf(Resource(it, "valid.png")) })
-        assertTrue(Image(manifest, resource = null).isIgnored)
-        assertTrue(Image(manifest, resource = "").isIgnored)
-        assertFalse(Image(manifest, resource = "valid.png").isIgnored)
+        assertTrue(Image(manifest, resource = null).testIsIgnored)
+        assertTrue(Image(manifest, resource = "").testIsIgnored)
+        assertFalse(Image(manifest, resource = "valid.png").testIsIgnored)
     }
     // endregion isIgnored
 }

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/LinkTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/LinkTest.kt
@@ -65,17 +65,17 @@ class LinkTest : UsesResources() {
     fun testIsIgnoredClickableState() {
         with(Link()) {
             assertFalse(isClickable)
-            assertTrue(isIgnored)
+            assertTrue(testIsIgnored)
         }
 
         with(Link(events = listOf(FOLLOWUP))) {
             assertTrue(isClickable)
-            assertFalse(isIgnored)
+            assertFalse(testIsIgnored)
         }
 
         with(Link(url = TEST_URL)) {
             assertTrue(isClickable)
-            assertFalse(isIgnored)
+            assertFalse(testIsIgnored)
         }
     }
 }

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/MultiselectTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/MultiselectTest.kt
@@ -70,10 +70,10 @@ class MultiselectTest : UsesResources() {
         val multiselect = Multiselect()
 
         ParserConfig.supportedFeatures = setOf(FEATURE_MULTISELECT)
-        assertFalse(multiselect.isIgnored)
+        assertFalse(multiselect.testIsIgnored)
 
         ParserConfig.supportedFeatures = emptySet()
-        assertTrue(multiselect.isIgnored)
+        assertTrue(multiselect.testIsIgnored)
     }
 
     @Test

--- a/module/state/src/commonTest/kotlin/org/cru/godtools/tool/state/StateTest.kt
+++ b/module/state/src/commonTest/kotlin/org/cru/godtools/tool/state/StateTest.kt
@@ -68,9 +68,9 @@ class StateTest {
 
     @Test
     fun testChangeFlowNoKeys() = runBlockingTest {
-        var i = 0
+        var count = 0
         val channel = Channel<Int>()
-        val flow = state.changeFlow { i++ }
+        val flow = state.changeFlow { count++ }
             .onEach { channel.send(it) }
             .launchIn(this)
 
@@ -86,7 +86,7 @@ class StateTest {
 
         // shut down flow
         flow.cancel()
-        assertEquals(1, i)
+        assertEquals(1, count)
     }
 
     @Test

--- a/module/state/src/commonTest/kotlin/org/cru/godtools/tool/state/StateTest.kt
+++ b/module/state/src/commonTest/kotlin/org/cru/godtools/tool/state/StateTest.kt
@@ -1,5 +1,6 @@
 package org.cru.godtools.tool.state
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.launchIn
@@ -14,6 +15,7 @@ import kotlin.test.assertTrue
 private const val KEY = "key"
 private const val KEY2 = "key2"
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class StateTest {
     private val state = State()
 


### PR DESCRIPTION
- make `isIgnored` internal
- opt-in to the experimental coroutines functionality in a test
- opt-in to ExperimentalCoroutines logic for tests
- rename a var to be more meaningful
