### PR TITLE
GT-1294 Refactor LessonPage logic to extend a shared Page model

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 
 allprojects {
     group = "org.cru.godtools.kotlin"
-    version = "0.3.2-SNAPSHOT"
+    version = "0.4.0-SNAPSHOT"
 
     repositories {
         maven("https://jitpack.io") {

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
@@ -1,10 +1,12 @@
 package org.cru.godtools.tool.model
 
+import io.github.aakira.napier.Napier
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import org.cru.godtools.tool.internal.AndroidColorInt
+import org.cru.godtools.tool.internal.DeprecationException
 import org.cru.godtools.tool.internal.RestrictTo
 import org.cru.godtools.tool.internal.fluidlocale.PlatformLocale
 import org.cru.godtools.tool.internal.fluidlocale.toLocaleOrNull
@@ -13,12 +15,13 @@ import org.cru.godtools.tool.model.ImageScaleType.Companion.toImageScaleTypeOrNu
 import org.cru.godtools.tool.model.Multiselect.Companion.XML_MULTISELECT_OPTION_BACKGROUND_COLOR
 import org.cru.godtools.tool.model.Multiselect.Companion.XML_MULTISELECT_OPTION_SELECTED_COLOR
 import org.cru.godtools.tool.model.Styles.Companion.DEFAULT_TEXT_SCALE
-import org.cru.godtools.tool.model.lesson.DEFAULT_LESSON_CONTROL_COLOR
 import org.cru.godtools.tool.model.lesson.DEFAULT_LESSON_NAV_BAR_COLOR
 import org.cru.godtools.tool.model.lesson.LessonPage
 import org.cru.godtools.tool.model.lesson.XMLNS_LESSON
-import org.cru.godtools.tool.model.lesson.XML_CONTROL_COLOR
+import org.cru.godtools.tool.model.page.DEFAULT_CONTROL_COLOR
 import org.cru.godtools.tool.model.page.Page
+import org.cru.godtools.tool.model.page.XMLNS_PAGE
+import org.cru.godtools.tool.model.page.XML_CONTROL_COLOR
 import org.cru.godtools.tool.model.tips.Tip
 import org.cru.godtools.tool.model.tract.TractPage
 import org.cru.godtools.tool.model.tract.XMLNS_TRACT
@@ -135,7 +138,7 @@ class Manifest : BaseModel, Styles {
     internal val categoryLabelColor get() = _categoryLabelColor ?: textColor
 
     @AndroidColorInt
-    internal val lessonControlColor: PlatformColor
+    internal val pageControlColor: PlatformColor
 
     override val buttonStyle get() = DEFAULT_BUTTON_STYLE
 
@@ -193,8 +196,13 @@ class Manifest : BaseModel, Styles {
 
         _cardBackgroundColor = parser.getAttributeValue(XMLNS_TRACT, XML_CARD_BACKGROUND_COLOR)?.toColorOrNull()
         _categoryLabelColor = parser.getAttributeValue(XML_CATEGORY_LABEL_COLOR)?.toColorOrNull()
-        lessonControlColor =
-            parser.getAttributeValue(XMLNS_LESSON, XML_CONTROL_COLOR)?.toColorOrNull() ?: DEFAULT_LESSON_CONTROL_COLOR
+        val lessonControlColor = parser.getAttributeValue(XMLNS_LESSON, XML_CONTROL_COLOR)?.toColorOrNull()?.also {
+            val message = "Deprecated lesson:control-color defined on tool: $code language: $locale"
+            Napier.e(message, DeprecationException(message), "Manifest")
+        }
+        pageControlColor =
+            parser.getAttributeValue(XMLNS_PAGE, XML_CONTROL_COLOR)?.toColorOrNull() ?: lessonControlColor
+                ?: DEFAULT_CONTROL_COLOR
 
         _multiselectOptionBackgroundColor =
             parser.getAttributeValue(XMLNS_CONTENT, XML_MULTISELECT_OPTION_BACKGROUND_COLOR)?.toColorOrNull()
@@ -242,7 +250,7 @@ class Manifest : BaseModel, Styles {
         backgroundColor: PlatformColor = DEFAULT_BACKGROUND_COLOR,
         cardBackgroundColor: PlatformColor? = null,
         categoryLabelColor: PlatformColor? = null,
-        lessonControlColor: PlatformColor = DEFAULT_LESSON_CONTROL_COLOR,
+        pageControlColor: PlatformColor = DEFAULT_CONTROL_COLOR,
         multiselectOptionSelectedColor: PlatformColor? = null,
         textColor: PlatformColor = DEFAULT_TEXT_COLOR,
         textScale: Double = DEFAULT_TEXT_SCALE,
@@ -269,7 +277,7 @@ class Manifest : BaseModel, Styles {
 
         _cardBackgroundColor = cardBackgroundColor
         _categoryLabelColor = categoryLabelColor
-        this.lessonControlColor = lessonControlColor
+        this.pageControlColor = pageControlColor
 
         _multiselectOptionBackgroundColor = null
         this.multiselectOptionSelectedColor = multiselectOptionSelectedColor

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/lesson/Constants.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/lesson/Constants.kt
@@ -6,11 +6,6 @@ import kotlin.native.concurrent.SharedImmutable
 
 internal const val XMLNS_LESSON = "https://mobile-content-api.cru.org/xmlns/lesson"
 
-internal const val XML_CONTROL_COLOR = "control-color"
-
 @AndroidColorInt
 @SharedImmutable
 internal val DEFAULT_LESSON_NAV_BAR_COLOR = color(0, 0, 0, 0.0)
-@AndroidColorInt
-@SharedImmutable
-internal val DEFAULT_LESSON_CONTROL_COLOR = color(255, 225, 225, 1.0)

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/lesson/LessonPage.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/lesson/LessonPage.kt
@@ -33,7 +33,7 @@ class LessonPage : Page, Parent {
         parser.require(XmlPullParser.START_TAG, XMLNS_LESSON, XML_PAGE)
 
         analyticsEvents = mutableListOf()
-        val content = mutableListOf<Content>()
+        content = mutableListOf()
         parser.parseChildren {
             when (parser.namespace) {
                 XMLNS_ANALYTICS -> when (parser.name) {
@@ -44,7 +44,6 @@ class LessonPage : Page, Parent {
                 }
             }
         }
-        this.content = content
     }
 
     @RestrictTo(RestrictTo.Scope.TESTS)

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/lesson/LessonPage.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/lesson/LessonPage.kt
@@ -6,7 +6,6 @@ import org.cru.godtools.tool.internal.VisibleForTesting
 import org.cru.godtools.tool.model.AnalyticsEvent
 import org.cru.godtools.tool.model.AnalyticsEvent.Companion.parseAnalyticsEvents
 import org.cru.godtools.tool.model.Content
-import org.cru.godtools.tool.model.EventId
 import org.cru.godtools.tool.model.ImageGravity
 import org.cru.godtools.tool.model.ImageScaleType
 import org.cru.godtools.tool.model.Manifest
@@ -14,14 +13,12 @@ import org.cru.godtools.tool.model.Parent
 import org.cru.godtools.tool.model.PlatformColor
 import org.cru.godtools.tool.model.Styles.Companion.DEFAULT_TEXT_SCALE
 import org.cru.godtools.tool.model.XMLNS_ANALYTICS
-import org.cru.godtools.tool.model.XML_LISTENERS
 import org.cru.godtools.tool.model.page.Page
 import org.cru.godtools.tool.model.page.Page.Companion.DEFAULT_BACKGROUND_COLOR
 import org.cru.godtools.tool.model.page.Page.Companion.DEFAULT_BACKGROUND_IMAGE_GRAVITY
 import org.cru.godtools.tool.model.page.Page.Companion.DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE
 import org.cru.godtools.tool.model.parseContent
 import org.cru.godtools.tool.model.toColorOrNull
-import org.cru.godtools.tool.model.toEventIds
 import org.cru.godtools.tool.xml.XmlPullParser
 import org.cru.godtools.tool.xml.parseChildren
 
@@ -37,7 +34,6 @@ class LessonPage : Page, Parent {
     internal val fileName: String?
 
     val isHidden: Boolean
-    val listeners: Set<EventId>
 
     @VisibleForTesting
     override val analyticsEvents: List<AnalyticsEvent>
@@ -59,7 +55,6 @@ class LessonPage : Page, Parent {
         parser.require(XmlPullParser.START_TAG, XMLNS_LESSON, XML_PAGE)
 
         isHidden = parser.getAttributeValue(XML_HIDDEN)?.toBoolean() ?: false
-        listeners = parser.getAttributeValue(XML_LISTENERS)?.toEventIds()?.toSet().orEmpty()
 
         _controlColor = parser.getAttributeValue(XML_CONTROL_COLOR)?.toColorOrNull()
 
@@ -100,7 +95,6 @@ class LessonPage : Page, Parent {
         this.fileName = fileName
 
         isHidden = false
-        listeners = emptySet()
 
         this.analyticsEvents = analyticsEvents
 

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/lesson/LessonPage.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/lesson/LessonPage.kt
@@ -27,12 +27,6 @@ private const val XML_HIDDEN = "hidden"
 private const val XML_CONTENT = "content"
 
 class LessonPage : Page, Parent {
-    val id by lazy { fileName ?: "${manifest.code}-$position" }
-    val position by lazy { manifest.lessonPages.indexOf(this) }
-
-    @VisibleForTesting
-    internal val fileName: String?
-
     val isHidden: Boolean
 
     @VisibleForTesting
@@ -49,9 +43,7 @@ class LessonPage : Page, Parent {
         manifest: Manifest,
         fileName: String?,
         parser: XmlPullParser
-    ) : super(manifest, parser) {
-        this.fileName = fileName
-
+    ) : super(manifest, fileName, parser) {
         parser.require(XmlPullParser.START_TAG, XMLNS_LESSON, XML_PAGE)
 
         isHidden = parser.getAttributeValue(XML_HIDDEN)?.toBoolean() ?: false
@@ -76,7 +68,6 @@ class LessonPage : Page, Parent {
     @RestrictTo(RestrictTo.Scope.TESTS)
     internal constructor(
         manifest: Manifest = Manifest(),
-        fileName: String? = null,
         analyticsEvents: List<AnalyticsEvent> = emptyList(),
         backgroundColor: PlatformColor = DEFAULT_BACKGROUND_COLOR,
         backgroundImage: String? = null,
@@ -92,8 +83,6 @@ class LessonPage : Page, Parent {
         backgroundImageScaleType = backgroundImageScaleType,
         textScale = textScale
     ) {
-        this.fileName = fileName
-
         isHidden = false
 
         this.analyticsEvents = analyticsEvents

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/lesson/LessonPage.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/lesson/LessonPage.kt
@@ -69,4 +69,6 @@ class LessonPage : Page, Parent {
 
         content = emptyList()
     }
+
+    override fun supports(type: Manifest.Type) = type == Manifest.Type.LESSON
 }

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/lesson/LessonPage.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/lesson/LessonPage.kt
@@ -5,37 +5,21 @@ import org.cru.godtools.tool.internal.RestrictTo
 import org.cru.godtools.tool.internal.VisibleForTesting
 import org.cru.godtools.tool.model.AnalyticsEvent
 import org.cru.godtools.tool.model.AnalyticsEvent.Companion.parseAnalyticsEvents
-import org.cru.godtools.tool.model.AnalyticsEvent.Trigger
-import org.cru.godtools.tool.model.BaseModel
 import org.cru.godtools.tool.model.Content
 import org.cru.godtools.tool.model.EventId
-import org.cru.godtools.tool.model.HasAnalyticsEvents
 import org.cru.godtools.tool.model.ImageGravity
-import org.cru.godtools.tool.model.ImageGravity.Companion.toImageGravityOrNull
 import org.cru.godtools.tool.model.ImageScaleType
-import org.cru.godtools.tool.model.ImageScaleType.Companion.toImageScaleTypeOrNull
 import org.cru.godtools.tool.model.Manifest
-import org.cru.godtools.tool.model.Multiselect.Companion.XML_MULTISELECT_OPTION_BACKGROUND_COLOR
-import org.cru.godtools.tool.model.Multiselect.Companion.XML_MULTISELECT_OPTION_SELECTED_COLOR
 import org.cru.godtools.tool.model.Parent
 import org.cru.godtools.tool.model.PlatformColor
-import org.cru.godtools.tool.model.Styles
 import org.cru.godtools.tool.model.Styles.Companion.DEFAULT_TEXT_SCALE
 import org.cru.godtools.tool.model.XMLNS_ANALYTICS
-import org.cru.godtools.tool.model.XMLNS_CONTENT
-import org.cru.godtools.tool.model.XML_BACKGROUND_COLOR
-import org.cru.godtools.tool.model.XML_BACKGROUND_IMAGE
-import org.cru.godtools.tool.model.XML_BACKGROUND_IMAGE_GRAVITY
-import org.cru.godtools.tool.model.XML_BACKGROUND_IMAGE_SCALE_TYPE
 import org.cru.godtools.tool.model.XML_LISTENERS
-import org.cru.godtools.tool.model.XML_TEXT_SCALE
-import org.cru.godtools.tool.model.color
-import org.cru.godtools.tool.model.getResource
-import org.cru.godtools.tool.model.lesson.LessonPage.Companion.DEFAULT_BACKGROUND_COLOR
-import org.cru.godtools.tool.model.lesson.LessonPage.Companion.DEFAULT_BACKGROUND_IMAGE_GRAVITY
-import org.cru.godtools.tool.model.lesson.LessonPage.Companion.DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE
+import org.cru.godtools.tool.model.page.Page
+import org.cru.godtools.tool.model.page.Page.Companion.DEFAULT_BACKGROUND_COLOR
+import org.cru.godtools.tool.model.page.Page.Companion.DEFAULT_BACKGROUND_IMAGE_GRAVITY
+import org.cru.godtools.tool.model.page.Page.Companion.DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE
 import org.cru.godtools.tool.model.parseContent
-import org.cru.godtools.tool.model.textScale
 import org.cru.godtools.tool.model.toColorOrNull
 import org.cru.godtools.tool.model.toEventIds
 import org.cru.godtools.tool.xml.XmlPullParser
@@ -45,17 +29,7 @@ private const val XML_PAGE = "page"
 private const val XML_HIDDEN = "hidden"
 private const val XML_CONTENT = "content"
 
-class LessonPage : BaseModel, Parent, Styles, HasAnalyticsEvents {
-    internal companion object {
-        @AndroidColorInt
-        @VisibleForTesting
-        internal val DEFAULT_BACKGROUND_COLOR = color(0, 0, 0, 0.0)
-        @VisibleForTesting
-        internal val DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE = ImageScaleType.FILL_X
-        @VisibleForTesting
-        internal val DEFAULT_BACKGROUND_IMAGE_GRAVITY = ImageGravity.CENTER
-    }
-
+class LessonPage : Page, Parent {
     val id by lazy { fileName ?: "${manifest.code}-$position" }
     val position by lazy { manifest.lessonPages.indexOf(this) }
 
@@ -66,31 +40,12 @@ class LessonPage : BaseModel, Parent, Styles, HasAnalyticsEvents {
     val listeners: Set<EventId>
 
     @VisibleForTesting
-    internal val analyticsEvents: List<AnalyticsEvent>
-
-    @AndroidColorInt
-    internal val backgroundColor: PlatformColor
-
-    @VisibleForTesting
-    internal val _backgroundImage: String?
-    val backgroundImage get() = getResource(_backgroundImage)
-    internal val backgroundImageGravity: ImageGravity
-    internal val backgroundImageScaleType: ImageScaleType
+    override val analyticsEvents: List<AnalyticsEvent>
 
     @AndroidColorInt
     private val _controlColor: PlatformColor?
     @get:AndroidColorInt
     internal val controlColor get() = _controlColor ?: manifest.lessonControlColor
-
-    private val _multiselectOptionBackgroundColor: PlatformColor?
-    override val multiselectOptionBackgroundColor
-        get() = _multiselectOptionBackgroundColor ?: super.multiselectOptionBackgroundColor
-    private val _multiselectOptionSelectedColor: PlatformColor?
-    override val multiselectOptionSelectedColor
-        get() = _multiselectOptionSelectedColor ?: super.multiselectOptionSelectedColor
-
-    private val _textScale: Double
-    override val textScale get() = _textScale * stylesParent.textScale
 
     override val content: List<Content>
 
@@ -98,7 +53,7 @@ class LessonPage : BaseModel, Parent, Styles, HasAnalyticsEvents {
         manifest: Manifest,
         fileName: String?,
         parser: XmlPullParser
-    ) : super(manifest) {
+    ) : super(manifest, parser) {
         this.fileName = fileName
 
         parser.require(XmlPullParser.START_TAG, XMLNS_LESSON, XML_PAGE)
@@ -106,21 +61,7 @@ class LessonPage : BaseModel, Parent, Styles, HasAnalyticsEvents {
         isHidden = parser.getAttributeValue(XML_HIDDEN)?.toBoolean() ?: false
         listeners = parser.getAttributeValue(XML_LISTENERS)?.toEventIds()?.toSet().orEmpty()
 
-        backgroundColor = parser.getAttributeValue(XML_BACKGROUND_COLOR)?.toColorOrNull() ?: DEFAULT_BACKGROUND_COLOR
-        _backgroundImage = parser.getAttributeValue(XML_BACKGROUND_IMAGE)
-        backgroundImageGravity = parser.getAttributeValue(XML_BACKGROUND_IMAGE_GRAVITY)?.toImageGravityOrNull()
-            ?: DEFAULT_BACKGROUND_IMAGE_GRAVITY
-        backgroundImageScaleType = parser.getAttributeValue(XML_BACKGROUND_IMAGE_SCALE_TYPE)?.toImageScaleTypeOrNull()
-            ?: DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE
-
         _controlColor = parser.getAttributeValue(XML_CONTROL_COLOR)?.toColorOrNull()
-
-        _multiselectOptionBackgroundColor =
-            parser.getAttributeValue(XMLNS_CONTENT, XML_MULTISELECT_OPTION_BACKGROUND_COLOR)?.toColorOrNull()
-        _multiselectOptionSelectedColor =
-            parser.getAttributeValue(XMLNS_CONTENT, XML_MULTISELECT_OPTION_SELECTED_COLOR)?.toColorOrNull()
-
-        _textScale = parser.getAttributeValue(XML_TEXT_SCALE)?.toDoubleOrNull() ?: DEFAULT_TEXT_SCALE
 
         analyticsEvents = mutableListOf()
         val content = mutableListOf<Content>()
@@ -148,7 +89,14 @@ class LessonPage : BaseModel, Parent, Styles, HasAnalyticsEvents {
         backgroundImageScaleType: ImageScaleType = DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE,
         controlColor: PlatformColor? = null,
         textScale: Double = DEFAULT_TEXT_SCALE
-    ) : super(manifest) {
+    ) : super(
+        manifest,
+        backgroundColor = backgroundColor,
+        backgroundImage = backgroundImage,
+        backgroundImageGravity = backgroundImageGravity,
+        backgroundImageScaleType = backgroundImageScaleType,
+        textScale = textScale
+    ) {
         this.fileName = fileName
 
         isHidden = false
@@ -156,25 +104,9 @@ class LessonPage : BaseModel, Parent, Styles, HasAnalyticsEvents {
 
         this.analyticsEvents = analyticsEvents
 
-        this.backgroundColor = backgroundColor
-        _backgroundImage = backgroundImage
-        this.backgroundImageGravity = backgroundImageGravity
-        this.backgroundImageScaleType = backgroundImageScaleType
-
         _controlColor = controlColor
 
-        _multiselectOptionBackgroundColor = null
-        _multiselectOptionSelectedColor = null
-
-        _textScale = textScale
-
         content = emptyList()
-    }
-
-    override fun getAnalyticsEvents(type: Trigger) = when (type) {
-        Trigger.VISIBLE -> analyticsEvents.filter { it.isTriggerType(Trigger.VISIBLE, Trigger.DEFAULT) }
-        Trigger.HIDDEN -> analyticsEvents.filter { it.isTriggerType(Trigger.HIDDEN) }
-        else -> error("Analytics trigger type $type is not currently supported on Heroes")
     }
 }
 

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/lesson/LessonPage.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/lesson/LessonPage.kt
@@ -1,6 +1,5 @@
 package org.cru.godtools.tool.model.lesson
 
-import org.cru.godtools.tool.internal.AndroidColorInt
 import org.cru.godtools.tool.internal.RestrictTo
 import org.cru.godtools.tool.internal.VisibleForTesting
 import org.cru.godtools.tool.model.AnalyticsEvent
@@ -13,11 +12,7 @@ import org.cru.godtools.tool.model.Parent
 import org.cru.godtools.tool.model.PlatformColor
 import org.cru.godtools.tool.model.Styles.Companion.DEFAULT_TEXT_SCALE
 import org.cru.godtools.tool.model.XMLNS_ANALYTICS
-import org.cru.godtools.tool.model.page.DEFAULT_CONTROL_COLOR
 import org.cru.godtools.tool.model.page.Page
-import org.cru.godtools.tool.model.page.Page.Companion.DEFAULT_BACKGROUND_COLOR
-import org.cru.godtools.tool.model.page.Page.Companion.DEFAULT_BACKGROUND_IMAGE_GRAVITY
-import org.cru.godtools.tool.model.page.Page.Companion.DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE
 import org.cru.godtools.tool.model.parseContent
 import org.cru.godtools.tool.xml.XmlPullParser
 import org.cru.godtools.tool.xml.parseChildren
@@ -84,11 +79,3 @@ class LessonPage : Page, Parent {
         content = emptyList()
     }
 }
-
-@get:AndroidColorInt
-val LessonPage?.backgroundColor get() = this?.backgroundColor ?: DEFAULT_BACKGROUND_COLOR
-val LessonPage?.backgroundImageScaleType get() = this?.backgroundImageScaleType ?: DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE
-val LessonPage?.backgroundImageGravity get() = this?.backgroundImageGravity ?: DEFAULT_BACKGROUND_IMAGE_GRAVITY
-
-@get:AndroidColorInt
-val LessonPage?.controlColor get() = this?.controlColor ?: DEFAULT_CONTROL_COLOR

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/lesson/LessonPage.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/lesson/LessonPage.kt
@@ -13,10 +13,12 @@ import org.cru.godtools.tool.model.Parent
 import org.cru.godtools.tool.model.PlatformColor
 import org.cru.godtools.tool.model.Styles.Companion.DEFAULT_TEXT_SCALE
 import org.cru.godtools.tool.model.XMLNS_ANALYTICS
+import org.cru.godtools.tool.model.page.DEFAULT_CONTROL_COLOR
 import org.cru.godtools.tool.model.page.Page
 import org.cru.godtools.tool.model.page.Page.Companion.DEFAULT_BACKGROUND_COLOR
 import org.cru.godtools.tool.model.page.Page.Companion.DEFAULT_BACKGROUND_IMAGE_GRAVITY
 import org.cru.godtools.tool.model.page.Page.Companion.DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE
+import org.cru.godtools.tool.model.page.XML_CONTROL_COLOR
 import org.cru.godtools.tool.model.parseContent
 import org.cru.godtools.tool.model.toColorOrNull
 import org.cru.godtools.tool.xml.XmlPullParser
@@ -35,7 +37,7 @@ class LessonPage : Page, Parent {
     @AndroidColorInt
     private val _controlColor: PlatformColor?
     @get:AndroidColorInt
-    internal val controlColor get() = _controlColor ?: manifest.lessonControlColor
+    internal val controlColor get() = _controlColor ?: manifest.pageControlColor
 
     override val content: List<Content>
 
@@ -99,4 +101,4 @@ val LessonPage?.backgroundImageScaleType get() = this?.backgroundImageScaleType 
 val LessonPage?.backgroundImageGravity get() = this?.backgroundImageGravity ?: DEFAULT_BACKGROUND_IMAGE_GRAVITY
 
 @get:AndroidColorInt
-val LessonPage?.controlColor get() = this?.controlColor ?: DEFAULT_LESSON_CONTROL_COLOR
+val LessonPage?.controlColor get() = this?.controlColor ?: DEFAULT_CONTROL_COLOR

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/lesson/LessonPage.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/lesson/LessonPage.kt
@@ -17,13 +17,9 @@ import org.cru.godtools.tool.model.parseContent
 import org.cru.godtools.tool.xml.XmlPullParser
 import org.cru.godtools.tool.xml.parseChildren
 
-private const val XML_PAGE = "page"
-private const val XML_HIDDEN = "hidden"
 private const val XML_CONTENT = "content"
 
 class LessonPage : Page, Parent {
-    val isHidden: Boolean
-
     @VisibleForTesting
     override val analyticsEvents: List<AnalyticsEvent>
 
@@ -35,8 +31,6 @@ class LessonPage : Page, Parent {
         parser: XmlPullParser
     ) : super(manifest, fileName, parser) {
         parser.require(XmlPullParser.START_TAG, XMLNS_LESSON, XML_PAGE)
-
-        isHidden = parser.getAttributeValue(XML_HIDDEN)?.toBoolean() ?: false
 
         analyticsEvents = mutableListOf()
         val content = mutableListOf<Content>()
@@ -72,8 +66,6 @@ class LessonPage : Page, Parent {
         controlColor = controlColor,
         textScale = textScale
     ) {
-        isHidden = false
-
         this.analyticsEvents = analyticsEvents
 
         content = emptyList()

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/lesson/LessonPage.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/lesson/LessonPage.kt
@@ -18,9 +18,7 @@ import org.cru.godtools.tool.model.page.Page
 import org.cru.godtools.tool.model.page.Page.Companion.DEFAULT_BACKGROUND_COLOR
 import org.cru.godtools.tool.model.page.Page.Companion.DEFAULT_BACKGROUND_IMAGE_GRAVITY
 import org.cru.godtools.tool.model.page.Page.Companion.DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE
-import org.cru.godtools.tool.model.page.XML_CONTROL_COLOR
 import org.cru.godtools.tool.model.parseContent
-import org.cru.godtools.tool.model.toColorOrNull
 import org.cru.godtools.tool.xml.XmlPullParser
 import org.cru.godtools.tool.xml.parseChildren
 
@@ -34,11 +32,6 @@ class LessonPage : Page, Parent {
     @VisibleForTesting
     override val analyticsEvents: List<AnalyticsEvent>
 
-    @AndroidColorInt
-    private val _controlColor: PlatformColor?
-    @get:AndroidColorInt
-    internal val controlColor get() = _controlColor ?: manifest.pageControlColor
-
     override val content: List<Content>
 
     internal constructor(
@@ -49,8 +42,6 @@ class LessonPage : Page, Parent {
         parser.require(XmlPullParser.START_TAG, XMLNS_LESSON, XML_PAGE)
 
         isHidden = parser.getAttributeValue(XML_HIDDEN)?.toBoolean() ?: false
-
-        _controlColor = parser.getAttributeValue(XML_CONTROL_COLOR)?.toColorOrNull()
 
         analyticsEvents = mutableListOf()
         val content = mutableListOf<Content>()
@@ -83,13 +74,12 @@ class LessonPage : Page, Parent {
         backgroundImage = backgroundImage,
         backgroundImageGravity = backgroundImageGravity,
         backgroundImageScaleType = backgroundImageScaleType,
+        controlColor = controlColor,
         textScale = textScale
     ) {
         isHidden = false
 
         this.analyticsEvents = analyticsEvents
-
-        _controlColor = controlColor
 
         content = emptyList()
     }

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/page/Constants.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/page/Constants.kt
@@ -1,4 +1,14 @@
 package org.cru.godtools.tool.model.page
 
+import org.cru.godtools.tool.internal.AndroidColorInt
+import org.cru.godtools.tool.model.color
+import kotlin.native.concurrent.SharedImmutable
+
 internal const val XMLNS_PAGE = "https://mobile-content-api.cru.org/xmlns/page"
 internal const val XMLNS_XSI = "http://www.w3.org/2001/XMLSchema-instance"
+
+internal const val XML_CONTROL_COLOR = "control-color"
+
+@AndroidColorInt
+@SharedImmutable
+internal val DEFAULT_CONTROL_COLOR = color(225, 225, 225, 1.0)

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/page/Constants.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/page/Constants.kt
@@ -1,0 +1,4 @@
+package org.cru.godtools.tool.model.page
+
+internal const val XMLNS_PAGE = "https://mobile-content-api.cru.org/xmlns/page"
+internal const val XMLNS_XSI = "http://www.w3.org/2001/XMLSchema-instance"

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/page/Page.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/page/Page.kt
@@ -38,7 +38,6 @@ import org.cru.godtools.tool.model.textScale
 import org.cru.godtools.tool.model.toColorOrNull
 import org.cru.godtools.tool.model.toEventIds
 import org.cru.godtools.tool.xml.XmlPullParser
-import org.cru.godtools.tool.xml.XmlPullParserException
 
 private const val XML_TYPE = "type"
 private const val XML_ID = "id"
@@ -70,8 +69,12 @@ abstract class Page : BaseModel, Styles, HasAnalyticsEvents {
                         }
                     }
                 }
-                else -> throw XmlPullParserException("Unrecognized page namespace: ${parser.namespace}")
-            }
+                else -> {
+                    val message = "Unrecognized page namespace: ${parser.namespace}"
+                    Napier.e(message, UnsupportedOperationException(message), "Page")
+                    null
+                }
+            }?.takeIf { it.supports(manifest.type) }
         }
     }
 
@@ -170,6 +173,8 @@ abstract class Page : BaseModel, Styles, HasAnalyticsEvents {
 
         _textScale = textScale
     }
+
+    internal abstract fun supports(type: Manifest.Type): Boolean
 
     // region HasAnalyticsEvents
     @VisibleForTesting

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/page/Page.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/page/Page.kt
@@ -7,6 +7,7 @@ import org.cru.godtools.tool.internal.VisibleForTesting
 import org.cru.godtools.tool.model.AnalyticsEvent
 import org.cru.godtools.tool.model.AnalyticsEvent.Trigger
 import org.cru.godtools.tool.model.BaseModel
+import org.cru.godtools.tool.model.EventId
 import org.cru.godtools.tool.model.HasAnalyticsEvents
 import org.cru.godtools.tool.model.ImageGravity
 import org.cru.godtools.tool.model.ImageGravity.Companion.toImageGravityOrNull
@@ -23,6 +24,8 @@ import org.cru.godtools.tool.model.XML_BACKGROUND_COLOR
 import org.cru.godtools.tool.model.XML_BACKGROUND_IMAGE
 import org.cru.godtools.tool.model.XML_BACKGROUND_IMAGE_GRAVITY
 import org.cru.godtools.tool.model.XML_BACKGROUND_IMAGE_SCALE_TYPE
+import org.cru.godtools.tool.model.XML_DISMISS_LISTENERS
+import org.cru.godtools.tool.model.XML_LISTENERS
 import org.cru.godtools.tool.model.XML_TEXT_SCALE
 import org.cru.godtools.tool.model.color
 import org.cru.godtools.tool.model.getResource
@@ -30,6 +33,7 @@ import org.cru.godtools.tool.model.lesson.LessonPage
 import org.cru.godtools.tool.model.lesson.XMLNS_LESSON
 import org.cru.godtools.tool.model.textScale
 import org.cru.godtools.tool.model.toColorOrNull
+import org.cru.godtools.tool.model.toEventIds
 import org.cru.godtools.tool.xml.XmlPullParser
 import org.cru.godtools.tool.xml.XmlPullParserException
 
@@ -65,6 +69,9 @@ abstract class Page : BaseModel, Styles, HasAnalyticsEvents {
         }
     }
 
+    val listeners: Set<EventId>
+    val dismissListeners: Set<EventId>
+
     @AndroidColorInt
     internal val backgroundColor: PlatformColor
 
@@ -86,6 +93,9 @@ abstract class Page : BaseModel, Styles, HasAnalyticsEvents {
 
     internal constructor(manifest: Manifest, parser: XmlPullParser) : super(manifest) {
         parser.require(XmlPullParser.START_TAG, null, XML_PAGE)
+
+        listeners = parser.getAttributeValue(XML_LISTENERS).toEventIds().toSet()
+        dismissListeners = parser.getAttributeValue(XML_DISMISS_LISTENERS).toEventIds().toSet()
 
         backgroundColor =
             parser.getAttributeValue(XML_BACKGROUND_COLOR)?.toColorOrNull() ?: DEFAULT_BACKGROUND_COLOR
@@ -112,6 +122,9 @@ abstract class Page : BaseModel, Styles, HasAnalyticsEvents {
         backgroundImageScaleType: ImageScaleType = DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE,
         textScale: Double = DEFAULT_TEXT_SCALE
     ) : super(manifest) {
+        listeners = emptySet()
+        dismissListeners = emptySet()
+
         this.backgroundColor = backgroundColor
         _backgroundImage = backgroundImage
         this.backgroundImageGravity = backgroundImageGravity

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/page/Page.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/page/Page.kt
@@ -39,6 +39,7 @@ import org.cru.godtools.tool.xml.XmlPullParserException
 
 private const val XML_PAGE = "page"
 private const val XML_TYPE = "type"
+private const val XML_ID = "id"
 
 abstract class Page : BaseModel, Styles, HasAnalyticsEvents {
     internal companion object {
@@ -69,6 +70,13 @@ abstract class Page : BaseModel, Styles, HasAnalyticsEvents {
         }
     }
 
+    val id by lazy { _id ?: fileName ?: "${manifest.code}-$position" }
+    val position by lazy { manifest.pages.indexOf(this) }
+
+    private val _id: String?
+    @VisibleForTesting
+    internal val fileName: String?
+
     val listeners: Set<EventId>
     val dismissListeners: Set<EventId>
 
@@ -91,8 +99,11 @@ abstract class Page : BaseModel, Styles, HasAnalyticsEvents {
     private val _textScale: Double
     override val textScale get() = _textScale * stylesParent.textScale
 
-    internal constructor(manifest: Manifest, parser: XmlPullParser) : super(manifest) {
+    internal constructor(manifest: Manifest, fileName: String?, parser: XmlPullParser) : super(manifest) {
         parser.require(XmlPullParser.START_TAG, null, XML_PAGE)
+
+        _id = parser.getAttributeValue(XML_ID)
+        this.fileName = fileName
 
         listeners = parser.getAttributeValue(XML_LISTENERS).toEventIds().toSet()
         dismissListeners = parser.getAttributeValue(XML_DISMISS_LISTENERS).toEventIds().toSet()
@@ -122,6 +133,9 @@ abstract class Page : BaseModel, Styles, HasAnalyticsEvents {
         backgroundImageScaleType: ImageScaleType = DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE,
         textScale: Double = DEFAULT_TEXT_SCALE
     ) : super(manifest) {
+        _id = null
+        fileName = null
+
         listeners = emptySet()
         dismissListeners = emptySet()
 

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/page/Page.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/page/Page.kt
@@ -40,12 +40,14 @@ import org.cru.godtools.tool.model.toEventIds
 import org.cru.godtools.tool.xml.XmlPullParser
 import org.cru.godtools.tool.xml.XmlPullParserException
 
-private const val XML_PAGE = "page"
 private const val XML_TYPE = "type"
 private const val XML_ID = "id"
+private const val XML_HIDDEN = "hidden"
 
 abstract class Page : BaseModel, Styles, HasAnalyticsEvents {
     internal companion object {
+        internal const val XML_PAGE = "page"
+
         @AndroidColorInt
         @VisibleForTesting
         internal val DEFAULT_BACKGROUND_COLOR = color(0, 0, 0, 0.0)
@@ -80,6 +82,8 @@ abstract class Page : BaseModel, Styles, HasAnalyticsEvents {
     @VisibleForTesting
     internal val fileName: String?
 
+    val isHidden: Boolean
+
     val listeners: Set<EventId>
     val dismissListeners: Set<EventId>
 
@@ -113,6 +117,8 @@ abstract class Page : BaseModel, Styles, HasAnalyticsEvents {
         _id = parser.getAttributeValue(XML_ID)
         this.fileName = fileName
 
+        isHidden = parser.getAttributeValue(XML_HIDDEN)?.toBoolean() ?: false
+
         listeners = parser.getAttributeValue(XML_LISTENERS).toEventIds().toSet()
         dismissListeners = parser.getAttributeValue(XML_DISMISS_LISTENERS).toEventIds().toSet()
 
@@ -136,7 +142,7 @@ abstract class Page : BaseModel, Styles, HasAnalyticsEvents {
 
     @RestrictTo(RestrictTo.Scope.SUBCLASSES, RestrictTo.Scope.TESTS)
     internal constructor(
-        manifest: Manifest,
+        manifest: Manifest = Manifest(),
         backgroundColor: PlatformColor = DEFAULT_BACKGROUND_COLOR,
         backgroundImage: String? = null,
         backgroundImageGravity: ImageGravity = DEFAULT_BACKGROUND_IMAGE_GRAVITY,
@@ -146,6 +152,8 @@ abstract class Page : BaseModel, Styles, HasAnalyticsEvents {
     ) : super(manifest) {
         _id = null
         fileName = null
+
+        isHidden = false
 
         listeners = emptySet()
         dismissListeners = emptySet()

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/page/Page.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/page/Page.kt
@@ -89,6 +89,11 @@ abstract class Page : BaseModel, Styles, HasAnalyticsEvents {
     internal val backgroundImageGravity: ImageGravity
     internal val backgroundImageScaleType: ImageScaleType
 
+    @AndroidColorInt
+    private val _controlColor: PlatformColor?
+    @get:AndroidColorInt
+    internal val controlColor get() = _controlColor ?: manifest.pageControlColor
+
     private val _multiselectOptionBackgroundColor: PlatformColor?
     override val multiselectOptionBackgroundColor
         get() = _multiselectOptionBackgroundColor ?: super.multiselectOptionBackgroundColor
@@ -116,6 +121,8 @@ abstract class Page : BaseModel, Styles, HasAnalyticsEvents {
         backgroundImageScaleType = parser.getAttributeValue(XML_BACKGROUND_IMAGE_SCALE_TYPE)?.toImageScaleTypeOrNull()
             ?: DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE
 
+        _controlColor = parser.getAttributeValue(XML_CONTROL_COLOR)?.toColorOrNull()
+
         _multiselectOptionBackgroundColor =
             parser.getAttributeValue(XMLNS_CONTENT, XML_MULTISELECT_OPTION_BACKGROUND_COLOR)?.toColorOrNull()
         _multiselectOptionSelectedColor =
@@ -131,6 +138,7 @@ abstract class Page : BaseModel, Styles, HasAnalyticsEvents {
         backgroundImage: String? = null,
         backgroundImageGravity: ImageGravity = DEFAULT_BACKGROUND_IMAGE_GRAVITY,
         backgroundImageScaleType: ImageScaleType = DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE,
+        controlColor: PlatformColor? = null,
         textScale: Double = DEFAULT_TEXT_SCALE
     ) : super(manifest) {
         _id = null
@@ -143,6 +151,8 @@ abstract class Page : BaseModel, Styles, HasAnalyticsEvents {
         _backgroundImage = backgroundImage
         this.backgroundImageGravity = backgroundImageGravity
         this.backgroundImageScaleType = backgroundImageScaleType
+
+        _controlColor = controlColor
 
         _multiselectOptionBackgroundColor = null
         _multiselectOptionSelectedColor = null

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/page/Page.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/page/Page.kt
@@ -1,0 +1,136 @@
+package org.cru.godtools.tool.model.page
+
+import io.github.aakira.napier.Napier
+import org.cru.godtools.tool.internal.AndroidColorInt
+import org.cru.godtools.tool.internal.RestrictTo
+import org.cru.godtools.tool.internal.VisibleForTesting
+import org.cru.godtools.tool.model.AnalyticsEvent
+import org.cru.godtools.tool.model.AnalyticsEvent.Trigger
+import org.cru.godtools.tool.model.BaseModel
+import org.cru.godtools.tool.model.HasAnalyticsEvents
+import org.cru.godtools.tool.model.ImageGravity
+import org.cru.godtools.tool.model.ImageGravity.Companion.toImageGravityOrNull
+import org.cru.godtools.tool.model.ImageScaleType
+import org.cru.godtools.tool.model.ImageScaleType.Companion.toImageScaleTypeOrNull
+import org.cru.godtools.tool.model.Manifest
+import org.cru.godtools.tool.model.Multiselect.Companion.XML_MULTISELECT_OPTION_BACKGROUND_COLOR
+import org.cru.godtools.tool.model.Multiselect.Companion.XML_MULTISELECT_OPTION_SELECTED_COLOR
+import org.cru.godtools.tool.model.PlatformColor
+import org.cru.godtools.tool.model.Styles
+import org.cru.godtools.tool.model.Styles.Companion.DEFAULT_TEXT_SCALE
+import org.cru.godtools.tool.model.XMLNS_CONTENT
+import org.cru.godtools.tool.model.XML_BACKGROUND_COLOR
+import org.cru.godtools.tool.model.XML_BACKGROUND_IMAGE
+import org.cru.godtools.tool.model.XML_BACKGROUND_IMAGE_GRAVITY
+import org.cru.godtools.tool.model.XML_BACKGROUND_IMAGE_SCALE_TYPE
+import org.cru.godtools.tool.model.XML_TEXT_SCALE
+import org.cru.godtools.tool.model.color
+import org.cru.godtools.tool.model.getResource
+import org.cru.godtools.tool.model.lesson.LessonPage
+import org.cru.godtools.tool.model.lesson.XMLNS_LESSON
+import org.cru.godtools.tool.model.textScale
+import org.cru.godtools.tool.model.toColorOrNull
+import org.cru.godtools.tool.xml.XmlPullParser
+import org.cru.godtools.tool.xml.XmlPullParserException
+
+private const val XML_PAGE = "page"
+private const val XML_TYPE = "type"
+
+abstract class Page : BaseModel, Styles, HasAnalyticsEvents {
+    internal companion object {
+        @AndroidColorInt
+        @VisibleForTesting
+        internal val DEFAULT_BACKGROUND_COLOR = color(0, 0, 0, 0.0)
+        @VisibleForTesting
+        internal val DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE = ImageScaleType.FILL_X
+        @VisibleForTesting
+        internal val DEFAULT_BACKGROUND_IMAGE_GRAVITY = ImageGravity.CENTER
+
+        fun parse(manifest: Manifest, fileName: String?, parser: XmlPullParser): Page? {
+            parser.require(XmlPullParser.START_TAG, null, XML_PAGE)
+
+            return when (parser.namespace) {
+                XMLNS_LESSON -> LessonPage(manifest, fileName, parser)
+                XMLNS_PAGE -> {
+                    when (val type = parser.getAttributeValue(XMLNS_XSI, XML_TYPE)) {
+                        else -> {
+                            val message = "Unrecognized page type: <${parser.namespace}:${parser.name} type=$type>"
+                            Napier.e(message, UnsupportedOperationException(message), "Page")
+                            null
+                        }
+                    }
+                }
+                else -> throw XmlPullParserException("Unrecognized page namespace: ${parser.namespace}")
+            }
+        }
+    }
+
+    @AndroidColorInt
+    internal val backgroundColor: PlatformColor
+
+    @VisibleForTesting
+    internal val _backgroundImage: String?
+    val backgroundImage get() = getResource(_backgroundImage)
+    internal val backgroundImageGravity: ImageGravity
+    internal val backgroundImageScaleType: ImageScaleType
+
+    private val _multiselectOptionBackgroundColor: PlatformColor?
+    override val multiselectOptionBackgroundColor
+        get() = _multiselectOptionBackgroundColor ?: super.multiselectOptionBackgroundColor
+    private val _multiselectOptionSelectedColor: PlatformColor?
+    override val multiselectOptionSelectedColor
+        get() = _multiselectOptionSelectedColor ?: super.multiselectOptionSelectedColor
+
+    private val _textScale: Double
+    override val textScale get() = _textScale * stylesParent.textScale
+
+    internal constructor(manifest: Manifest, parser: XmlPullParser) : super(manifest) {
+        parser.require(XmlPullParser.START_TAG, null, XML_PAGE)
+
+        backgroundColor =
+            parser.getAttributeValue(XML_BACKGROUND_COLOR)?.toColorOrNull() ?: DEFAULT_BACKGROUND_COLOR
+        _backgroundImage = parser.getAttributeValue(XML_BACKGROUND_IMAGE)
+        backgroundImageGravity = parser.getAttributeValue(XML_BACKGROUND_IMAGE_GRAVITY)?.toImageGravityOrNull()
+            ?: DEFAULT_BACKGROUND_IMAGE_GRAVITY
+        backgroundImageScaleType = parser.getAttributeValue(XML_BACKGROUND_IMAGE_SCALE_TYPE)?.toImageScaleTypeOrNull()
+            ?: DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE
+
+        _multiselectOptionBackgroundColor =
+            parser.getAttributeValue(XMLNS_CONTENT, XML_MULTISELECT_OPTION_BACKGROUND_COLOR)?.toColorOrNull()
+        _multiselectOptionSelectedColor =
+            parser.getAttributeValue(XMLNS_CONTENT, XML_MULTISELECT_OPTION_SELECTED_COLOR)?.toColorOrNull()
+
+        _textScale = parser.getAttributeValue(XML_TEXT_SCALE)?.toDoubleOrNull() ?: DEFAULT_TEXT_SCALE
+    }
+
+    @RestrictTo(RestrictTo.Scope.SUBCLASSES, RestrictTo.Scope.TESTS)
+    internal constructor(
+        manifest: Manifest,
+        backgroundColor: PlatformColor = DEFAULT_BACKGROUND_COLOR,
+        backgroundImage: String? = null,
+        backgroundImageGravity: ImageGravity = DEFAULT_BACKGROUND_IMAGE_GRAVITY,
+        backgroundImageScaleType: ImageScaleType = DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE,
+        textScale: Double = DEFAULT_TEXT_SCALE
+    ) : super(manifest) {
+        this.backgroundColor = backgroundColor
+        _backgroundImage = backgroundImage
+        this.backgroundImageGravity = backgroundImageGravity
+        this.backgroundImageScaleType = backgroundImageScaleType
+
+        _multiselectOptionBackgroundColor = null
+        _multiselectOptionSelectedColor = null
+
+        _textScale = textScale
+    }
+
+    // region HasAnalyticsEvents
+    @VisibleForTesting
+    internal abstract val analyticsEvents: List<AnalyticsEvent>
+
+    override fun getAnalyticsEvents(type: Trigger) = when (type) {
+        Trigger.VISIBLE -> analyticsEvents.filter { it.isTriggerType(Trigger.VISIBLE, Trigger.DEFAULT) }
+        Trigger.HIDDEN -> analyticsEvents.filter { it.isTriggerType(Trigger.HIDDEN) }
+        else -> error("Analytics trigger type $type is not currently supported on Pages")
+    }
+    // endregion HasAnalyticsEvents
+}

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/page/Page.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/page/Page.kt
@@ -31,6 +31,9 @@ import org.cru.godtools.tool.model.color
 import org.cru.godtools.tool.model.getResource
 import org.cru.godtools.tool.model.lesson.LessonPage
 import org.cru.godtools.tool.model.lesson.XMLNS_LESSON
+import org.cru.godtools.tool.model.page.Page.Companion.DEFAULT_BACKGROUND_COLOR
+import org.cru.godtools.tool.model.page.Page.Companion.DEFAULT_BACKGROUND_IMAGE_GRAVITY
+import org.cru.godtools.tool.model.page.Page.Companion.DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE
 import org.cru.godtools.tool.model.textScale
 import org.cru.godtools.tool.model.toColorOrNull
 import org.cru.godtools.tool.model.toEventIds
@@ -171,3 +174,11 @@ abstract class Page : BaseModel, Styles, HasAnalyticsEvents {
     }
     // endregion HasAnalyticsEvents
 }
+
+@get:AndroidColorInt
+val Page?.backgroundColor get() = this?.backgroundColor ?: DEFAULT_BACKGROUND_COLOR
+val Page?.backgroundImageScaleType get() = this?.backgroundImageScaleType ?: DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE
+val Page?.backgroundImageGravity get() = this?.backgroundImageGravity ?: DEFAULT_BACKGROUND_IMAGE_GRAVITY
+
+@get:AndroidColorInt
+val Page?.controlColor get() = this?.controlColor ?: DEFAULT_CONTROL_COLOR

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ManifestTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ManifestTest.kt
@@ -7,8 +7,8 @@ import org.cru.godtools.tool.internal.UsesResources
 import org.cru.godtools.tool.internal.fluidlocale.toCommon
 import org.cru.godtools.tool.internal.runBlockingTest
 import org.cru.godtools.tool.model.Styles.Companion.DEFAULT_TEXT_SCALE
-import org.cru.godtools.tool.model.lesson.DEFAULT_LESSON_CONTROL_COLOR
 import org.cru.godtools.tool.model.lesson.DEFAULT_LESSON_NAV_BAR_COLOR
+import org.cru.godtools.tool.model.page.DEFAULT_CONTROL_COLOR
 import org.cru.godtools.tool.model.tract.TractPage
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -37,7 +37,7 @@ class ManifestTest : UsesResources() {
 
         assertEquals(manifest.backgroundColor, manifest.cardBackgroundColor)
         assertEquals(manifest.textColor, manifest.categoryLabelColor)
-        assertEquals(DEFAULT_LESSON_CONTROL_COLOR, manifest.lessonControlColor)
+        assertEquals(DEFAULT_CONTROL_COLOR, manifest.pageControlColor)
 
         assertEquals(manifest.backgroundColor, manifest.multiselectOptionBackgroundColor)
         assertNull(manifest.multiselectOptionSelectedColor)
@@ -77,7 +77,7 @@ class ManifestTest : UsesResources() {
         assertEquals("lesson1", manifest.code)
         assertEquals(Locale.forLanguage("ar"), manifest.locale?.toCommon())
         assertEquals(Manifest.Type.LESSON, manifest.type)
-        assertEquals(TestColors.RED, manifest.lessonControlColor)
+        assertEquals(TestColors.RED, manifest.pageControlColor)
         assertEquals(EventId.parse("dismiss_event").toSet(), manifest.dismissListeners)
 
         assertEquals(TestColors.RED, manifest.multiselectOptionBackgroundColor)

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ManifestTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ManifestTest.kt
@@ -45,6 +45,7 @@ class ManifestTest : UsesResources() {
         assertEquals(Manifest.DEFAULT_TEXT_COLOR, manifest.textColor)
         assertEquals(DEFAULT_TEXT_SCALE, manifest.textScale, 0.0001)
         assertEquals(0, manifest.aemImports.size)
+        assertTrue(manifest.pages.isEmpty())
         assertTrue(manifest.lessonPages.isEmpty())
         assertTrue(manifest.tractPages.isEmpty())
         assertEquals(0, manifest.resources.size)
@@ -85,6 +86,8 @@ class ManifestTest : UsesResources() {
         assertTrue(manifest.tractPages.isEmpty())
         assertEquals(1, manifest.lessonPages.size)
         assertEquals("page0.xml", manifest.lessonPages[0].fileName)
+        assertEquals(1, manifest.pages.size)
+        assertEquals("page0.xml", manifest.pages[0].fileName)
     }
 
     @Test
@@ -98,6 +101,7 @@ class ManifestTest : UsesResources() {
         assertEquals(color(255, 0, 255, 1.0), manifest.navBarControlColor)
         assertEquals(1.2345, manifest.textScale, 0.00001)
         assertTrue(manifest.lessonPages.isEmpty())
+        assertTrue(manifest.pages.isEmpty())
         assertEquals(2, manifest.tractPages.size)
         assertEquals("page0.xml", manifest.tractPages[0].fileName)
         assertEquals(0, manifest.tractPages[0].position)

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ManifestTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ManifestTest.kt
@@ -88,6 +88,7 @@ class ManifestTest : UsesResources() {
         assertEquals("page0.xml", manifest.lessonPages[0].fileName)
         assertEquals(1, manifest.pages.size)
         assertEquals("page0.xml", manifest.pages[0].fileName)
+        assertEquals("page_defaults", manifest.pages[0].id)
     }
 
     @Test

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/lesson/LessonPageTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/lesson/LessonPageTest.kt
@@ -16,6 +16,10 @@ import org.cru.godtools.tool.model.page.DEFAULT_CONTROL_COLOR
 import org.cru.godtools.tool.model.page.Page.Companion.DEFAULT_BACKGROUND_COLOR
 import org.cru.godtools.tool.model.page.Page.Companion.DEFAULT_BACKGROUND_IMAGE_GRAVITY
 import org.cru.godtools.tool.model.page.Page.Companion.DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE
+import org.cru.godtools.tool.model.page.backgroundColor
+import org.cru.godtools.tool.model.page.backgroundImageGravity
+import org.cru.godtools.tool.model.page.backgroundImageScaleType
+import org.cru.godtools.tool.model.page.controlColor
 import org.cru.godtools.tool.model.toEventIds
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/lesson/LessonPageTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/lesson/LessonPageTest.kt
@@ -12,6 +12,7 @@ import org.cru.godtools.tool.model.Styles.Companion.DEFAULT_TEXT_SCALE
 import org.cru.godtools.tool.model.TEST_GRAVITY
 import org.cru.godtools.tool.model.TestColors
 import org.cru.godtools.tool.model.Text
+import org.cru.godtools.tool.model.page.DEFAULT_CONTROL_COLOR
 import org.cru.godtools.tool.model.page.Page.Companion.DEFAULT_BACKGROUND_COLOR
 import org.cru.godtools.tool.model.page.Page.Companion.DEFAULT_BACKGROUND_IMAGE_GRAVITY
 import org.cru.godtools.tool.model.page.Page.Companion.DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE
@@ -50,7 +51,7 @@ class LessonPageTest : UsesResources("model/lesson") {
     fun testParsePageDefault() = runBlockingTest {
         val manifest = Manifest()
         val page = parsePageXml("page_defaults.xml", manifest)
-        assertEquals(manifest.lessonControlColor, page.controlColor)
+        assertEquals(manifest.pageControlColor, page.controlColor)
         assertEquals(manifest.multiselectOptionBackgroundColor, page.multiselectOptionBackgroundColor)
         assertEquals(manifest.multiselectOptionSelectedColor, page.multiselectOptionSelectedColor)
         assertEquals(DEFAULT_TEXT_SCALE, page.textScale, 0.001)
@@ -99,18 +100,18 @@ class LessonPageTest : UsesResources("model/lesson") {
 
     @Test
     fun testControlColor() {
-        assertEquals(DEFAULT_LESSON_CONTROL_COLOR, (null as LessonPage?).controlColor)
+        assertEquals(DEFAULT_CONTROL_COLOR, (null as LessonPage?).controlColor)
 
         with(LessonPage(Manifest(), controlColor = TestColors.GREEN)) {
             assertEquals(TestColors.GREEN, controlColor)
             assertEquals(TestColors.GREEN, (this as LessonPage?).controlColor)
         }
 
-        with(LessonPage(Manifest(lessonControlColor = TestColors.GREEN))) {
+        with(LessonPage(Manifest(pageControlColor = TestColors.GREEN))) {
             assertEquals(TestColors.GREEN, controlColor)
             assertEquals(TestColors.GREEN, (this as LessonPage?).controlColor)
         }
-        with(LessonPage(Manifest(lessonControlColor = TestColors.RED), controlColor = TestColors.GREEN)) {
+        with(LessonPage(Manifest(pageControlColor = TestColors.RED), controlColor = TestColors.GREEN)) {
             assertEquals(TestColors.GREEN, controlColor)
             assertEquals(TestColors.GREEN, (this as LessonPage?).controlColor)
         }

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/lesson/LessonPageTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/lesson/LessonPageTest.kt
@@ -12,9 +12,9 @@ import org.cru.godtools.tool.model.Styles.Companion.DEFAULT_TEXT_SCALE
 import org.cru.godtools.tool.model.TEST_GRAVITY
 import org.cru.godtools.tool.model.TestColors
 import org.cru.godtools.tool.model.Text
-import org.cru.godtools.tool.model.lesson.LessonPage.Companion.DEFAULT_BACKGROUND_COLOR
-import org.cru.godtools.tool.model.lesson.LessonPage.Companion.DEFAULT_BACKGROUND_IMAGE_GRAVITY
-import org.cru.godtools.tool.model.lesson.LessonPage.Companion.DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE
+import org.cru.godtools.tool.model.page.Page.Companion.DEFAULT_BACKGROUND_COLOR
+import org.cru.godtools.tool.model.page.Page.Companion.DEFAULT_BACKGROUND_IMAGE_GRAVITY
+import org.cru.godtools.tool.model.page.Page.Companion.DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE
 import org.cru.godtools.tool.model.toEventIds
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/page/PageTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/page/PageTest.kt
@@ -5,23 +5,33 @@ import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
 import org.cru.godtools.tool.internal.runBlockingTest
 import org.cru.godtools.tool.model.Manifest
-import org.cru.godtools.tool.xml.XmlPullParserException
+import org.cru.godtools.tool.model.lesson.LessonPage
 import kotlin.test.Test
-import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
 import kotlin.test.assertNull
 
 @RunOnAndroidWith(AndroidJUnit4::class)
 class PageTest : UsesResources("model/page") {
     // region Page.parse()
     @Test
+    fun testParseLessonPage() = runBlockingTest {
+        assertIs<LessonPage>(
+            Page.parse(Manifest(type = Manifest.Type.LESSON), null, getTestXmlParser("../lesson/page.xml"))
+        )
+        assertNull(Page.parse(Manifest(type = Manifest.Type.TRACT), null, getTestXmlParser("../lesson/page.xml")))
+    }
+
+    @Test
     fun testParseInvalidPageType() = runBlockingTest {
-        assertNull(Page.parse(Manifest(), null, getTestXmlParser("page_invalid_type.xml")))
+        Manifest.Type.values().forEach {
+            assertNull(Page.parse(Manifest(type = it), null, getTestXmlParser("page_invalid_type.xml")))
+        }
     }
 
     @Test
     fun testParseInvalidPageNamespace() = runBlockingTest {
-        assertFailsWith(XmlPullParserException::class) {
-            Page.parse(Manifest(), null, getTestXmlParser("page_invalid_namespace.xml"))
+        Manifest.Type.values().forEach {
+            assertNull(Page.parse(Manifest(type = it), null, getTestXmlParser("page_invalid_namespace.xml")))
         }
     }
     // endregion Page.parse()

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/page/PageTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/page/PageTest.kt
@@ -1,0 +1,28 @@
+package org.cru.godtools.tool.model.page
+
+import org.cru.godtools.tool.internal.AndroidJUnit4
+import org.cru.godtools.tool.internal.RunOnAndroidWith
+import org.cru.godtools.tool.internal.UsesResources
+import org.cru.godtools.tool.internal.runBlockingTest
+import org.cru.godtools.tool.model.Manifest
+import org.cru.godtools.tool.xml.XmlPullParserException
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+@RunOnAndroidWith(AndroidJUnit4::class)
+class PageTest : UsesResources("model/page") {
+    // region Page.parse()
+    @Test
+    fun testParseInvalidPageType() = runBlockingTest {
+        assertNull(Page.parse(Manifest(), null, getTestXmlParser("page_invalid_type.xml")))
+    }
+
+    @Test
+    fun testParseInvalidPageNamespace() = runBlockingTest {
+        assertFailsWith(XmlPullParserException::class) {
+            Page.parse(Manifest(), null, getTestXmlParser("page_invalid_namespace.xml"))
+        }
+    }
+    // endregion Page.parse()
+}

--- a/module/parser/src/commonTest/resources/org/cru/godtools/tool/model/lesson/page_defaults.xml
+++ b/module/parser/src/commonTest/resources/org/cru/godtools/tool/model/lesson/page_defaults.xml
@@ -1,1 +1,1 @@
-<page xmlns="https://mobile-content-api.cru.org/xmlns/lesson" />
+<page xmlns="https://mobile-content-api.cru.org/xmlns/lesson" id="page_defaults" />

--- a/module/parser/src/commonTest/resources/org/cru/godtools/tool/model/page/page_invalid_namespace.xml
+++ b/module/parser/src/commonTest/resources/org/cru/godtools/tool/model/page/page_invalid_namespace.xml
@@ -1,0 +1,1 @@
+<page xmlns="https://example.com/invalid" />

--- a/module/parser/src/commonTest/resources/org/cru/godtools/tool/model/page/page_invalid_type.xml
+++ b/module/parser/src/commonTest/resources/org/cru/godtools/tool/model/page/page_invalid_type.xml
@@ -1,0 +1,2 @@
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://mobile-content-api.cru.org/xmlns/page" xsi:type="invalid" />


### PR DESCRIPTION
This moves a bunch of common logic to an abstract `Page` model. this `Page` model will be the foundation for various page types across the different tool types.

Dependent on:
- [x] https://github.com/CruGlobal/mobile-content-api/pull/757