### PR TITLE
GT-1292 Support parsing a Flow element

### DIFF
--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/ParserConfig.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/ParserConfig.kt
@@ -3,6 +3,7 @@ package org.cru.godtools.tool
 import org.cru.godtools.tool.model.DeviceType
 
 const val FEATURE_ANIMATION = "animation"
+const val FEATURE_FLOW = "flow"
 const val FEATURE_MULTISELECT = "multiselect"
 
 expect object ParserConfig {

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Content.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Content.kt
@@ -79,6 +79,7 @@ abstract class Content : BaseModel {
                     Animation.XML_ANIMATION -> Animation(parent, this)
                     Button.XML_BUTTON -> Button(parent, this)
                     Fallback.XML_FALLBACK -> Fallback(parent, this).content.firstOrNull()
+                    Flow.XML_FLOW -> Flow(parent, this)
                     Form.XML_FORM -> Form(parent, this)
                     Image.XML_IMAGE -> Image(parent, this)
                     Input.XML_INPUT -> Input(parent, this)

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Dimension.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Dimension.kt
@@ -1,0 +1,25 @@
+package org.cru.godtools.tool.model
+
+import org.cru.godtools.tool.util.contains
+import kotlin.native.concurrent.SharedImmutable
+
+@SharedImmutable
+private val REGEX_PERCENT = Regex("^(100|[0-9]{1,2}(\\.[0-9]+)?)%$")
+@SharedImmutable
+private val REGEX_PIXELS = Regex("^[0-9]+$")
+
+sealed class Dimension {
+    internal companion object {
+        fun String?.toDimensionOrNull(): Dimension? {
+            return when (val trimmed = this?.trim()) {
+                null -> null
+                in REGEX_PERCENT -> trimmed.trimEnd('%').toFloatOrNull()?.let { Percent(it / 100) }
+                in REGEX_PIXELS -> trimmed.toIntOrNull()?.let { Pixels(it) }
+                else -> null
+            }
+        }
+    }
+
+    data class Percent internal constructor(val value: Float) : Dimension()
+    data class Pixels internal constructor(val value: Int) : Dimension()
+}

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Flow.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Flow.kt
@@ -3,11 +3,13 @@ package org.cru.godtools.tool.model
 import org.cru.godtools.tool.FEATURE_FLOW
 import org.cru.godtools.tool.ParserConfig
 import org.cru.godtools.tool.internal.VisibleForTesting
+import org.cru.godtools.tool.model.Dimension.Companion.toDimensionOrNull
 import org.cru.godtools.tool.xml.XmlPullParser
 import org.cru.godtools.tool.xml.parseChildren
 
 private const val XML_COLUMNS = "columns"
 private const val XML_ITEM = "item"
+private const val XML_ITEM_WIDTH = "width"
 
 class Flow : Content {
     internal companion object {
@@ -18,6 +20,7 @@ class Flow : Content {
     }
 
     val columns: Int
+    private val itemWidth get() = Dimension.Percent(1f / columns)
 
     val items: List<Item>
 
@@ -47,16 +50,23 @@ class Flow : Content {
     class Item : BaseModel, Parent {
         val flow: Flow
 
+        private val _width: Dimension?
+        val width get() = _width ?: flow.itemWidth
+
         override val content: List<Content>
 
         internal constructor(flow: Flow, parser: XmlPullParser) : super(flow) {
             parser.require(XmlPullParser.START_TAG, XMLNS_CONTENT, XML_ITEM)
             this.flow = flow
+
+            _width = parser.getAttributeValue(XML_ITEM_WIDTH).toDimensionOrNull()
+
             content = parseContent(parser)
         }
 
         internal constructor(flow: Flow, content: (Item) -> Content?) : super(flow) {
             this.flow = flow
+            _width = null
             this.content = listOfNotNull(content(this))
         }
     }

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Flow.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Flow.kt
@@ -8,23 +8,22 @@ import org.cru.godtools.tool.model.Gravity.Companion.toGravityOrNull
 import org.cru.godtools.tool.xml.XmlPullParser
 import org.cru.godtools.tool.xml.parseChildren
 
-private const val XML_COLUMNS = "columns"
 private const val XML_ROW_GRAVITY = "row-gravity"
 private const val XML_ITEM = "item"
-private const val XML_ITEM_WIDTH = "width"
 
 class Flow : Content {
     internal companion object {
         internal const val XML_FLOW = "flow"
+        private const val XML_ITEM_WIDTH = "item-width"
 
         @VisibleForTesting
-        internal const val DEFAULT_COLUMNS = 1
+        internal val DEFAULT_ITEM_WIDTH = Dimension.Percent(1f)
         @VisibleForTesting
         internal val DEFAULT_ROW_GRAVITY = Gravity.Horizontal.START
     }
 
-    internal val columns: Int
-    private val itemWidth get() = Dimension.Percent(1f / columns)
+    @VisibleForTesting
+    internal val itemWidth: Dimension
 
     val rowGravity: Gravity.Horizontal
 
@@ -33,7 +32,7 @@ class Flow : Content {
     internal constructor(parent: Base, parser: XmlPullParser) : super(parent, parser) {
         parser.require(XmlPullParser.START_TAG, XMLNS_CONTENT, XML_FLOW)
 
-        columns = parser.getAttributeValue(XML_COLUMNS)?.toIntOrNull()?.takeUnless { it < 1 } ?: DEFAULT_COLUMNS
+        itemWidth = parser.getAttributeValue(XML_ITEM_WIDTH).toDimensionOrNull() ?: DEFAULT_ITEM_WIDTH
         rowGravity = parser.getAttributeValue(XML_ROW_GRAVITY)?.toGravityOrNull()?.horizontal ?: DEFAULT_ROW_GRAVITY
 
         items = mutableListOf()
@@ -55,6 +54,10 @@ class Flow : Content {
     override val isIgnored get() = FEATURE_FLOW !in ParserConfig.supportedFeatures || super.isIgnored
 
     class Item : BaseModel, Parent {
+        companion object {
+            private const val XML_WIDTH = "width"
+        }
+
         val flow: Flow
 
         private val _width: Dimension?
@@ -66,7 +69,7 @@ class Flow : Content {
             parser.require(XmlPullParser.START_TAG, XMLNS_CONTENT, XML_ITEM)
             this.flow = flow
 
-            _width = parser.getAttributeValue(XML_ITEM_WIDTH).toDimensionOrNull()
+            _width = parser.getAttributeValue(XML_WIDTH).toDimensionOrNull()
 
             content = parseContent(parser)
         }

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Flow.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Flow.kt
@@ -1,0 +1,47 @@
+package org.cru.godtools.tool.model
+
+import org.cru.godtools.tool.xml.XmlPullParser
+import org.cru.godtools.tool.xml.parseChildren
+
+class Flow : Content {
+    internal companion object {
+        internal const val XML_FLOW = "flow"
+        private const val XML_ITEM = "item"
+    }
+
+    val items: List<Item>
+
+    internal constructor(parent: Base, parser: XmlPullParser) : super(parent, parser) {
+        parser.require(XmlPullParser.START_TAG, XMLNS_CONTENT, XML_FLOW)
+
+        items = mutableListOf()
+        parser.parseChildren {
+            when (parser.namespace) {
+                XMLNS_CONTENT -> when (parser.name) {
+                    XML_ITEM -> items += Item(this, parser)
+                    else -> {
+                        val item = Item(this) { parser.parseContentElement(it)?.takeUnless { it.isIgnored } }
+                        if (item.content.isNotEmpty()) items += item
+                    }
+                }
+            }
+        }
+    }
+
+    class Item : BaseModel, Parent {
+        val flow: Flow
+
+        override val content: List<Content>
+
+        internal constructor(flow: Flow, parser: XmlPullParser) : super(flow) {
+            parser.require(XmlPullParser.START_TAG, XMLNS_CONTENT, XML_ITEM)
+            this.flow = flow
+            content = parseContent(parser)
+        }
+
+        internal constructor(flow: Flow, content: (Item) -> Content?) : super(flow) {
+            this.flow = flow
+            this.content = listOfNotNull(content(this))
+        }
+    }
+}

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Flow.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Flow.kt
@@ -1,5 +1,7 @@
 package org.cru.godtools.tool.model
 
+import org.cru.godtools.tool.FEATURE_FLOW
+import org.cru.godtools.tool.ParserConfig
 import org.cru.godtools.tool.xml.XmlPullParser
 import org.cru.godtools.tool.xml.parseChildren
 
@@ -27,6 +29,8 @@ class Flow : Content {
             }
         }
     }
+
+    override val isIgnored get() = FEATURE_FLOW !in ParserConfig.supportedFeatures || super.isIgnored
 
     class Item : BaseModel, Parent {
         val flow: Flow

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Flow.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Flow.kt
@@ -4,10 +4,12 @@ import org.cru.godtools.tool.FEATURE_FLOW
 import org.cru.godtools.tool.ParserConfig
 import org.cru.godtools.tool.internal.VisibleForTesting
 import org.cru.godtools.tool.model.Dimension.Companion.toDimensionOrNull
+import org.cru.godtools.tool.model.Gravity.Companion.toGravityOrNull
 import org.cru.godtools.tool.xml.XmlPullParser
 import org.cru.godtools.tool.xml.parseChildren
 
 private const val XML_COLUMNS = "columns"
+private const val XML_ROW_GRAVITY = "row-gravity"
 private const val XML_ITEM = "item"
 private const val XML_ITEM_WIDTH = "width"
 
@@ -17,10 +19,14 @@ class Flow : Content {
 
         @VisibleForTesting
         internal const val DEFAULT_COLUMNS = 1
+        @VisibleForTesting
+        internal val DEFAULT_ROW_GRAVITY = Gravity.Horizontal.START
     }
 
-    val columns: Int
+    internal val columns: Int
     private val itemWidth get() = Dimension.Percent(1f / columns)
+
+    val rowGravity: Gravity.Horizontal
 
     val items: List<Item>
 
@@ -28,6 +34,7 @@ class Flow : Content {
         parser.require(XmlPullParser.START_TAG, XMLNS_CONTENT, XML_FLOW)
 
         columns = parser.getAttributeValue(XML_COLUMNS)?.toIntOrNull()?.takeUnless { it < 1 } ?: DEFAULT_COLUMNS
+        rowGravity = parser.getAttributeValue(XML_ROW_GRAVITY)?.toGravityOrNull()?.horizontal ?: DEFAULT_ROW_GRAVITY
 
         items = mutableListOf()
         parser.parseChildren {

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Flow.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Flow.kt
@@ -4,6 +4,7 @@ import org.cru.godtools.tool.FEATURE_FLOW
 import org.cru.godtools.tool.ParserConfig
 import org.cru.godtools.tool.internal.VisibleForTesting
 import org.cru.godtools.tool.model.Dimension.Companion.toDimensionOrNull
+import org.cru.godtools.tool.model.Flow.Companion.DEFAULT_ITEM_WIDTH
 import org.cru.godtools.tool.model.Flow.Companion.DEFAULT_ROW_GRAVITY
 import org.cru.godtools.tool.model.Gravity.Companion.toGravityOrNull
 import org.cru.godtools.tool.xml.XmlPullParser
@@ -61,7 +62,7 @@ class Flow : Content {
         val flow: Flow
 
         private val _width: Dimension?
-        val width get() = _width ?: flow.itemWidth
+        internal val width get() = _width ?: flow.itemWidth
 
         override val content: List<Content>
 
@@ -83,3 +84,4 @@ class Flow : Content {
 }
 
 val Flow?.rowGravity get() = this?.rowGravity ?: DEFAULT_ROW_GRAVITY
+val Flow.Item?.width get() = this?.width ?: DEFAULT_ITEM_WIDTH

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Flow.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Flow.kt
@@ -4,6 +4,7 @@ import org.cru.godtools.tool.FEATURE_FLOW
 import org.cru.godtools.tool.ParserConfig
 import org.cru.godtools.tool.internal.VisibleForTesting
 import org.cru.godtools.tool.model.Dimension.Companion.toDimensionOrNull
+import org.cru.godtools.tool.model.Flow.Companion.DEFAULT_ROW_GRAVITY
 import org.cru.godtools.tool.model.Gravity.Companion.toGravityOrNull
 import org.cru.godtools.tool.xml.XmlPullParser
 import org.cru.godtools.tool.xml.parseChildren
@@ -18,14 +19,13 @@ class Flow : Content {
 
         @VisibleForTesting
         internal val DEFAULT_ITEM_WIDTH = Dimension.Percent(1f)
-        @VisibleForTesting
         internal val DEFAULT_ROW_GRAVITY = Gravity.Horizontal.START
     }
 
     @VisibleForTesting
     internal val itemWidth: Dimension
 
-    val rowGravity: Gravity.Horizontal
+    internal val rowGravity: Gravity.Horizontal
 
     val items: List<Item>
 
@@ -81,3 +81,5 @@ class Flow : Content {
         }
     }
 }
+
+val Flow?.rowGravity get() = this?.rowGravity ?: DEFAULT_ROW_GRAVITY

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/util/Regex.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/util/Regex.kt
@@ -1,0 +1,3 @@
+package org.cru.godtools.tool.util
+
+internal operator fun Regex.contains(value: String) = matches(value)

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ContentTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ContentTest.kt
@@ -252,6 +252,11 @@ class ContentTest : UsesResources() {
     }
 
     @Test
+    fun verifyParseContentElementFlow() = runBlockingTest {
+        assertIs<Flow>(getTestXmlParser("flow.xml").parseContentElement(Manifest()))
+    }
+
+    @Test
     fun verifyParseContentElementForm() = runBlockingTest {
         assertIs<Form>(getTestXmlParser("form.xml").parseContentElement(Manifest()))
         assertIs<Form>(getTestXmlParser("form_ignored_content.xml").parseContentElement(Manifest()))

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/DimensionTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/DimensionTest.kt
@@ -6,7 +6,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNull
 
-private const val TOLERANCE = 0.0001f
+internal const val DIMENSION_TOLERANCE = 0.0001f
 
 class DimensionTest {
     @Test
@@ -23,12 +23,12 @@ class DimensionTest {
 
     @Test
     fun testToDimensionOrNullValidPercentages() {
-        assertEquals(0f, assertIs<Dimension.Percent>("0%".toDimensionOrNull()).value, TOLERANCE)
-        assertEquals(.5f, assertIs<Dimension.Percent>("50%".toDimensionOrNull()).value, TOLERANCE)
-        assertEquals(1f, assertIs<Dimension.Percent>("100%".toDimensionOrNull()).value, TOLERANCE)
-        assertEquals(1f, assertIs<Dimension.Percent>(" 100%".toDimensionOrNull()).value, TOLERANCE)
-        assertEquals(1f, assertIs<Dimension.Percent>("100% ".toDimensionOrNull()).value, TOLERANCE)
-        assertEquals(1f, assertIs<Dimension.Percent>("\t 100%\t ".toDimensionOrNull()).value, TOLERANCE)
+        assertEquals(0f, assertIs<Dimension.Percent>("0%".toDimensionOrNull()).value, DIMENSION_TOLERANCE)
+        assertEquals(.5f, assertIs<Dimension.Percent>("50%".toDimensionOrNull()).value, DIMENSION_TOLERANCE)
+        assertEquals(1f, assertIs<Dimension.Percent>("100%".toDimensionOrNull()).value, DIMENSION_TOLERANCE)
+        assertEquals(1f, assertIs<Dimension.Percent>(" 100%".toDimensionOrNull()).value, DIMENSION_TOLERANCE)
+        assertEquals(1f, assertIs<Dimension.Percent>("100% ".toDimensionOrNull()).value, DIMENSION_TOLERANCE)
+        assertEquals(1f, assertIs<Dimension.Percent>("\t 100%\t ".toDimensionOrNull()).value, DIMENSION_TOLERANCE)
     }
 
     @Test

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/DimensionTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/DimensionTest.kt
@@ -1,0 +1,43 @@
+package org.cru.godtools.tool.model
+
+import org.cru.godtools.tool.model.Dimension.Companion.toDimensionOrNull
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+
+private const val TOLERANCE = 0.0001f
+
+class DimensionTest {
+    @Test
+    fun testToDimensionOrNullInvalid() {
+        assertNull((null as String?).toDimensionOrNull())
+        assertNull("".toDimensionOrNull())
+
+        assertNull("-1%".toDimensionOrNull())
+        assertNull("101%".toDimensionOrNull())
+
+        assertNull("-1".toDimensionOrNull())
+        assertNull("12a".toDimensionOrNull())
+    }
+
+    @Test
+    fun testToDimensionOrNullValidPercentages() {
+        assertEquals(0f, assertIs<Dimension.Percent>("0%".toDimensionOrNull()).value, TOLERANCE)
+        assertEquals(.5f, assertIs<Dimension.Percent>("50%".toDimensionOrNull()).value, TOLERANCE)
+        assertEquals(1f, assertIs<Dimension.Percent>("100%".toDimensionOrNull()).value, TOLERANCE)
+        assertEquals(1f, assertIs<Dimension.Percent>(" 100%".toDimensionOrNull()).value, TOLERANCE)
+        assertEquals(1f, assertIs<Dimension.Percent>("100% ".toDimensionOrNull()).value, TOLERANCE)
+        assertEquals(1f, assertIs<Dimension.Percent>("\t 100%\t ".toDimensionOrNull()).value, TOLERANCE)
+    }
+
+    @Test
+    fun testToDimensionOrNullValidPixels() {
+        assertEquals(0, assertIs<Dimension.Pixels>("0".toDimensionOrNull()).value)
+        assertEquals(37, assertIs<Dimension.Pixels>("37".toDimensionOrNull()).value)
+        assertEquals(1234, assertIs<Dimension.Pixels>("1234".toDimensionOrNull()).value)
+        assertEquals(1, assertIs<Dimension.Pixels>(" \t1".toDimensionOrNull()).value)
+        assertEquals(1, assertIs<Dimension.Pixels>("1\t ".toDimensionOrNull()).value)
+        assertEquals(1, assertIs<Dimension.Pixels>(" \t1\t ".toDimensionOrNull()).value)
+    }
+}

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/FlowTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/FlowTest.kt
@@ -4,7 +4,7 @@ import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
 import org.cru.godtools.tool.internal.runBlockingTest
-import org.cru.godtools.tool.model.Flow.Companion.DEFAULT_COLUMNS
+import org.cru.godtools.tool.model.Flow.Companion.DEFAULT_ITEM_WIDTH
 import org.cru.godtools.tool.model.Flow.Companion.DEFAULT_ROW_GRAVITY
 import org.cru.godtools.tool.model.tips.InlineTip
 import kotlin.test.Test
@@ -17,7 +17,7 @@ class FlowTest : UsesResources() {
     @Test
     fun testParseFlowDefaults() = runBlockingTest {
         val flow = Flow(Manifest(), getTestXmlParser("flow_defaults.xml"))
-        assertEquals(DEFAULT_COLUMNS, flow.columns)
+        assertEquals(DEFAULT_ITEM_WIDTH, flow.itemWidth)
         assertEquals(DEFAULT_ROW_GRAVITY, flow.rowGravity)
         assertTrue(flow.items.isEmpty())
     }
@@ -25,7 +25,7 @@ class FlowTest : UsesResources() {
     @Test
     fun testParseFlow() = runBlockingTest {
         val flow = Flow(Manifest(), getTestXmlParser("flow.xml"))
-        assertEquals(3, flow.columns)
+        assertEquals(0.33f, assertIs<Dimension.Percent>(flow.itemWidth).value, DIMENSION_TOLERANCE)
         assertEquals(Gravity.Horizontal.END, flow.rowGravity)
         assertEquals(4, flow.items.size)
         assertIs<Spacer>(flow.items[0].content.single())

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/FlowTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/FlowTest.kt
@@ -45,4 +45,11 @@ class FlowTest : UsesResources() {
             assertEquals(DEFAULT_ROW_GRAVITY, rowGravity)
         }
     }
+
+    @Test
+    fun testItemWidth() {
+        with(null as Flow.Item?) {
+            assertEquals(DEFAULT_ITEM_WIDTH, width)
+        }
+    }
 }

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/FlowTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/FlowTest.kt
@@ -27,6 +27,7 @@ class FlowTest : UsesResources() {
         assertEquals(4, flow.items.size)
         assertIs<Spacer>(flow.items[0].content.single())
         with(flow.items[1]) {
+            assertEquals(25, assertIs<Dimension.Pixels>(width).value)
             assertEquals(2, content.size)
             assertIs<Text>(content[0])
             assertIs<Spacer>(content[1])

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/FlowTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/FlowTest.kt
@@ -5,6 +5,7 @@ import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
 import org.cru.godtools.tool.internal.runBlockingTest
 import org.cru.godtools.tool.model.Flow.Companion.DEFAULT_COLUMNS
+import org.cru.godtools.tool.model.Flow.Companion.DEFAULT_ROW_GRAVITY
 import org.cru.godtools.tool.model.tips.InlineTip
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -17,6 +18,7 @@ class FlowTest : UsesResources() {
     fun testParseFlowDefaults() = runBlockingTest {
         val flow = Flow(Manifest(), getTestXmlParser("flow_defaults.xml"))
         assertEquals(DEFAULT_COLUMNS, flow.columns)
+        assertEquals(DEFAULT_ROW_GRAVITY, flow.rowGravity)
         assertTrue(flow.items.isEmpty())
     }
 
@@ -24,6 +26,7 @@ class FlowTest : UsesResources() {
     fun testParseFlow() = runBlockingTest {
         val flow = Flow(Manifest(), getTestXmlParser("flow.xml"))
         assertEquals(3, flow.columns)
+        assertEquals(Gravity.Horizontal.END, flow.rowGravity)
         assertEquals(4, flow.items.size)
         assertIs<Spacer>(flow.items[0].content.single())
         with(flow.items[1]) {

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/FlowTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/FlowTest.kt
@@ -4,16 +4,26 @@ import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
 import org.cru.godtools.tool.internal.runBlockingTest
+import org.cru.godtools.tool.model.Flow.Companion.DEFAULT_COLUMNS
 import org.cru.godtools.tool.model.tips.InlineTip
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertTrue
 
 @RunOnAndroidWith(AndroidJUnit4::class)
 class FlowTest : UsesResources() {
     @Test
+    fun testParseFlowDefaults() = runBlockingTest {
+        val flow = Flow(Manifest(), getTestXmlParser("flow_defaults.xml"))
+        assertEquals(DEFAULT_COLUMNS, flow.columns)
+        assertTrue(flow.items.isEmpty())
+    }
+
+    @Test
     fun testParseFlow() = runBlockingTest {
         val flow = Flow(Manifest(), getTestXmlParser("flow.xml"))
+        assertEquals(3, flow.columns)
         assertEquals(4, flow.items.size)
         assertIs<Spacer>(flow.items[0].content.single())
         with(flow.items[1]) {

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/FlowTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/FlowTest.kt
@@ -1,0 +1,27 @@
+package org.cru.godtools.tool.model
+
+import org.cru.godtools.tool.internal.AndroidJUnit4
+import org.cru.godtools.tool.internal.RunOnAndroidWith
+import org.cru.godtools.tool.internal.UsesResources
+import org.cru.godtools.tool.internal.runBlockingTest
+import org.cru.godtools.tool.model.tips.InlineTip
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+@RunOnAndroidWith(AndroidJUnit4::class)
+class FlowTest : UsesResources() {
+    @Test
+    fun testParseFlow() = runBlockingTest {
+        val flow = Flow(Manifest(), getTestXmlParser("flow.xml"))
+        assertEquals(4, flow.items.size)
+        assertIs<Spacer>(flow.items[0].content.single())
+        with(flow.items[1]) {
+            assertEquals(2, content.size)
+            assertIs<Text>(content[0])
+            assertIs<Spacer>(content[1])
+        }
+        assertIs<Paragraph>(flow.items[2].content.single())
+        assertIs<InlineTip>(flow.items[3].content.single())
+    }
+}

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/FlowTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/FlowTest.kt
@@ -38,4 +38,11 @@ class FlowTest : UsesResources() {
         assertIs<Paragraph>(flow.items[2].content.single())
         assertIs<InlineTip>(flow.items[3].content.single())
     }
+
+    @Test
+    fun testRowGravity() {
+        with(null as Flow?) {
+            assertEquals(DEFAULT_ROW_GRAVITY, rowGravity)
+        }
+    }
 }

--- a/module/parser/src/commonTest/resources/org/cru/godtools/tool/model/flow.xml
+++ b/module/parser/src/commonTest/resources/org/cru/godtools/tool/model/flow.xml
@@ -1,4 +1,5 @@
-<content:flow xmlns:content="https://mobile-content-api.cru.org/xmlns/content" xmlns:training="https://mobile-content-api.cru.org/xmlns/training">
+<content:flow xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    xmlns:training="https://mobile-content-api.cru.org/xmlns/training" columns="3">
     <content:spacer height="20" mode="fixed" />
     <content:invalid />
     <content:item>

--- a/module/parser/src/commonTest/resources/org/cru/godtools/tool/model/flow.xml
+++ b/module/parser/src/commonTest/resources/org/cru/godtools/tool/model/flow.xml
@@ -1,0 +1,13 @@
+<content:flow xmlns:content="https://mobile-content-api.cru.org/xmlns/content" xmlns:training="https://mobile-content-api.cru.org/xmlns/training">
+    <content:spacer height="20" mode="fixed" />
+    <content:invalid />
+    <content:item>
+        <content:text>Test</content:text>
+        <content:spacer height="20" mode="fixed" />
+    </content:item>
+    <training:invalid />
+    <content:paragraph>
+        <content:text />
+    </content:paragraph>
+    <training:tip id="test" />
+</content:flow>

--- a/module/parser/src/commonTest/resources/org/cru/godtools/tool/model/flow.xml
+++ b/module/parser/src/commonTest/resources/org/cru/godtools/tool/model/flow.xml
@@ -1,5 +1,5 @@
 <content:flow xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
-    xmlns:training="https://mobile-content-api.cru.org/xmlns/training" columns="3"
+    xmlns:training="https://mobile-content-api.cru.org/xmlns/training" item-width="33%"
     row-gravity="end">
     <content:spacer height="20" mode="fixed" />
     <content:invalid />

--- a/module/parser/src/commonTest/resources/org/cru/godtools/tool/model/flow.xml
+++ b/module/parser/src/commonTest/resources/org/cru/godtools/tool/model/flow.xml
@@ -2,7 +2,7 @@
     xmlns:training="https://mobile-content-api.cru.org/xmlns/training" columns="3">
     <content:spacer height="20" mode="fixed" />
     <content:invalid />
-    <content:item>
+    <content:item width="25">
         <content:text>Test</content:text>
         <content:spacer height="20" mode="fixed" />
     </content:item>

--- a/module/parser/src/commonTest/resources/org/cru/godtools/tool/model/flow.xml
+++ b/module/parser/src/commonTest/resources/org/cru/godtools/tool/model/flow.xml
@@ -1,5 +1,6 @@
 <content:flow xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
-    xmlns:training="https://mobile-content-api.cru.org/xmlns/training" columns="3">
+    xmlns:training="https://mobile-content-api.cru.org/xmlns/training" columns="3"
+    row-gravity="end">
     <content:spacer height="20" mode="fixed" />
     <content:invalid />
     <content:item width="25">

--- a/module/parser/src/commonTest/resources/org/cru/godtools/tool/model/flow_defaults.xml
+++ b/module/parser/src/commonTest/resources/org/cru/godtools/tool/model/flow_defaults.xml
@@ -1,0 +1,1 @@
+<content:flow xmlns:content="https://mobile-content-api.cru.org/xmlns/content" />


### PR DESCRIPTION
Introduces the following new models:
- `Flow`
   - has an `items` property that is a list of `Flow.Items` that the flow contains
   - has a  `rowGravity` property that defines how each row in the flow should be aligned. This matters when the items in an individual row of the flow don't take up all the horizontal space.
- `Flow.Item`
   - provides a `content` list that is to be rendered as children of the item. 
   - provides a `width` property that defines how wide this item should be within the containing flow.

There is a new `FEATURE_FLOW` flag that will enable parsing/usage of the new Flow models.
