### PR TITLE
removeUnnecessaryDeprecations

### DIFF
--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Link.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Link.kt
@@ -1,14 +1,10 @@
 package org.cru.godtools.tool.model
 
-import io.github.aakira.napier.Napier
-import org.cru.godtools.tool.internal.DeprecationException
 import org.cru.godtools.tool.internal.RestrictTo
 import org.cru.godtools.tool.internal.RestrictToScope
 import org.cru.godtools.tool.model.AnalyticsEvent.Companion.parseAnalyticsEvents
 import org.cru.godtools.tool.model.AnalyticsEvent.Trigger
 import org.cru.godtools.tool.xml.XmlPullParser
-
-private const val TAG = "Link"
 
 class Link : Content, Styles, HasAnalyticsEvents, Clickable {
     internal companion object {
@@ -37,15 +33,6 @@ class Link : Content, Styles, HasAnalyticsEvents, Clickable {
                     }
             }
         }
-
-        // Log a non-fatal warning if any analytics event is still using the SELECTED trigger
-        analyticsEvents.forEach {
-            if (it.trigger == Trigger.SELECTED) {
-                val message =
-                    "tool: ${manifest.code} locale: ${manifest.locale} action: ${it.action} trigger: ${it.trigger}"
-                Napier.e(message, DeprecationException("XML Analytics Event Deprecated trigger $message"), TAG)
-            }
-        }
     }
 
     override val isIgnored get() = super.isIgnored || !isClickable
@@ -65,8 +52,7 @@ class Link : Content, Styles, HasAnalyticsEvents, Clickable {
     }
 
     override fun getAnalyticsEvents(type: Trigger) = when (type) {
-        Trigger.CLICKED ->
-            analyticsEvents.filter { it.isTriggerType(Trigger.CLICKED, Trigger.SELECTED, Trigger.DEFAULT) }
+        Trigger.CLICKED -> analyticsEvents.filter { it.isTriggerType(Trigger.CLICKED, Trigger.DEFAULT) }
         else -> error("The $type trigger type is currently unsupported on Links")
     }
 }

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Tabs.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Tabs.kt
@@ -1,15 +1,11 @@
 package org.cru.godtools.tool.model
 
-import io.github.aakira.napier.Napier
-import org.cru.godtools.tool.internal.DeprecationException
 import org.cru.godtools.tool.internal.RestrictTo
 import org.cru.godtools.tool.internal.RestrictToScope
 import org.cru.godtools.tool.model.AnalyticsEvent.Companion.parseAnalyticsEvents
 import org.cru.godtools.tool.model.AnalyticsEvent.Trigger
 import org.cru.godtools.tool.xml.XmlPullParser
 import org.cru.godtools.tool.xml.parseChildren
-
-private const val TAG = "Tabs"
 
 private const val XML_TAB = "tab"
 private const val XML_LABEL = "label"
@@ -71,15 +67,6 @@ class Tabs : Content {
                 }
             }
             this.label = label
-
-            // Log a non-fatal warning if any analytics event is still using the SELECTED trigger
-            analyticsEvents.forEach {
-                if (it.trigger == Trigger.SELECTED) {
-                    val message =
-                        "tool: ${manifest.code} locale: ${manifest.locale} action: ${it.action} trigger: ${it.trigger}"
-                    Napier.e(message, DeprecationException("XML Analytics Deprecated trigger $message"), TAG)
-                }
-            }
         }
 
         @RestrictTo(RestrictToScope.TESTS)
@@ -95,8 +82,7 @@ class Tabs : Content {
         }
 
         override fun getAnalyticsEvents(type: Trigger) = when (type) {
-            Trigger.CLICKED ->
-                analyticsEvents.filter { it.isTriggerType(Trigger.CLICKED, Trigger.SELECTED, Trigger.DEFAULT) }
+            Trigger.CLICKED -> analyticsEvents.filter { it.isTriggerType(Trigger.CLICKED, Trigger.DEFAULT) }
             else -> error("The $type trigger type is currently unsupported on Tabs")
         }
     }


### PR DESCRIPTION
- there have been no instances of the SELECTED trigger on Links reported to Crashlytics
- remove selected analytics trigger from Tabs, there have been no reported uses on Crashlytics
