### PR TITLE
GT-1338 Parse content cards

### DIFF
--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/ParserConfig.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/ParserConfig.kt
@@ -3,6 +3,7 @@ package org.cru.godtools.tool
 import org.cru.godtools.tool.model.DeviceType
 
 const val FEATURE_ANIMATION = "animation"
+const val FEATURE_CONTENT_CARD = "content_card"
 const val FEATURE_FLOW = "flow"
 const val FEATURE_MULTISELECT = "multiselect"
 

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Card.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Card.kt
@@ -7,6 +7,8 @@ import org.cru.godtools.tool.xml.XmlPullParser
 class Card : Content, Parent, Clickable {
     internal companion object {
         internal const val XML_CARD = "card"
+
+        internal const val XML_CARD_BACKGROUND_COLOR = "card-background-color"
     }
 
     override val content: List<Content>

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Card.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Card.kt
@@ -1,0 +1,29 @@
+package org.cru.godtools.tool.model
+
+import org.cru.godtools.tool.FEATURE_CONTENT_CARD
+import org.cru.godtools.tool.ParserConfig
+import org.cru.godtools.tool.xml.XmlPullParser
+
+class Card : Content, Parent, Clickable {
+    internal companion object {
+        internal const val XML_CARD = "card"
+    }
+
+    override val content: List<Content>
+
+    override val events: List<EventId>
+    override val url: Uri?
+
+    internal constructor(parent: Base, parser: XmlPullParser) : super(parent, parser) {
+        parser.require(XmlPullParser.START_TAG, XMLNS_CONTENT, XML_CARD)
+
+        parser.parseClickableAttrs { events, url ->
+            this.events = events
+            this.url = url
+        }
+
+        content = parseContent(parser)
+    }
+
+    override val isIgnored get() = FEATURE_CONTENT_CARD !in ParserConfig.supportedFeatures || super.isIgnored
+}

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Card.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Card.kt
@@ -2,6 +2,8 @@ package org.cru.godtools.tool.model
 
 import org.cru.godtools.tool.FEATURE_CONTENT_CARD
 import org.cru.godtools.tool.ParserConfig
+import org.cru.godtools.tool.internal.RestrictTo
+import org.cru.godtools.tool.internal.RestrictToScope
 import org.cru.godtools.tool.xml.XmlPullParser
 
 class Card : Content, Parent, Clickable {
@@ -29,6 +31,14 @@ class Card : Content, Parent, Clickable {
         }
 
         content = parseContent(parser)
+    }
+
+    @RestrictTo(RestrictToScope.TESTS)
+    internal constructor(parent: Base = Manifest(), backgroundColor: PlatformColor? = null) : super(parent) {
+        _backgroundColor = backgroundColor
+        content = emptyList()
+        events = emptyList()
+        url = null
     }
 
     override val isIgnored get() = FEATURE_CONTENT_CARD !in ParserConfig.supportedFeatures || super.isIgnored

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Card.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Card.kt
@@ -11,6 +11,8 @@ class Card : Content, Parent, Clickable {
         internal const val XML_CARD_BACKGROUND_COLOR = "card-background-color"
     }
 
+    internal val _backgroundColor: PlatformColor?
+
     override val content: List<Content>
 
     override val events: List<EventId>
@@ -18,6 +20,8 @@ class Card : Content, Parent, Clickable {
 
     internal constructor(parent: Base, parser: XmlPullParser) : super(parent, parser) {
         parser.require(XmlPullParser.START_TAG, XMLNS_CONTENT, XML_CARD)
+
+        _backgroundColor = parser.getAttributeValue(XML_BACKGROUND_COLOR).toColorOrNull()
 
         parser.parseClickableAttrs { events, url ->
             this.events = events
@@ -29,3 +33,5 @@ class Card : Content, Parent, Clickable {
 
     override val isIgnored get() = FEATURE_CONTENT_CARD !in ParserConfig.supportedFeatures || super.isIgnored
 }
+
+val Card?.backgroundColor get() = this?._backgroundColor ?: stylesParent.cardBackgroundColor

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Content.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Content.kt
@@ -78,6 +78,7 @@ abstract class Content : BaseModel {
                     Accordion.XML_ACCORDION -> Accordion(parent, this)
                     Animation.XML_ANIMATION -> Animation(parent, this)
                     Button.XML_BUTTON -> Button(parent, this)
+                    Card.XML_CARD -> Card(parent, this)
                     Fallback.XML_FALLBACK -> Fallback(parent, this).content.firstOrNull()
                     Flow.XML_FLOW -> Flow(parent, this)
                     Form.XML_FORM -> Form(parent, this)

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
@@ -25,8 +25,6 @@ import org.cru.godtools.tool.model.page.XMLNS_PAGE
 import org.cru.godtools.tool.model.page.XML_CONTROL_COLOR
 import org.cru.godtools.tool.model.tips.Tip
 import org.cru.godtools.tool.model.tract.TractPage
-import org.cru.godtools.tool.model.tract.XMLNS_TRACT
-import org.cru.godtools.tool.model.tract.XML_CARD_BACKGROUND_COLOR
 import org.cru.godtools.tool.util.setOnce
 import org.cru.godtools.tool.xml.XmlPullParser
 import org.cru.godtools.tool.xml.parseChildren
@@ -193,7 +191,7 @@ class Manifest : BaseModel, Styles {
         backgroundImageScaleType = parser.getAttributeValue(XML_BACKGROUND_IMAGE_SCALE_TYPE)?.toImageScaleTypeOrNull()
             ?: DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE
 
-        _cardBackgroundColor = parser.getAttributeValue(XMLNS_TRACT, XML_CARD_BACKGROUND_COLOR)?.toColorOrNull()
+        _cardBackgroundColor = parser.getAttributeValue(XMLNS_CONTENT, Card.XML_CARD_BACKGROUND_COLOR)?.toColorOrNull()
         _categoryLabelColor = parser.getAttributeValue(XML_CATEGORY_LABEL_COLOR)?.toColorOrNull()
         pageControlColor =
             parser.getAttributeValue(XMLNS_PAGE, XML_CONTROL_COLOR)?.toColorOrNull()

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
@@ -127,7 +127,7 @@ class Manifest : BaseModel, Styles {
     @AndroidColorInt
     private val _cardBackgroundColor: PlatformColor?
     @get:AndroidColorInt
-    val cardBackgroundColor get() = _cardBackgroundColor ?: backgroundColor
+    override val cardBackgroundColor get() = _cardBackgroundColor ?: backgroundColor
 
     @AndroidColorInt
     private val _categoryLabelColor: PlatformColor?

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Styles.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Styles.kt
@@ -19,6 +19,10 @@ interface Styles : Base {
     val buttonColor: PlatformColor? get() = stylesParent?.buttonColor
     // endregion Button styles
 
+    // region Card styles
+    val cardBackgroundColor: PlatformColor get() = stylesParent.cardBackgroundColor
+    // endregion Card styles
+
     // region Multiselect styles
     @get:AndroidColorInt
     val multiselectOptionBackgroundColor: PlatformColor get() = stylesParent.multiselectOptionBackgroundColor
@@ -40,6 +44,10 @@ val Styles?.primaryColor get() = this?.primaryColor ?: Manifest.DEFAULT_PRIMARY_
 val Styles?.primaryTextColor get() = this?.primaryTextColor ?: Manifest.DEFAULT_PRIMARY_TEXT_COLOR
 
 val Styles?.buttonStyle get() = this?.buttonStyle ?: Manifest.DEFAULT_BUTTON_STYLE
+
+// region Card styles
+internal val Styles?.cardBackgroundColor get() = this?.cardBackgroundColor ?: Manifest.DEFAULT_BACKGROUND_COLOR
+// endregion Card styles
 
 // region Multiselect styles
 internal val Styles?.multiselectOptionBackgroundColor

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/page/Page.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/page/Page.kt
@@ -136,7 +136,7 @@ abstract class Page : BaseModel, Styles, HasAnalyticsEvents {
     @AndroidColorInt
     private val _cardBackgroundColor: PlatformColor?
     @get:AndroidColorInt
-    internal val cardBackgroundColor get() = _cardBackgroundColor ?: manifest.cardBackgroundColor
+    override val cardBackgroundColor get() = _cardBackgroundColor ?: manifest.cardBackgroundColor
 
     private val _multiselectOptionBackgroundColor: PlatformColor?
     override val multiselectOptionBackgroundColor

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/page/Page.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/page/Page.kt
@@ -8,6 +8,7 @@ import org.cru.godtools.tool.internal.VisibleForTesting
 import org.cru.godtools.tool.model.AnalyticsEvent
 import org.cru.godtools.tool.model.AnalyticsEvent.Trigger
 import org.cru.godtools.tool.model.BaseModel
+import org.cru.godtools.tool.model.Card
 import org.cru.godtools.tool.model.EventId
 import org.cru.godtools.tool.model.Gravity
 import org.cru.godtools.tool.model.Gravity.Companion.toGravityOrNull
@@ -132,6 +133,11 @@ abstract class Page : BaseModel, Styles, HasAnalyticsEvents {
     @get:AndroidColorInt
     internal val controlColor get() = _controlColor ?: manifest.pageControlColor
 
+    @AndroidColorInt
+    private val _cardBackgroundColor: PlatformColor?
+    @get:AndroidColorInt
+    internal val cardBackgroundColor get() = _cardBackgroundColor ?: manifest.cardBackgroundColor
+
     private val _multiselectOptionBackgroundColor: PlatformColor?
     override val multiselectOptionBackgroundColor
         get() = _multiselectOptionBackgroundColor ?: super.multiselectOptionBackgroundColor
@@ -170,6 +176,8 @@ abstract class Page : BaseModel, Styles, HasAnalyticsEvents {
 
         _controlColor = parser.getAttributeValue(XML_CONTROL_COLOR)?.toColorOrNull()
 
+        _cardBackgroundColor = parser.getAttributeValue(XMLNS_CONTENT, Card.XML_CARD_BACKGROUND_COLOR)?.toColorOrNull()
+
         _multiselectOptionBackgroundColor =
             parser.getAttributeValue(XMLNS_CONTENT, XML_MULTISELECT_OPTION_BACKGROUND_COLOR)?.toColorOrNull()
         _multiselectOptionSelectedColor =
@@ -189,6 +197,7 @@ abstract class Page : BaseModel, Styles, HasAnalyticsEvents {
         backgroundImageGravity: Gravity = DEFAULT_BACKGROUND_IMAGE_GRAVITY,
         backgroundImageScaleType: ImageScaleType = DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE,
         controlColor: PlatformColor? = null,
+        cardBackgroundColor: PlatformColor? = null,
         textColor: PlatformColor? = null,
         textScale: Double = DEFAULT_TEXT_SCALE
     ) : super(manifest) {
@@ -209,6 +218,8 @@ abstract class Page : BaseModel, Styles, HasAnalyticsEvents {
         this.backgroundImageScaleType = backgroundImageScaleType
 
         _controlColor = controlColor
+
+        _cardBackgroundColor = cardBackgroundColor
 
         _multiselectOptionBackgroundColor = null
         _multiselectOptionSelectedColor = null

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Constants.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/Constants.kt
@@ -1,5 +1,3 @@
 package org.cru.godtools.tool.model.tract
 
 internal const val XMLNS_TRACT = "https://mobile-content-api.cru.org/xmlns/tract"
-
-internal const val XML_CARD_BACKGROUND_COLOR = "card-background-color"

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/TractPage.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/TractPage.kt
@@ -64,7 +64,6 @@ class TractPage : Page {
     ) : super(manifest, fileName, parser) {
         parser.require(XmlPullParser.START_TAG, XMLNS_TRACT, XML_PAGE)
 
-        _cardBackgroundColor = parser.getAttributeValue(XML_CARD_BACKGROUND_COLOR)?.toColorOrNull()
         _cardTextColor = parser.getAttributeValue(XML_CARD_TEXT_COLOR)?.toColorOrNull()
 
         // process any child elements
@@ -112,10 +111,10 @@ class TractPage : Page {
         backgroundImage = backgroundImage,
         backgroundImageGravity = backgroundImageGravity,
         backgroundImageScaleType = backgroundImageScaleType,
+        cardBackgroundColor = cardBackgroundColor,
         textColor = textColor,
         textScale = textScale
     ) {
-        _cardBackgroundColor = cardBackgroundColor
         _cardTextColor = cardTextColor
 
         header = null
@@ -137,11 +136,6 @@ class TractPage : Page {
     private val _cardTextColor: PlatformColor?
     @get:AndroidColorInt
     val cardTextColor get() = _cardTextColor ?: textColor
-
-    @AndroidColorInt
-    private val _cardBackgroundColor: PlatformColor?
-    @get:AndroidColorInt
-    val cardBackgroundColor get() = _cardBackgroundColor ?: manifest.cardBackgroundColor
 
     class Card : BaseModel, Styles, Parent, HasAnalyticsEvents {
         internal companion object {

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/CardTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/CardTest.kt
@@ -1,0 +1,33 @@
+package org.cru.godtools.tool.model
+
+import org.cru.godtools.tool.internal.AndroidJUnit4
+import org.cru.godtools.tool.internal.RunOnAndroidWith
+import org.cru.godtools.tool.internal.UsesResources
+import org.cru.godtools.tool.internal.runBlockingTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+@RunOnAndroidWith(AndroidJUnit4::class)
+class CardTest : UsesResources() {
+    @Test
+    fun testParseCard() = runBlockingTest {
+        val card = Card(Manifest(), getTestXmlParser("card.xml"))
+        assertEquals(TestColors.RED, card.backgroundColor)
+        assertTrue(card.isClickable)
+        assertEquals("https://www.example.com", card.url.toString())
+        assertEquals(2, card.content.size)
+        assertIs<Spacer>(card.content[0])
+        assertIs<Text>(card.content[1])
+    }
+
+    @Test
+    fun testParseCardDefaults() = runBlockingTest {
+        val card = Card(Manifest(), getTestXmlParser("card_defaults.xml"))
+        assertEquals(Manifest.DEFAULT_BACKGROUND_COLOR, card.backgroundColor)
+        assertFalse(card.isClickable)
+        assertTrue(card.content.isEmpty())
+    }
+}

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/CardTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/CardTest.kt
@@ -1,5 +1,7 @@
 package org.cru.godtools.tool.model
 
+import org.cru.godtools.tool.FEATURE_CONTENT_CARD
+import org.cru.godtools.tool.ParserConfig
 import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
@@ -29,6 +31,17 @@ class CardTest : UsesResources() {
         assertEquals(Manifest.DEFAULT_BACKGROUND_COLOR, card.backgroundColor)
         assertFalse(card.isClickable)
         assertTrue(card.content.isEmpty())
+    }
+
+    @Test
+    fun testIsIgnored() {
+        val card = Card()
+
+        ParserConfig.supportedFeatures = setOf(FEATURE_CONTENT_CARD)
+        assertFalse(card.isIgnored)
+
+        ParserConfig.supportedFeatures = emptySet()
+        assertTrue(card.isIgnored)
     }
 
     @Test

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/CardTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/CardTest.kt
@@ -30,4 +30,14 @@ class CardTest : UsesResources() {
         assertFalse(card.isClickable)
         assertTrue(card.content.isEmpty())
     }
+
+    @Test
+    fun testCardBackgroundColorFallbackBehavior() {
+        val parent = object : BaseModel(), Styles {
+            override val multiselectOptionBackgroundColor = TestColors.RANDOM
+        }
+        assertEquals(parent.cardBackgroundColor, Card(parent).backgroundColor)
+        assertEquals(TestColors.GREEN, Card(parent, backgroundColor = TestColors.GREEN).backgroundColor)
+        assertEquals(Manifest.DEFAULT_BACKGROUND_COLOR, (null as Card?).backgroundColor)
+    }
 }

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ContentTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ContentTest.kt
@@ -246,6 +246,12 @@ class ContentTest : UsesResources() {
     }
 
     @Test
+    fun verifyParseContentElementCard() = runBlockingTest {
+        assertIs<Card>(getTestXmlParser("card.xml").parseContentElement(Manifest()))
+        assertIs<Card>(getTestXmlParser("card_defaults.xml").parseContentElement(Manifest()))
+    }
+
+    @Test
     fun verifyParseContentElementFallback() = runBlockingTest {
         assertIs<Text>(getTestXmlParser("fallback.xml").parseContentElement(Manifest()))
         assertNull(getTestXmlParser("fallback_all_ignored.xml").parseContentElement(Manifest()))

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/TractPageTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/TractPageTest.kt
@@ -46,8 +46,15 @@ class TractPageTest : UsesResources("model/tract") {
     fun verifyParseCards() = runBlockingTest {
         val page = parsePageXml("page_cards.xml")
         assertEquals(2, page.cards.size)
-        assertEquals("Card 1", page.cards[0].label!!.text)
-        assertEquals("Card 2", page.cards[1].label!!.text)
+        assertEquals(TestColors.GREEN, page.cardBackgroundColor)
+        with(page.cards[0]) {
+            assertEquals("Card 1", label!!.text)
+            assertEquals(TestColors.BLACK, backgroundColor)
+        }
+        with(page.cards[1]) {
+            assertEquals("Card 2", label!!.text)
+            assertEquals(TestColors.GREEN, backgroundColor)
+        }
     }
 
     @Test

--- a/module/parser/src/commonTest/resources/org/cru/godtools/tool/model/card.xml
+++ b/module/parser/src/commonTest/resources/org/cru/godtools/tool/model/card.xml
@@ -1,0 +1,5 @@
+<content:card xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    background-color="rgba(255,0,0,1)" events="event" url="https://www.example.com">
+    <content:spacer height="10" mode="fixed" />
+    <content:text>Text</content:text>
+</content:card>

--- a/module/parser/src/commonTest/resources/org/cru/godtools/tool/model/card_defaults.xml
+++ b/module/parser/src/commonTest/resources/org/cru/godtools/tool/model/card_defaults.xml
@@ -1,0 +1,1 @@
+<content:card xmlns:content="https://mobile-content-api.cru.org/xmlns/content" />

--- a/module/parser/src/commonTest/resources/org/cru/godtools/tool/model/manifest_background.xml
+++ b/module/parser/src/commonTest/resources/org/cru/godtools/tool/model/manifest_background.xml
@@ -1,7 +1,7 @@
 <manifest xmlns="https://mobile-content-api.cru.org/xmlns/manifest"
-    xmlns:tract="https://mobile-content-api.cru.org/xmlns/tract" background-color="rgba(0,255,0,1)"
-    background-image="file.jpg" background-image-align="top end" background-image-scale-type="fit"
-    tract:card-background-color="rgba(0,0,255,1)">
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    background-color="rgba(0,255,0,1)" background-image="file.jpg" background-image-align="top end"
+    background-image-scale-type="fit" content:card-background-color="rgba(0,0,255,1)">
     <resources>
         <resource filename="file.jpg" src="sha1.jpg" />
     </resources>

--- a/module/parser/src/commonTest/resources/org/cru/godtools/tool/model/tract/page_cards.xml
+++ b/module/parser/src/commonTest/resources/org/cru/godtools/tool/model/tract/page_cards.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <page xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
-    xmlns="https://mobile-content-api.cru.org/xmlns/tract">
+    xmlns="https://mobile-content-api.cru.org/xmlns/tract"
+    content:card-background-color="rgba(0,255,0,1)">
     <cards>
-        <card card-background-color="rgba(0,0,0,1)">
+        <card background-color="rgba(0,0,0,1)">
             <label>
                 <content:text>Card 1</content:text>
             </label>


### PR DESCRIPTION
Create the following new model:
- `Card`
   - has a `backgroundColor` property that defines the background color of the card
   - implements `Clickable` interface so you can make a card clickable to trigger events or open a URL
   - implements `Parent` interface because it contains a `content` stack
