### PR TITLE
cleanup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Run Android Unit Tests
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: test jacocoTestReport --scan
+          arguments: test jacocoTestReport --scan --no-build-cache
       - name: Codecov
         uses: codecov/codecov-action@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Run Android Unit Tests
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: test jacocoTestReport
+          arguments: test jacocoTestReport --scan
       - name: Codecov
         uses: codecov/codecov-action@v2
         with:

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Accordion.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Accordion.kt
@@ -16,7 +16,6 @@ class Accordion : Content {
     val sections: List<Section>
     override val tips get() = sections.flatMap { it.contentTips }
 
-    @OptIn(ExperimentalStdlibApi::class)
     internal constructor(parent: Base, parser: XmlPullParser) : super(parent, parser) {
         parser.require(XmlPullParser.START_TAG, XMLNS_CONTENT, XML_ACCORDION)
 

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/AnalyticsEvent.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/AnalyticsEvent.kt
@@ -30,7 +30,6 @@ private const val XML_ATTRIBUTE = "attribute"
 private const val XML_ATTRIBUTE_KEY = "key"
 private const val XML_ATTRIBUTE_VALUE = "value"
 
-@OptIn(ExperimentalStdlibApi::class)
 class AnalyticsEvent : BaseModel {
     internal companion object {
         internal const val XML_EVENTS = "events"

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Category.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Category.kt
@@ -10,7 +10,6 @@ private const val XML_LABEL = "label"
 private const val XML_BANNER = "banner"
 private const val XML_AEM_TAG = "aem-tag"
 
-@OptIn(ExperimentalStdlibApi::class)
 class Category : BaseModel, Styles {
     internal companion object {
         internal const val XML_CATEGORY = "category"

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
@@ -54,7 +54,6 @@ private const val XML_TIPS_TIP = "tip"
 private const val XML_TIPS_TIP_ID = "id"
 private const val XML_TIPS_TIP_SRC = "src"
 
-@OptIn(ExperimentalStdlibApi::class)
 class Manifest : BaseModel, Styles {
     internal companion object {
         @AndroidColorInt

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Parent.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Parent.kt
@@ -14,7 +14,6 @@ internal inline val Parent.contentTips get() = content.flatMap { it.tips }
  * @param block Custom parsing logic, if the block processes the current tag,
  * it should advance the parser to the END_TAG event.
  */
-@OptIn(ExperimentalStdlibApi::class)
 internal inline fun Parent.parseContent(
     parser: XmlPullParser,
     block: () -> Unit = { }

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Tabs.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Tabs.kt
@@ -18,7 +18,6 @@ class Tabs : Content {
     val tabs: List<Tab>
     override val tips get() = tabs.flatMap { it.contentTips }
 
-    @OptIn(ExperimentalStdlibApi::class)
     internal constructor(parent: Base, parser: XmlPullParser) : super(parent, parser) {
         parser.require(XmlPullParser.START_TAG, XMLNS_CONTENT, XML_TABS)
 

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/tips/Tip.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/tips/Tip.kt
@@ -18,7 +18,6 @@ private const val XML_TYPE_PREPARE = "prepare"
 private const val XML_TYPE_QUOTE = "quote"
 private const val XML_PAGES = "pages"
 
-@OptIn(ExperimentalStdlibApi::class)
 class Tip : BaseModel, Styles {
     val id: String
     val type: Type

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/TractPage.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/TractPage.kt
@@ -252,7 +252,6 @@ class TractPage : Page {
         }
     }
 
-    @OptIn(ExperimentalStdlibApi::class)
     private fun XmlPullParser.parseCardsXml() = buildList {
         require(XmlPullParser.START_TAG, XMLNS_TRACT, XML_CARDS)
         parseChildren {
@@ -265,7 +264,6 @@ class TractPage : Page {
     }
     // endregion Cards
 
-    @OptIn(ExperimentalStdlibApi::class)
     private fun XmlPullParser.parseModalsXml() = buildList {
         require(XmlPullParser.START_TAG, XMLNS_TRACT, XML_MODALS)
         parseChildren {


### PR DESCRIPTION
- remove Opt-Ins that are no longer necessary
- add build scans for Android Unit tests
- disable the build-cache because jacoco doesn't seem to correctly utilize the build cache
