### PR TITLE
cleanup

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,9 +3,9 @@ import org.ajoberstar.grgit.Grgit
 plugins {
     kotlin("multiplatform")
     kotlin("native.cocoapods")
-    id("org.ajoberstar.grgit") version "4.1.1"
-    id("org.jlleitschuh.gradle.ktlint") version "10.2.1"
-    id("com.vanniktech.android.junit.jacoco") version "0.16.0"
+    alias(libs.plugins.grgit)
+    alias(libs.plugins.junitJacoco)
+    alias(libs.plugins.ktlint)
 }
 
 allprojects {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,3 +33,8 @@ okio-js = { module = "com.squareup.okio:okio-js", version.ref = "okio" }
 okio-nodefilesystem = { module = "com.squareup.okio:okio-nodefilesystem", version.ref = "okio" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 splitties-bitflags = { module = "com.louiscad.splitties:splitties-bitflags", version.ref = "splitties" }
+
+[plugins]
+grgit = { id = "org.ajoberstar.grgit", version = "4.1.1" }
+junitJacoco = { id = "com.vanniktech.android.junit.jacoco", version = "0.16.0" }
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version = "10.2.1" }

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Button.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Button.kt
@@ -30,7 +30,7 @@ class Button : Content, Styles, HasAnalyticsEvents, Clickable {
         internal const val XML_BUTTON = "button"
 
         internal val DEFAULT_BACKGROUND_COLOR = TRANSPARENT
-        internal val DEFAULT_ICON_GRAVITY = Gravity.START
+        internal val DEFAULT_ICON_GRAVITY = Gravity.Horizontal.START
         internal const val DEFAULT_ICON_SIZE = 18
     }
 
@@ -56,7 +56,7 @@ class Button : Content, Styles, HasAnalyticsEvents, Clickable {
     private val iconName: String?
     val icon get() = getResource(iconName)
     internal val iconSize: Int
-    internal val iconGravity: Gravity
+    internal val iconGravity: Gravity.Horizontal
 
     val text: Text?
     override val textAlign get() = Text.Align.CENTER
@@ -82,7 +82,7 @@ class Button : Content, Styles, HasAnalyticsEvents, Clickable {
         backgroundColor = parser.getAttributeValue(XML_BACKGROUND_COLOR)?.toColorOrNull() ?: DEFAULT_BACKGROUND_COLOR
 
         iconName = parser.getAttributeValue(XML_ICON)
-        iconGravity = parser.getAttributeValue(XML_ICON_GRAVITY)?.toGravityOrNull() ?: DEFAULT_ICON_GRAVITY
+        iconGravity = parser.getAttributeValue(XML_ICON_GRAVITY).toGravityOrNull()?.horizontal ?: DEFAULT_ICON_GRAVITY
         iconSize = parser.getAttributeValue(XML_ICON_SIZE)?.toIntOrNull() ?: DEFAULT_ICON_SIZE
 
         // process any child elements

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Flow.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Flow.kt
@@ -18,7 +18,6 @@ class Flow : Content {
         internal const val XML_FLOW = "flow"
         private const val XML_ITEM_WIDTH = "item-width"
 
-        @VisibleForTesting
         internal val DEFAULT_ITEM_WIDTH = Dimension.Percent(1f)
         internal val DEFAULT_ROW_GRAVITY = Gravity.Horizontal.START
     }

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Gravity.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Gravity.kt
@@ -45,40 +45,43 @@ class Gravity internal constructor(private val gravity: Int) {
         val CENTER = Gravity(0)
         internal val START = Gravity(BIT_START)
 
-        internal fun String.toGravityOrNull() = try {
-            var gravity = 0
-            var seenX = false
-            var seenY = false
-            REGEX_SEQUENCE_SEPARATOR.split(this).forEach {
-                when (it) {
-                    XML_START -> {
-                        require(!seenX) { "multiple X-Axis gravities in: $this" }
-                        gravity = gravity.minusFlag(MASK_X_AXIS).withFlag(BIT_START)
-                        seenX = true
+        internal fun String?.toGravityOrNull(): Gravity? {
+            if (this == null) return null
+            try {
+                var gravity = 0
+                var seenX = false
+                var seenY = false
+                REGEX_SEQUENCE_SEPARATOR.split(this).forEach {
+                    when (it) {
+                        XML_START -> {
+                            require(!seenX) { "multiple X-Axis gravities in: $this" }
+                            gravity = gravity.minusFlag(MASK_X_AXIS).withFlag(BIT_START)
+                            seenX = true
+                        }
+                        XML_END -> {
+                            require(!seenX) { "multiple X-Axis gravities in: $this" }
+                            gravity = gravity.minusFlag(MASK_X_AXIS).withFlag(BIT_END)
+                            seenX = true
+                        }
+                        XML_TOP -> {
+                            require(!seenY) { "multiple Y-Axis gravities in: $this" }
+                            gravity = gravity.minusFlag(MASK_Y_AXIS).withFlag(BIT_TOP)
+                            seenY = true
+                        }
+                        XML_BOTTOM -> {
+                            require(!seenY) { "multiple Y-Axis gravities in: $this" }
+                            gravity = gravity.minusFlag(MASK_Y_AXIS).withFlag(BIT_BOTTOM)
+                            seenY = true
+                        }
+                        XML_CENTER -> Unit
                     }
-                    XML_END -> {
-                        require(!seenX) { "multiple X-Axis gravities in: $this" }
-                        gravity = gravity.minusFlag(MASK_X_AXIS).withFlag(BIT_END)
-                        seenX = true
-                    }
-                    XML_TOP -> {
-                        require(!seenY) { "multiple Y-Axis gravities in: $this" }
-                        gravity = gravity.minusFlag(MASK_Y_AXIS).withFlag(BIT_TOP)
-                        seenY = true
-                    }
-                    XML_BOTTOM -> {
-                        require(!seenY) { "multiple Y-Axis gravities in: $this" }
-                        gravity = gravity.minusFlag(MASK_Y_AXIS).withFlag(BIT_BOTTOM)
-                        seenY = true
-                    }
-                    XML_CENTER -> Unit
                 }
-            }
 
-            Gravity(gravity)
-        } catch (e: IllegalArgumentException) {
-            Napier.e(tag = "Gravity", throwable = e, message = { "error parsing Gravity: $this" })
-            null
+                return Gravity(gravity)
+            } catch (e: IllegalArgumentException) {
+                Napier.e(tag = "Gravity", throwable = e, message = { "error parsing Gravity: $this" })
+                return null
+            }
         }
     }
 

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ButtonTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ButtonTest.kt
@@ -43,7 +43,7 @@ class ButtonTest : UsesResources() {
             assertEquals(Button.DEFAULT_BACKGROUND_COLOR, backgroundColor)
 
             assertNull(icon)
-            assertTrue(iconGravity.isStart)
+            assertEquals(Gravity.Horizontal.START, iconGravity)
             assertEquals(Button.DEFAULT_ICON_SIZE, iconSize)
         }
     }
@@ -84,7 +84,7 @@ class ButtonTest : UsesResources() {
         val resource = Resource(name = "image.png")
         with(Button(Manifest(resources = { listOf(resource) }), getTestXmlParser("button_icon.xml"))) {
             assertSame(resource, icon)
-            assertTrue(iconGravity.isEnd)
+            assertEquals(Gravity.Horizontal.END, iconGravity)
             assertEquals(24, iconSize)
         }
     }

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/GravityTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/GravityTest.kt
@@ -70,7 +70,8 @@ class GravityTest {
     }
 
     @Test
-    fun verifyParseConflictingGravity() {
+    fun verifyParseInvalidGravity() {
+        assertNull((null as String?).toGravityOrNull())
         assertNull("start end".toGravityOrNull())
         assertNull("end start".toGravityOrNull())
         assertNull("start top end".toGravityOrNull())


### PR DESCRIPTION
- track plugins in version catalog
- this needs to be internal not just for tests
- update `toGravityOrNull` to accept a null receiver
- make Button.iconGravity only return the horizontal gravity
