### PR TITLE
cleanup

### DIFF
--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Flow.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Flow.kt
@@ -76,8 +76,8 @@ class Flow : Content {
             _width = parser.getAttributeValue(XML_WIDTH).toDimensionOrNull()
 
             parser.parseVisibilityAttrs { invisibleIf, goneIf ->
-                this.invisibleIf = invisibleIf
-                this.goneIf = goneIf
+                this.invisibleIf = invisibleIf?.takeIf { it.isValid() }
+                this.goneIf = goneIf?.takeIf { it.isValid() }
             }
 
             content = parseContent(parser)

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
@@ -18,7 +18,6 @@ import org.cru.godtools.tool.model.Multiselect.Companion.XML_MULTISELECT_OPTION_
 import org.cru.godtools.tool.model.Multiselect.Companion.XML_MULTISELECT_OPTION_SELECTED_COLOR
 import org.cru.godtools.tool.model.Styles.Companion.DEFAULT_TEXT_SCALE
 import org.cru.godtools.tool.model.lesson.DEFAULT_LESSON_NAV_BAR_COLOR
-import org.cru.godtools.tool.model.lesson.LessonPage
 import org.cru.godtools.tool.model.lesson.XMLNS_LESSON
 import org.cru.godtools.tool.model.page.DEFAULT_CONTROL_COLOR
 import org.cru.godtools.tool.model.page.Page
@@ -151,15 +150,10 @@ class Manifest : BaseModel, Styles {
     private val _title: Text?
     val title: String? get() = _title?.text
 
+    val aemImports: List<Uri>
     val categories: List<Category>
     var pages: List<Page> by setOnce()
         private set
-    @Deprecated("Since v0.4.0, use pages instead which will support different page types in the future.")
-    val lessonPages get() = pages.filterIsInstance<LessonPage>()
-    @Deprecated("Since v0.4.0, use pages instead which will support different page types in the future.")
-    val tractPages get() = pages.filterIsInstance<TractPage>()
-    val aemImports: List<Uri>
-
     @VisibleForTesting
     internal val resources: Map<String?, Resource>
     var tips: Map<String, Tip> by setOnce()

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
@@ -9,6 +9,7 @@ import org.cru.godtools.tool.internal.AndroidColorInt
 import org.cru.godtools.tool.internal.DeprecationException
 import org.cru.godtools.tool.internal.RestrictTo
 import org.cru.godtools.tool.internal.RestrictToScope
+import org.cru.godtools.tool.internal.VisibleForTesting
 import org.cru.godtools.tool.internal.fluidlocale.PlatformLocale
 import org.cru.godtools.tool.internal.fluidlocale.toLocaleOrNull
 import org.cru.godtools.tool.model.Gravity.Companion.toGravityOrNull
@@ -159,8 +160,8 @@ class Manifest : BaseModel, Styles {
     val tractPages get() = pages.filterIsInstance<TractPage>()
     val aemImports: List<Uri>
 
-    // XXX: make this visible to aid in iOS migration
-    val resources: Map<String?, Resource>
+    @VisibleForTesting
+    internal val resources: Map<String?, Resource>
     var tips: Map<String, Tip> by setOnce()
         private set
 

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
@@ -24,7 +24,6 @@ import org.cru.godtools.tool.model.page.Page
 import org.cru.godtools.tool.model.page.XMLNS_PAGE
 import org.cru.godtools.tool.model.page.XML_CONTROL_COLOR
 import org.cru.godtools.tool.model.tips.Tip
-import org.cru.godtools.tool.model.tract.TractPage
 import org.cru.godtools.tool.util.setOnce
 import org.cru.godtools.tool.xml.XmlPullParser
 import org.cru.godtools.tool.xml.parseChildren
@@ -293,11 +292,6 @@ class Manifest : BaseModel, Styles {
     fun findCategory(category: String?) = categories.firstOrNull { it.id == category }
     fun findPage(id: String?) = id?.let { pages.firstOrNull { it.id == id } }
     fun findTip(id: String?) = tips[id]
-    @Deprecated(
-        "Since v0.4.0, use findPage(id) instead which will support different page types in the future.",
-        ReplaceWith("findPage(id)")
-    )
-    fun findTractPage(id: String?) = findPage(id) as? TractPage
 
     private fun XmlPullParser.parseCategories() = buildList {
         require(XmlPullParser.START_TAG, XMLNS_MANIFEST, XML_CATEGORIES)

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
@@ -211,7 +211,7 @@ class Manifest : BaseModel, Styles {
         var title: Text? = null
         aemImports = mutableListOf()
         categories = mutableListOf()
-        val resources = mutableListOf<Resource>()
+        resources = mutableMapOf()
         pagesToParse = mutableListOf()
         tipsToParse = mutableListOf()
         parser.parseChildren {
@@ -224,14 +224,13 @@ class Manifest : BaseModel, Styles {
                         aemImports += result.aemImports
                         pagesToParse += result.pages
                     }
-                    XML_RESOURCES -> resources += parser.parseResources()
+                    XML_RESOURCES -> resources += parser.parseResources().associateBy { it.name }
                     XML_TIPS -> tipsToParse += parser.parseTips()
                 }
             }
         }
 
         _title = title
-        this.resources = resources.associateBy { it.name }
     }
 
     @RestrictTo(RestrictToScope.TESTS)

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/FlowTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/FlowTest.kt
@@ -64,6 +64,19 @@ class FlowTest : UsesResources() {
     }
 
     @Test
+    fun testParseFlowItemVisibilityInvalid() = runTest {
+        val flow = Flow(Manifest(), getTestXmlParser("flow_visibility_invalid.xml"))
+        assertEquals(1, flow.items.size)
+        with(flow.items[0]) {
+            assertNull(invisibleIf)
+            assertFalse(isInvisible(state))
+
+            assertNull(goneIf)
+            assertFalse(isGone(state))
+        }
+    }
+
+    @Test
     fun testRowGravity() {
         with(null as Flow?) {
             assertEquals(DEFAULT_ROW_GRAVITY, rowGravity)

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ManifestTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ManifestTest.kt
@@ -48,8 +48,6 @@ class ManifestTest : UsesResources() {
         assertEquals(DEFAULT_TEXT_SCALE, manifest.textScale, 0.0001)
         assertEquals(0, manifest.aemImports.size)
         assertTrue(manifest.pages.isEmpty())
-        assertTrue(manifest.lessonPages.isEmpty())
-        assertTrue(manifest.tractPages.isEmpty())
         assertEquals(0, manifest.resources.size)
         assertEquals(0, manifest.tips.size)
     }
@@ -97,9 +95,8 @@ class ManifestTest : UsesResources() {
         assertEquals(TestColors.RED, manifest.multiselectOptionBackgroundColor)
         assertEquals(TestColors.GREEN, manifest.multiselectOptionSelectedColor)
 
-        assertTrue(manifest.tractPages.isEmpty())
-        assertEquals(1, manifest.lessonPages.size)
-        assertEquals("page0.xml", manifest.lessonPages[0].fileName)
+        assertEquals(1, manifest.pages.size)
+        assertEquals("page0.xml", manifest.pages[0].fileName)
         assertEquals(1, manifest.pages.size)
         assertEquals("page0.xml", manifest.pages[0].fileName)
         assertEquals("page_defaults", manifest.pages[0].id)
@@ -116,13 +113,11 @@ class ManifestTest : UsesResources() {
         assertEquals(color(255, 0, 255, 1.0), manifest.navBarControlColor)
         assertEquals(color(255, 255, 0, 1.0), manifest.pageControlColor)
         assertEquals(1.2345, manifest.textScale, 0.00001)
-        assertTrue(manifest.lessonPages.isEmpty())
         assertEquals(2, manifest.pages.size)
-        assertEquals(2, manifest.tractPages.size)
-        assertEquals("page0.xml", manifest.tractPages[0].fileName)
-        assertEquals(0, manifest.tractPages[0].position)
-        assertEquals(null, manifest.tractPages[1].fileName)
-        assertEquals(1, manifest.tractPages[1].position)
+        assertEquals("page0.xml", manifest.pages[0].fileName)
+        assertEquals(0, manifest.pages[0].position)
+        assertEquals(null, manifest.pages[1].fileName)
+        assertEquals(1, manifest.pages[1].position)
     }
 
     @Test
@@ -141,7 +136,7 @@ class ManifestTest : UsesResources() {
     @Test
     fun testParseManifestContainingTips() = runTest {
         val manifest = parseManifest("manifest_tips.xml")
-        assertEquals(0, manifest.tractPages.size)
+        assertEquals(0, manifest.pages.size)
         assertEquals(0, manifest.resources.size)
         assertEquals(1, manifest.tips.size)
         assertEquals("tip1", manifest.findTip("tip1")!!.id)
@@ -150,7 +145,7 @@ class ManifestTest : UsesResources() {
     @Test
     fun testParseManifestInvalidTips() = runTest {
         val manifest = parseManifest("manifest_tips_invalid.xml")
-        assertEquals(0, manifest.tractPages.size)
+        assertEquals(0, manifest.pages.size)
         assertEquals(0, manifest.resources.size)
         assertEquals(0, manifest.tips.size)
     }
@@ -159,11 +154,11 @@ class ManifestTest : UsesResources() {
     // endregion parse Manifest
 
     @Test
-    fun testManifestFindTractPage() {
+    fun testManifestFindPage() {
         val manifest = Manifest(code = "tool", pages = { manifest -> List(10) { TractPage(manifest) } })
-        assertNull(manifest.findTractPage("invalid"))
-        manifest.tractPages.forEach { page ->
-            assertSame(page, manifest.findTractPage(page.id))
+        assertNull(manifest.findPage("invalid"))
+        manifest.pages.forEach { page ->
+            assertSame(page, manifest.findPage(page.id))
         }
     }
 

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/TractPageTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/TractPageTest.kt
@@ -70,10 +70,10 @@ class TractPageTest : UsesResources("model/tract") {
     @Test
     fun testIsLastPage() {
         val manifest = Manifest(pages = { manifest -> List(3) { TractPage(manifest) } })
-        assertEquals(3, manifest.tractPages.size)
-        assertFalse(manifest.tractPages[0].isLastPage)
-        assertFalse(manifest.tractPages[1].isLastPage)
-        assertTrue(manifest.tractPages[2].isLastPage)
+        assertEquals(3, manifest.pages.size)
+        assertFalse((manifest.pages[0] as TractPage).isLastPage)
+        assertFalse((manifest.pages[1] as TractPage).isLastPage)
+        assertTrue((manifest.pages[2] as TractPage).isLastPage)
     }
 
     @Test

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/service/ManifestParserTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/service/ManifestParserTest.kt
@@ -19,7 +19,7 @@ class ManifestParserTest : UsesResources("service") {
     @Test
     fun testParseManifest() = runTest {
         val result = assertIs<ParserResult.Data>(parser.parseManifest("manifest_valid.xml"))
-        assertEquals(2, result.manifest.tractPages.size)
+        assertEquals(2, result.manifest.pages.size)
     }
 
     @Test

--- a/module/parser/src/commonTest/resources/org/cru/godtools/tool/model/flow_visibility_invalid.xml
+++ b/module/parser/src/commonTest/resources/org/cru/godtools/tool/model/flow_visibility_invalid.xml
@@ -1,0 +1,5 @@
+<content:flow xmlns:content="https://mobile-content-api.cru.org/xmlns/content">
+    <content:item gone-if="a====c" invisible-if="a====c">
+        <content:text>Test</content:text>
+    </content:item>
+</content:flow>

--- a/module/parser/src/iosMain/kotlin/org/cru/godtools/tool/model/IosManifest.kt
+++ b/module/parser/src/iosMain/kotlin/org/cru/godtools/tool/model/IosManifest.kt
@@ -1,4 +1,18 @@
 package org.cru.godtools.tool.model
 
+import org.cru.godtools.tool.model.lesson.LessonPage
+import org.cru.godtools.tool.model.tract.TractPage
+
+@Deprecated(
+    "Since v0.4.0, use pages instead which will support different page types in the future.",
+    ReplaceWith("pages.filterIsInstance<LessonPage>()", "org.cru.godtools.tool.model.lesson.LessonPage")
+)
+val Manifest.lessonPages get() = pages.filterIsInstance<LessonPage>()
+@Deprecated(
+    "Since v0.4.0, use pages instead which will support different page types in the future.",
+    ReplaceWith("pages.filterIsInstance<TractPage>()", "org.cru.godtools.tool.model.tract.TractPage")
+)
+val Manifest.tractPages get() = pages.filterIsInstance<TractPage>()
+
 @Deprecated("This is provided to aid in iOS migration")
 val Manifest?.resources get() = this?.resources.orEmpty()

--- a/module/parser/src/iosMain/kotlin/org/cru/godtools/tool/model/IosManifest.kt
+++ b/module/parser/src/iosMain/kotlin/org/cru/godtools/tool/model/IosManifest.kt
@@ -1,0 +1,4 @@
+package org.cru.godtools.tool.model
+
+@Deprecated("This is provided to aid in iOS migration")
+val Manifest?.resources get() = this?.resources.orEmpty()


### PR DESCRIPTION
- only take expressions that are valid for flow visibility
- simplify resource parsing logic
- move several deprecated Manifest methods to be iOS only
