### PR TITLE
Cleanup Gravity class

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,6 @@ ktlint = "0.42.1"
 napier = "2.4.0"
 okio = "3.0.0"
 robolectric = "4.7.3"
-splitties = "3.0.0"
 
 [libraries]
 android-gradle = "com.android.tools.build:gradle:7.1.2"
@@ -32,7 +31,6 @@ napier = { module = "io.github.aakira:napier", version.ref = "napier" }
 okio-js = { module = "com.squareup.okio:okio-js", version.ref = "okio" }
 okio-nodefilesystem = { module = "com.squareup.okio:okio-nodefilesystem", version.ref = "okio" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
-splitties-bitflags = { module = "com.louiscad.splitties:splitties-bitflags", version.ref = "splitties" }
 
 [plugins]
 grgit = { id = "org.ajoberstar.grgit", version = "5.0.0" }

--- a/module/parser/build.gradle.kts
+++ b/module/parser/build.gradle.kts
@@ -21,7 +21,6 @@ kotlin {
                 implementation(libs.colormath)
                 implementation(libs.fluidLocale)
                 implementation(libs.napier)
-                implementation(libs.splitties.bitflags)
             }
         }
         val androidMain by getting {

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Gravity.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Gravity.kt
@@ -2,8 +2,6 @@ package org.cru.godtools.tool.model
 
 import io.github.aakira.napier.Napier
 import org.cru.godtools.tool.REGEX_SEQUENCE_SEPARATOR
-import splitties.bitflags.minusFlag
-import splitties.bitflags.withFlag
 
 private const val XML_START = "start"
 private const val XML_END = "end"
@@ -11,26 +9,7 @@ private const val XML_TOP = "top"
 private const val XML_BOTTOM = "bottom"
 private const val XML_CENTER = "center"
 
-private const val BIT_START = 1 shl 0
-private const val BIT_END = 1 shl 1
-private const val BIT_TOP = 1 shl 2
-private const val BIT_BOTTOM = 1 shl 3
-
-private const val MASK_X_AXIS = BIT_START or BIT_END
-private const val MASK_Y_AXIS = BIT_TOP or BIT_BOTTOM
-
-class Gravity internal constructor(gravity: Int) {
-    val horizontal = when {
-        gravity and MASK_X_AXIS == BIT_START -> Horizontal.START
-        gravity and MASK_X_AXIS == BIT_END -> Horizontal.END
-        else -> Horizontal.CENTER
-    }
-    val vertical = when {
-        gravity and MASK_Y_AXIS == BIT_TOP -> Vertical.TOP
-        gravity and MASK_Y_AXIS == BIT_BOTTOM -> Vertical.BOTTOM
-        else -> Vertical.CENTER
-    }
-
+class Gravity internal constructor(val horizontal: Horizontal, val vertical: Vertical) {
     val isStart get() = horizontal == Horizontal.START
     val isEnd get() = horizontal == Horizontal.END
     val isCenterX get() = horizontal == Horizontal.CENTER
@@ -40,41 +19,36 @@ class Gravity internal constructor(gravity: Int) {
     val isCenter get() = isCenterX && isCenterY
 
     companion object {
-        val CENTER = Gravity(0)
+        val CENTER = Gravity(Horizontal.CENTER, Vertical.CENTER)
 
         internal fun String?.toGravityOrNull(): Gravity? {
             if (this == null) return null
             try {
-                var gravity = 0
-                var seenX = false
-                var seenY = false
+                var horizontal: Horizontal? = null
+                var vertical: Vertical? = null
                 REGEX_SEQUENCE_SEPARATOR.split(this).forEach {
                     when (it) {
                         XML_START -> {
-                            require(!seenX) { "multiple X-Axis gravities in: $this" }
-                            gravity = gravity.minusFlag(MASK_X_AXIS).withFlag(BIT_START)
-                            seenX = true
+                            require(horizontal == null) { "multiple X-Axis gravities in: $this" }
+                            horizontal = Horizontal.START
                         }
                         XML_END -> {
-                            require(!seenX) { "multiple X-Axis gravities in: $this" }
-                            gravity = gravity.minusFlag(MASK_X_AXIS).withFlag(BIT_END)
-                            seenX = true
+                            require(horizontal == null) { "multiple X-Axis gravities in: $this" }
+                            horizontal = Horizontal.END
                         }
                         XML_TOP -> {
-                            require(!seenY) { "multiple Y-Axis gravities in: $this" }
-                            gravity = gravity.minusFlag(MASK_Y_AXIS).withFlag(BIT_TOP)
-                            seenY = true
+                            require(vertical == null) { "multiple Y-Axis gravities in: $this" }
+                            vertical = Vertical.TOP
                         }
                         XML_BOTTOM -> {
-                            require(!seenY) { "multiple Y-Axis gravities in: $this" }
-                            gravity = gravity.minusFlag(MASK_Y_AXIS).withFlag(BIT_BOTTOM)
-                            seenY = true
+                            require(vertical == null) { "multiple Y-Axis gravities in: $this" }
+                            vertical = Vertical.BOTTOM
                         }
                         XML_CENTER -> Unit
                     }
                 }
 
-                return Gravity(gravity)
+                return Gravity(horizontal ?: Horizontal.CENTER, vertical ?: Vertical.CENTER)
             } catch (e: IllegalArgumentException) {
                 Napier.e(tag = "Gravity", throwable = e, message = { "error parsing Gravity: $this" })
                 return null

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Gravity.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Gravity.kt
@@ -19,27 +19,25 @@ private const val BIT_BOTTOM = 1 shl 3
 private const val MASK_X_AXIS = BIT_START or BIT_END
 private const val MASK_Y_AXIS = BIT_TOP or BIT_BOTTOM
 
-class Gravity internal constructor(private val gravity: Int) {
-    val isStart get() = gravity and MASK_X_AXIS == BIT_START
-    val isEnd get() = gravity and MASK_X_AXIS == BIT_END
-    val isCenterX get() = gravity and MASK_X_AXIS == 0
-    val isTop get() = gravity and MASK_Y_AXIS == BIT_TOP
-    val isBottom get() = gravity and MASK_Y_AXIS == BIT_BOTTOM
-    val isCenterY get() = gravity and MASK_Y_AXIS == 0
-    val isCenter get() = gravity and (MASK_X_AXIS or MASK_Y_AXIS) == 0
+class Gravity internal constructor(gravity: Int) {
+    val horizontal = when {
+        gravity and MASK_X_AXIS == BIT_START -> Horizontal.START
+        gravity and MASK_X_AXIS == BIT_END -> Horizontal.END
+        else -> Horizontal.CENTER
+    }
+    val vertical = when {
+        gravity and MASK_Y_AXIS == BIT_TOP -> Vertical.TOP
+        gravity and MASK_Y_AXIS == BIT_BOTTOM -> Vertical.BOTTOM
+        else -> Vertical.CENTER
+    }
 
-    val horizontal
-        get() = when {
-            isStart -> Horizontal.START
-            isEnd -> Horizontal.END
-            else -> Horizontal.CENTER
-        }
-    val vertical
-        get() = when {
-            isTop -> Vertical.TOP
-            isBottom -> Vertical.BOTTOM
-            else -> Vertical.CENTER
-        }
+    val isStart get() = horizontal == Horizontal.START
+    val isEnd get() = horizontal == Horizontal.END
+    val isCenterX get() = horizontal == Horizontal.CENTER
+    val isTop get() = vertical == Vertical.TOP
+    val isBottom get() = vertical == Vertical.BOTTOM
+    val isCenterY get() = vertical == Vertical.CENTER
+    val isCenter get() = isCenterX && isCenterY
 
     companion object {
         val CENTER = Gravity(0)

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Gravity.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Gravity.kt
@@ -2,6 +2,7 @@ package org.cru.godtools.tool.model
 
 import io.github.aakira.napier.Napier
 import org.cru.godtools.tool.REGEX_SEQUENCE_SEPARATOR
+import org.cru.godtools.tool.internal.VisibleForTesting
 
 private const val XML_START = "start"
 private const val XML_END = "end"
@@ -9,7 +10,7 @@ private const val XML_TOP = "top"
 private const val XML_BOTTOM = "bottom"
 private const val XML_CENTER = "center"
 
-class Gravity internal constructor(val horizontal: Horizontal, val vertical: Vertical) {
+class Gravity @VisibleForTesting constructor(val horizontal: Horizontal, val vertical: Vertical) {
     val isStart get() = horizontal == Horizontal.START
     val isEnd get() = horizontal == Horizontal.END
     val isCenterX get() = horizontal == Horizontal.CENTER

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Gravity.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Gravity.kt
@@ -41,7 +41,6 @@ class Gravity internal constructor(gravity: Int) {
 
     companion object {
         val CENTER = Gravity(0)
-        internal val START = Gravity(BIT_START)
 
         internal fun String?.toGravityOrNull(): Gravity? {
             if (this == null) return null

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/GravityTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/GravityTest.kt
@@ -57,6 +57,12 @@ class GravityTest {
             assertEquals(Gravity.Vertical.TOP, vertical)
         }
 
+        with("top center".toGravityOrNull()!!) {
+            assertFalse(isCenter)
+            assertEquals(Gravity.Vertical.TOP, vertical)
+            assertEquals(Gravity.Horizontal.CENTER, horizontal)
+        }
+
         with("end bottom".toGravityOrNull()!!) {
             assertFalse(isStart)
             assertTrue(isEnd)
@@ -64,6 +70,7 @@ class GravityTest {
             assertFalse(isTop)
             assertTrue(isBottom)
             assertFalse(isCenterY)
+            assertFalse(isCenter)
             assertEquals(Gravity.Horizontal.END, horizontal)
             assertEquals(Gravity.Vertical.BOTTOM, vertical)
         }

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/TestConstants.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/TestConstants.kt
@@ -1,9 +1,8 @@
 package org.cru.godtools.tool.model
 
 import kotlin.native.concurrent.SharedImmutable
-import kotlin.random.Random
 
 @SharedImmutable
-internal val TEST_GRAVITY = Gravity(Random.nextInt())
+internal val TEST_GRAVITY = Gravity(Gravity.Horizontal.values().random(), Gravity.Vertical.values().random())
 
 expect val TEST_URL: Uri


### PR DESCRIPTION
- track gravity by the horizontal and vertical component enums
- remove unused START gravity constant
- remove unnecessary bit math logic for tracking the gravity
- make the Gravity constructor visible for testing
