### PR TITLE
Don't implement Styles on a Button

### DIFF
--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/StylesOverride.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/StylesOverride.kt
@@ -4,14 +4,17 @@ import org.cru.godtools.tool.model.Styles.Companion.DEFAULT_TEXT_SCALE
 
 private class StylesOverride(
     parent: Base,
+    private val _textAlign: (() -> Text.Align?)?,
     private val _textColor: (() -> PlatformColor?)?,
     private val _textScale: Double
 ) : BaseModel(parent), Styles {
+    override val textAlign get() = _textAlign?.invoke() ?: super.textAlign
     override val textColor get() = _textColor?.invoke() ?: super.textColor
     override val textScale get() = super.textScale * _textScale
 }
 
 internal fun Base.stylesOverride(
+    textAlign: (() -> Text.Align?)? = null,
     textColor: (() -> PlatformColor?)? = null,
     textScale: Double = DEFAULT_TEXT_SCALE
-): Base = StylesOverride(this, textColor, textScale)
+): Base = StylesOverride(this, textAlign, textColor, textScale)

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ButtonTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ButtonTest.kt
@@ -27,6 +27,7 @@ class ButtonTest : UsesResources() {
         override lateinit var buttonStyle: Button.Style
         override var primaryColor = TestColors.BLACK
         override var primaryTextColor = TestColors.BLACK
+        override var textAlign = Text.Align.START
     }
     private val state = State()
 
@@ -173,6 +174,25 @@ class ButtonTest : UsesResources() {
         }
     }
     // endregion Property - buttonColor
+
+    // region Property - text - textAlign
+    @Test
+    fun testButtonTextTextAlignFallbackBehavior() {
+        parent.textAlign = Text.Align.START
+
+        // Buttons default to center aligned text
+        with(Button(parent, text = { Text(it) })) {
+            assertNotEquals(parent.textAlign, text!!.textAlign)
+            assertEquals(Text.Align.CENTER, text!!.textAlign)
+        }
+
+        // Text Align can still be overridden on the text element
+        with(Button(parent, text = { Text(it, textAlign = Text.Align.END) })) {
+            assertNotEquals(parent.textAlign, text!!.textAlign)
+            assertEquals(Text.Align.END, text!!.textAlign)
+        }
+    }
+    // endregion Property - text - textAlign
 
     // region Property - text - textColor
     @Test

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ButtonTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ButtonTest.kt
@@ -139,16 +139,23 @@ class ButtonTest : UsesResources() {
     }
     // endregion Property - isIgnored
 
-    // region Property - buttonStyle
+    // region Property - style
     @Test
     fun testButtonStyleUtilizesStylesDefault() {
-        val button = Button(parent)
+        with(Button(parent)) {
+            parent.buttonStyle = Button.Style.CONTAINED
+            assertEquals(Button.Style.CONTAINED, style)
+            parent.buttonStyle = Button.Style.OUTLINED
+            assertEquals(Button.Style.OUTLINED, style)
+        }
+
         parent.buttonStyle = Button.Style.CONTAINED
-        assertEquals(Button.Style.CONTAINED, button.buttonStyle)
-        parent.buttonStyle = Button.Style.OUTLINED
-        assertEquals(Button.Style.OUTLINED, button.buttonStyle)
+        with(Button(parent, style = Button.Style.OUTLINED)) {
+            assertNotEquals(parent.buttonStyle, style)
+            assertEquals(Button.Style.OUTLINED, style)
+        }
     }
-    // endregion Property - buttonStyle
+    // endregion Property - style
 
     // region Property - buttonColor
     @Test

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ButtonTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ButtonTest.kt
@@ -203,13 +203,13 @@ class ButtonTest : UsesResources() {
         with(Button(parent, style = Button.Style.CONTAINED, text = { Text(it) })) {
             assertNotEquals(parent.primaryColor, text!!.textColor)
             assertNotEquals(parent.textColor, text!!.textColor)
-            assertEquals(primaryTextColor, text!!.textColor)
+            assertNotEquals(buttonColor, text!!.textColor)
+            assertEquals(parent.primaryTextColor, text!!.textColor)
             assertEquals(TestColors.GREEN, text!!.textColor)
         }
 
         with(Button(parent, style = Button.Style.CONTAINED, text = { Text(it, textColor = TestColors.BLUE) })) {
-            assertNotEquals(primaryTextColor, text!!.textColor)
-            assertNotEquals(textColor, text!!.textColor)
+            assertNotEquals(parent.primaryTextColor, text!!.textColor)
             assertEquals(TestColors.BLUE, text!!.textColor)
         }
     }
@@ -236,7 +236,6 @@ class ButtonTest : UsesResources() {
             )
         ) {
             assertNotEquals(buttonColor, text!!.textColor)
-            assertNotEquals(textColor, text!!.textColor)
             assertEquals(TestColors.GREEN, text!!.textColor)
         }
     }

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ButtonTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ButtonTest.kt
@@ -1,5 +1,6 @@
 package org.cru.godtools.tool.model
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.cru.godtools.tool.FEATURE_MULTISELECT
 import org.cru.godtools.tool.ParserConfig
@@ -20,6 +21,7 @@ import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 @RunOnAndroidWith(AndroidJUnit4::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 class ButtonTest : UsesResources() {
     private val parent = object : BaseModel(), Styles {
         override lateinit var buttonStyle: Button.Style
@@ -28,6 +30,7 @@ class ButtonTest : UsesResources() {
     }
     private val state = State()
 
+    // region Parse Button
     @Test
     fun testParseButtonEvent() = runTest {
         val manifest = Manifest()
@@ -107,8 +110,9 @@ class ButtonTest : UsesResources() {
             assertTrue(isGone(state))
         }
     }
+    // endregion Parse Button
 
-    // region isIgnored
+    // region Property - isIgnored
     @Test
     fun testIsIgnoredClickable() {
         with(Button()) {
@@ -132,8 +136,9 @@ class ButtonTest : UsesResources() {
         val button = Button(style = Button.Style.UNKNOWN, events = listOf(EventId.FOLLOWUP))
         assertTrue(button.testIsIgnored)
     }
-    // endregion isIgnored
+    // endregion Property - isIgnored
 
+    // region Property - buttonStyle
     @Test
     fun testButtonStyleUtilizesStylesDefault() {
         val button = Button(parent)
@@ -142,21 +147,9 @@ class ButtonTest : UsesResources() {
         parent.buttonStyle = Button.Style.OUTLINED
         assertEquals(Button.Style.OUTLINED, button.buttonStyle)
     }
+    // endregion Property - buttonStyle
 
-    @Test
-    fun testButtonGetAnalyticsEvents() {
-        val defaultEvent = AnalyticsEvent(trigger = Trigger.DEFAULT)
-        val clickedEvent = AnalyticsEvent(trigger = Trigger.CLICKED)
-        val selectedEvent = AnalyticsEvent(trigger = Trigger.SELECTED)
-        val visibleEvent = AnalyticsEvent(trigger = Trigger.VISIBLE)
-        val button = Button(analyticsEvents = listOf(defaultEvent, clickedEvent, selectedEvent, visibleEvent))
-
-        assertEquals(listOf(defaultEvent, clickedEvent, selectedEvent), button.getAnalyticsEvents(Trigger.CLICKED))
-        assertFailsWith(IllegalStateException::class) { button.getAnalyticsEvents(Trigger.DEFAULT) }
-        assertFailsWith(IllegalStateException::class) { button.getAnalyticsEvents(Trigger.SELECTED) }
-        assertFailsWith(IllegalStateException::class) { button.getAnalyticsEvents(Trigger.VISIBLE) }
-    }
-
+    // region Property - buttonColor
     @Test
     fun testButtonColorFallbackBehavior() {
         val manifest = Manifest()
@@ -179,7 +172,9 @@ class ButtonTest : UsesResources() {
             assertNotEquals(manifest.primaryColor, buttonColor)
         }
     }
+    // endregion Property - buttonColor
 
+    // region Property - text - textColor
     @Test
     fun testButtonTextColorFallbackBehaviorContained() {
         parent.primaryColor = TestColors.RED
@@ -224,6 +219,21 @@ class ButtonTest : UsesResources() {
             assertNotEquals(textColor, text!!.textColor)
             assertEquals(TestColors.GREEN, text!!.textColor)
         }
+    }
+    // endregion Property - text - textColor
+
+    @Test
+    fun testButtonGetAnalyticsEvents() {
+        val defaultEvent = AnalyticsEvent(trigger = Trigger.DEFAULT)
+        val clickedEvent = AnalyticsEvent(trigger = Trigger.CLICKED)
+        val selectedEvent = AnalyticsEvent(trigger = Trigger.SELECTED)
+        val visibleEvent = AnalyticsEvent(trigger = Trigger.VISIBLE)
+        val button = Button(analyticsEvents = listOf(defaultEvent, clickedEvent, selectedEvent, visibleEvent))
+
+        assertEquals(listOf(defaultEvent, clickedEvent, selectedEvent), button.getAnalyticsEvents(Trigger.CLICKED))
+        assertFailsWith(IllegalStateException::class) { button.getAnalyticsEvents(Trigger.DEFAULT) }
+        assertFailsWith(IllegalStateException::class) { button.getAnalyticsEvents(Trigger.SELECTED) }
+        assertFailsWith(IllegalStateException::class) { button.getAnalyticsEvents(Trigger.VISIBLE) }
     }
 
     // region Button.Style


### PR DESCRIPTION
This removes the `Styles` interface from the `Button` model. The interface was included as an implementation details to provide default text styles to the child `Text` node. This is no longer necessary due to the `StylesOverride` internal util.

I made sure there was test coverage for all the properties that depended on the `Styles` interface to ensure functionality remained the same after the change.