### PR TITLE
GT-1449 configure parser with ParserConfig instance object

### DIFF
--- a/module/parser/src/androidMain/java/org/cru/godtools/tool/AndroidParserConfig.kt
+++ b/module/parser/src/androidMain/java/org/cru/godtools/tool/AndroidParserConfig.kt
@@ -2,6 +2,6 @@ package org.cru.godtools.tool
 
 import org.cru.godtools.tool.model.DeviceType
 
-actual typealias ParserConfig = SimpleParserConfig
+actual typealias LegacyParserConfig = SimpleParserConfig
 
 internal actual val DEFAULT_SUPPORTED_DEVICE_TYPES = setOf(DeviceType.ANDROID, DeviceType.MOBILE)

--- a/module/parser/src/androidMain/java/org/cru/godtools/tool/AndroidParserConfig.kt
+++ b/module/parser/src/androidMain/java/org/cru/godtools/tool/AndroidParserConfig.kt
@@ -2,6 +2,4 @@ package org.cru.godtools.tool
 
 import org.cru.godtools.tool.model.DeviceType
 
-actual typealias LegacyParserConfig = SimpleParserConfig
-
 internal actual val DEFAULT_SUPPORTED_DEVICE_TYPES = setOf(DeviceType.ANDROID, DeviceType.MOBILE)

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/ParserConfig.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/ParserConfig.kt
@@ -7,14 +7,19 @@ const val FEATURE_CONTENT_CARD = "content_card"
 const val FEATURE_FLOW = "flow"
 const val FEATURE_MULTISELECT = "multiselect"
 
-expect object LegacyParserConfig {
-    var supportedDeviceTypes: Set<DeviceType>
-    var supportedFeatures: Set<String>
+open class ParserConfig(
+    open val supportedFeatures: Set<String> = emptySet(),
+    open val supportedDeviceTypes: Set<DeviceType> = DEFAULT_SUPPORTED_DEVICE_TYPES
+)
+
+expect object LegacyParserConfig : ParserConfig {
+    override var supportedDeviceTypes: Set<DeviceType>
+    override var supportedFeatures: Set<String>
 }
 
-object SimpleParserConfig {
-    var supportedDeviceTypes = DEFAULT_SUPPORTED_DEVICE_TYPES
-    var supportedFeatures = emptySet<String>()
+object SimpleParserConfig : ParserConfig() {
+    override var supportedDeviceTypes = DEFAULT_SUPPORTED_DEVICE_TYPES
+    override var supportedFeatures = emptySet<String>()
 }
 
 internal expect val DEFAULT_SUPPORTED_DEVICE_TYPES: Set<DeviceType>

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/ParserConfig.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/ParserConfig.kt
@@ -7,19 +7,9 @@ const val FEATURE_CONTENT_CARD = "content_card"
 const val FEATURE_FLOW = "flow"
 const val FEATURE_MULTISELECT = "multiselect"
 
-open class ParserConfig(
-    open val supportedFeatures: Set<String> = emptySet(),
-    open val supportedDeviceTypes: Set<DeviceType> = DEFAULT_SUPPORTED_DEVICE_TYPES
+class ParserConfig(
+    val supportedFeatures: Set<String> = emptySet(),
+    val supportedDeviceTypes: Set<DeviceType> = DEFAULT_SUPPORTED_DEVICE_TYPES
 )
-
-expect object LegacyParserConfig : ParserConfig {
-    override var supportedDeviceTypes: Set<DeviceType>
-    override var supportedFeatures: Set<String>
-}
-
-object SimpleParserConfig : ParserConfig() {
-    override var supportedDeviceTypes = DEFAULT_SUPPORTED_DEVICE_TYPES
-    override var supportedFeatures = emptySet<String>()
-}
 
 internal expect val DEFAULT_SUPPORTED_DEVICE_TYPES: Set<DeviceType>

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/ParserConfig.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/ParserConfig.kt
@@ -7,7 +7,7 @@ const val FEATURE_CONTENT_CARD = "content_card"
 const val FEATURE_FLOW = "flow"
 const val FEATURE_MULTISELECT = "multiselect"
 
-expect object ParserConfig {
+expect object LegacyParserConfig {
     var supportedDeviceTypes: Set<DeviceType>
     var supportedFeatures: Set<String>
 }

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Animation.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Animation.kt
@@ -1,7 +1,7 @@
 package org.cru.godtools.tool.model
 
 import org.cru.godtools.tool.FEATURE_ANIMATION
-import org.cru.godtools.tool.ParserConfig
+import org.cru.godtools.tool.LegacyParserConfig
 import org.cru.godtools.tool.internal.RestrictTo
 import org.cru.godtools.tool.internal.RestrictToScope
 import org.cru.godtools.tool.internal.VisibleForTesting
@@ -61,5 +61,5 @@ class Animation : Content, Clickable {
         stopListeners = emptySet()
     }
 
-    override val isIgnored get() = FEATURE_ANIMATION !in ParserConfig.supportedFeatures || super.isIgnored
+    override val isIgnored get() = FEATURE_ANIMATION !in LegacyParserConfig.supportedFeatures || super.isIgnored
 }

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Animation.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Animation.kt
@@ -1,7 +1,6 @@
 package org.cru.godtools.tool.model
 
 import org.cru.godtools.tool.FEATURE_ANIMATION
-import org.cru.godtools.tool.LegacyParserConfig
 import org.cru.godtools.tool.internal.RestrictTo
 import org.cru.godtools.tool.internal.RestrictToScope
 import org.cru.godtools.tool.internal.VisibleForTesting
@@ -61,5 +60,5 @@ class Animation : Content, Clickable {
         stopListeners = emptySet()
     }
 
-    override val isIgnored get() = FEATURE_ANIMATION !in LegacyParserConfig.supportedFeatures || super.isIgnored
+    override val isIgnored get() = FEATURE_ANIMATION !in manifest.config.supportedFeatures || super.isIgnored
 }

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Animation.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Animation.kt
@@ -50,7 +50,7 @@ class Animation : Content, Clickable {
     }
 
     @RestrictTo(RestrictToScope.TESTS)
-    internal constructor() : super(Manifest()) {
+    internal constructor(parent: Base = Manifest()) : super(parent) {
         resourceName = null
         loop = true
         autoPlay = true

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Card.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Card.kt
@@ -1,7 +1,6 @@
 package org.cru.godtools.tool.model
 
 import org.cru.godtools.tool.FEATURE_CONTENT_CARD
-import org.cru.godtools.tool.LegacyParserConfig
 import org.cru.godtools.tool.internal.RestrictTo
 import org.cru.godtools.tool.internal.RestrictToScope
 import org.cru.godtools.tool.xml.XmlPullParser
@@ -41,7 +40,7 @@ class Card : Content, Parent, Clickable {
         url = null
     }
 
-    override val isIgnored get() = FEATURE_CONTENT_CARD !in LegacyParserConfig.supportedFeatures || super.isIgnored
+    override val isIgnored get() = FEATURE_CONTENT_CARD !in manifest.config.supportedFeatures || super.isIgnored
 }
 
 val Card?.backgroundColor get() = this?._backgroundColor ?: stylesParent.cardBackgroundColor

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Card.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Card.kt
@@ -1,7 +1,7 @@
 package org.cru.godtools.tool.model
 
 import org.cru.godtools.tool.FEATURE_CONTENT_CARD
-import org.cru.godtools.tool.ParserConfig
+import org.cru.godtools.tool.LegacyParserConfig
 import org.cru.godtools.tool.internal.RestrictTo
 import org.cru.godtools.tool.internal.RestrictToScope
 import org.cru.godtools.tool.xml.XmlPullParser
@@ -41,7 +41,7 @@ class Card : Content, Parent, Clickable {
         url = null
     }
 
-    override val isIgnored get() = FEATURE_CONTENT_CARD !in ParserConfig.supportedFeatures || super.isIgnored
+    override val isIgnored get() = FEATURE_CONTENT_CARD !in LegacyParserConfig.supportedFeatures || super.isIgnored
 }
 
 val Card?.backgroundColor get() = this?._backgroundColor ?: stylesParent.cardBackgroundColor

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Content.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Content.kt
@@ -1,7 +1,7 @@
 package org.cru.godtools.tool.model
 
 import org.cru.godtools.expressions.Expression
-import org.cru.godtools.tool.ParserConfig
+import org.cru.godtools.tool.LegacyParserConfig
 import org.cru.godtools.tool.REGEX_SEQUENCE_SEPARATOR
 import org.cru.godtools.tool.internal.RestrictTo
 import org.cru.godtools.tool.internal.RestrictToScope
@@ -56,7 +56,7 @@ abstract class Content : BaseModel, Visibility {
      */
     internal open val isIgnored
         get() = version > SCHEMA_VERSION ||
-            !ParserConfig.supportedFeatures.containsAll(requiredFeatures) ||
+            !LegacyParserConfig.supportedFeatures.containsAll(requiredFeatures) ||
             restrictTo.none { it in DeviceType.SUPPORTED } ||
             invisibleIf?.isValid() == false ||
             goneIf?.isValid() == false

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Content.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Content.kt
@@ -1,7 +1,6 @@
 package org.cru.godtools.tool.model
 
 import org.cru.godtools.expressions.Expression
-import org.cru.godtools.tool.LegacyParserConfig
 import org.cru.godtools.tool.REGEX_SEQUENCE_SEPARATOR
 import org.cru.godtools.tool.internal.RestrictTo
 import org.cru.godtools.tool.internal.RestrictToScope
@@ -56,8 +55,8 @@ abstract class Content : BaseModel, Visibility {
      */
     internal open val isIgnored
         get() = version > SCHEMA_VERSION ||
-            !LegacyParserConfig.supportedFeatures.containsAll(requiredFeatures) ||
-            restrictTo.none { it in DeviceType.SUPPORTED } ||
+            !manifest.config.supportedFeatures.containsAll(requiredFeatures) ||
+            restrictTo.none { it in manifest.config.supportedDeviceTypes } ||
             invisibleIf?.isValid() == false ||
             goneIf?.isValid() == false
 

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/DeviceType.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/DeviceType.kt
@@ -1,6 +1,5 @@
 package org.cru.godtools.tool.model
 
-import org.cru.godtools.tool.LegacyParserConfig
 import org.cru.godtools.tool.REGEX_SEQUENCE_SEPARATOR
 
 private const val XML_DEVICE_TYPE_ANDROID = "android"
@@ -13,7 +12,6 @@ enum class DeviceType {
 
     internal companion object {
         internal val ALL = values().toSet()
-        internal val SUPPORTED get() = LegacyParserConfig.supportedDeviceTypes
 
         private fun String.toDeviceType() = when (this) {
             XML_DEVICE_TYPE_ANDROID -> ANDROID

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/DeviceType.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/DeviceType.kt
@@ -1,6 +1,6 @@
 package org.cru.godtools.tool.model
 
-import org.cru.godtools.tool.ParserConfig
+import org.cru.godtools.tool.LegacyParserConfig
 import org.cru.godtools.tool.REGEX_SEQUENCE_SEPARATOR
 
 private const val XML_DEVICE_TYPE_ANDROID = "android"
@@ -13,7 +13,7 @@ enum class DeviceType {
 
     internal companion object {
         internal val ALL = values().toSet()
-        internal val SUPPORTED get() = ParserConfig.supportedDeviceTypes
+        internal val SUPPORTED get() = LegacyParserConfig.supportedDeviceTypes
 
         private fun String.toDeviceType() = when (this) {
             XML_DEVICE_TYPE_ANDROID -> ANDROID

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Flow.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Flow.kt
@@ -2,7 +2,6 @@ package org.cru.godtools.tool.model
 
 import org.cru.godtools.expressions.Expression
 import org.cru.godtools.tool.FEATURE_FLOW
-import org.cru.godtools.tool.LegacyParserConfig
 import org.cru.godtools.tool.internal.VisibleForTesting
 import org.cru.godtools.tool.model.Dimension.Companion.toDimensionOrNull
 import org.cru.godtools.tool.model.Flow.Companion.DEFAULT_ITEM_WIDTH
@@ -52,7 +51,7 @@ class Flow : Content {
         }
     }
 
-    override val isIgnored get() = FEATURE_FLOW !in LegacyParserConfig.supportedFeatures || super.isIgnored
+    override val isIgnored get() = FEATURE_FLOW !in manifest.config.supportedFeatures || super.isIgnored
 
     class Item : BaseModel, Parent, Visibility {
         companion object {

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Flow.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Flow.kt
@@ -2,7 +2,7 @@ package org.cru.godtools.tool.model
 
 import org.cru.godtools.expressions.Expression
 import org.cru.godtools.tool.FEATURE_FLOW
-import org.cru.godtools.tool.ParserConfig
+import org.cru.godtools.tool.LegacyParserConfig
 import org.cru.godtools.tool.internal.VisibleForTesting
 import org.cru.godtools.tool.model.Dimension.Companion.toDimensionOrNull
 import org.cru.godtools.tool.model.Flow.Companion.DEFAULT_ITEM_WIDTH
@@ -52,7 +52,7 @@ class Flow : Content {
         }
     }
 
-    override val isIgnored get() = FEATURE_FLOW !in ParserConfig.supportedFeatures || super.isIgnored
+    override val isIgnored get() = FEATURE_FLOW !in LegacyParserConfig.supportedFeatures || super.isIgnored
 
     class Item : BaseModel, Parent, Visibility {
         companion object {

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
@@ -5,7 +5,6 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
-import org.cru.godtools.tool.LegacyParserConfig
 import org.cru.godtools.tool.ParserConfig
 import org.cru.godtools.tool.internal.AndroidColorInt
 import org.cru.godtools.tool.internal.DeprecationException
@@ -172,7 +171,7 @@ class Manifest : BaseModel, Styles {
     private constructor(parser: XmlPullParser) {
         parser.require(XmlPullParser.START_TAG, XMLNS_MANIFEST, XML_MANIFEST)
 
-        config = LegacyParserConfig
+        config = ParserConfig()
 
         code = parser.getAttributeValue(XML_TOOL)
         locale = parser.getAttributeValue(XML_LOCALE)?.toLocaleOrNull()
@@ -244,7 +243,7 @@ class Manifest : BaseModel, Styles {
 
     @RestrictTo(RestrictToScope.TESTS)
     constructor(
-        config: ParserConfig = LegacyParserConfig,
+        config: ParserConfig = ParserConfig(),
         type: Type = Type.DEFAULT,
         code: String? = null,
         locale: PlatformLocale? = null,

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
@@ -98,7 +98,7 @@ class Manifest : BaseModel, Styles {
         }
     }
 
-    internal val config: ParserConfig = LegacyParserConfig
+    internal val config: ParserConfig
 
     val code: String?
     val locale: PlatformLocale?
@@ -172,6 +172,8 @@ class Manifest : BaseModel, Styles {
     private constructor(parser: XmlPullParser) {
         parser.require(XmlPullParser.START_TAG, XMLNS_MANIFEST, XML_MANIFEST)
 
+        config = LegacyParserConfig
+
         code = parser.getAttributeValue(XML_TOOL)
         locale = parser.getAttributeValue(XML_LOCALE)?.toLocaleOrNull()
         type = Type.parseOrNull(parser.getAttributeValue(XML_TYPE)) ?: Type.DEFAULT
@@ -242,6 +244,7 @@ class Manifest : BaseModel, Styles {
 
     @RestrictTo(RestrictToScope.TESTS)
     constructor(
+        config: ParserConfig = LegacyParserConfig,
         type: Type = Type.DEFAULT,
         code: String? = null,
         locale: PlatformLocale? = null,
@@ -261,6 +264,8 @@ class Manifest : BaseModel, Styles {
         tips: ((Manifest) -> List<Tip>)? = null,
         pages: ((Manifest) -> List<Page>)? = null
     ) {
+        this.config = config
+
         this.code = code
         this.locale = locale
         this.type = type

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
@@ -5,6 +5,8 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
+import org.cru.godtools.tool.LegacyParserConfig
+import org.cru.godtools.tool.ParserConfig
 import org.cru.godtools.tool.internal.AndroidColorInt
 import org.cru.godtools.tool.internal.DeprecationException
 import org.cru.godtools.tool.internal.RestrictTo
@@ -95,6 +97,8 @@ class Manifest : BaseModel, Styles {
             return manifest
         }
     }
+
+    internal val config: ParserConfig = LegacyParserConfig
 
     val code: String?
     val locale: PlatformLocale?

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
@@ -75,8 +75,12 @@ class Manifest : BaseModel, Styles {
         internal val DEFAULT_TEXT_COLOR = color(90, 90, 90, 1.0)
         internal val DEFAULT_TEXT_ALIGN = Text.Align.START
 
-        internal suspend fun parse(fileName: String, parseFile: suspend (String) -> XmlPullParser): Manifest {
-            val manifest = Manifest(parseFile(fileName))
+        internal suspend fun parse(
+            fileName: String,
+            config: ParserConfig,
+            parseFile: suspend (String) -> XmlPullParser
+        ): Manifest {
+            val manifest = Manifest(parseFile(fileName), config)
             coroutineScope {
                 // parse pages
                 launch {
@@ -168,10 +172,10 @@ class Manifest : BaseModel, Styles {
     private val pagesToParse: List<Pair<String?, String>>
     private val tipsToParse: List<Pair<String, String>>
 
-    private constructor(parser: XmlPullParser) {
+    private constructor(parser: XmlPullParser, config: ParserConfig) {
         parser.require(XmlPullParser.START_TAG, XMLNS_MANIFEST, XML_MANIFEST)
 
-        config = ParserConfig()
+        this.config = config
 
         code = parser.getAttributeValue(XML_TOOL)
         locale = parser.getAttributeValue(XML_LOCALE)?.toLocaleOrNull()

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Multiselect.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Multiselect.kt
@@ -2,7 +2,7 @@ package org.cru.godtools.tool.model
 
 import kotlinx.coroutines.flow.distinctUntilChanged
 import org.cru.godtools.tool.FEATURE_MULTISELECT
-import org.cru.godtools.tool.ParserConfig
+import org.cru.godtools.tool.LegacyParserConfig
 import org.cru.godtools.tool.internal.RestrictTo
 import org.cru.godtools.tool.internal.RestrictToScope
 import org.cru.godtools.tool.internal.VisibleForTesting
@@ -86,7 +86,7 @@ class Multiselect : Content {
         this.options = options?.invoke(this).orEmpty()
     }
 
-    override val isIgnored get() = FEATURE_MULTISELECT !in ParserConfig.supportedFeatures || super.isIgnored
+    override val isIgnored get() = FEATURE_MULTISELECT !in LegacyParserConfig.supportedFeatures || super.isIgnored
 
     class Option : Content, Parent, HasAnalyticsEvents {
         internal companion object {

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Multiselect.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Multiselect.kt
@@ -2,7 +2,6 @@ package org.cru.godtools.tool.model
 
 import kotlinx.coroutines.flow.distinctUntilChanged
 import org.cru.godtools.tool.FEATURE_MULTISELECT
-import org.cru.godtools.tool.LegacyParserConfig
 import org.cru.godtools.tool.internal.RestrictTo
 import org.cru.godtools.tool.internal.RestrictToScope
 import org.cru.godtools.tool.internal.VisibleForTesting
@@ -86,7 +85,7 @@ class Multiselect : Content {
         this.options = options?.invoke(this).orEmpty()
     }
 
-    override val isIgnored get() = FEATURE_MULTISELECT !in LegacyParserConfig.supportedFeatures || super.isIgnored
+    override val isIgnored get() = FEATURE_MULTISELECT !in manifest.config.supportedFeatures || super.isIgnored
 
     class Option : Content, Parent, HasAnalyticsEvents {
         internal companion object {

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/service/ManifestParser.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/service/ManifestParser.kt
@@ -1,14 +1,15 @@
 package org.cru.godtools.tool.service
 
 import io.github.aakira.napier.Napier
+import org.cru.godtools.tool.ParserConfig
 import org.cru.godtools.tool.internal.FileNotFoundException
 import org.cru.godtools.tool.model.Manifest
 import org.cru.godtools.tool.xml.XmlPullParserException
 import org.cru.godtools.tool.xml.XmlPullParserFactory
 
-open class ManifestParser(private val parserFactory: XmlPullParserFactory) {
-    suspend fun parseManifest(fileName: String): ParserResult = try {
-        val manifest = Manifest.parse(fileName) {
+open class ManifestParser(private val parserFactory: XmlPullParserFactory, protected val config: ParserConfig) {
+    suspend fun parseManifest(fileName: String, config: ParserConfig = this.config): ParserResult = try {
+        val manifest = Manifest.parse(fileName, config) {
             parserFactory.getXmlParser(it)?.apply { nextTag() } ?: throw FileNotFoundException(fileName)
         }
         ParserResult.Data(manifest)

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/AnimationTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/AnimationTest.kt
@@ -2,7 +2,7 @@ package org.cru.godtools.tool.model
 
 import kotlinx.coroutines.test.runTest
 import org.cru.godtools.tool.FEATURE_ANIMATION
-import org.cru.godtools.tool.ParserConfig
+import org.cru.godtools.tool.LegacyParserConfig
 import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
@@ -39,10 +39,10 @@ class AnimationTest : UsesResources() {
     fun testIsIgnored() {
         val animation = Animation()
 
-        ParserConfig.supportedFeatures = setOf(FEATURE_ANIMATION)
+        LegacyParserConfig.supportedFeatures = setOf(FEATURE_ANIMATION)
         assertFalse(animation.testIsIgnored)
 
-        ParserConfig.supportedFeatures = emptySet()
+        LegacyParserConfig.supportedFeatures = emptySet()
         assertTrue(animation.testIsIgnored)
     }
 }

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/AnimationTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/AnimationTest.kt
@@ -1,8 +1,9 @@
 package org.cru.godtools.tool.model
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.cru.godtools.tool.FEATURE_ANIMATION
-import org.cru.godtools.tool.LegacyParserConfig
+import org.cru.godtools.tool.ParserConfig
 import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
@@ -12,6 +13,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @RunOnAndroidWith(AndroidJUnit4::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 class AnimationTest : UsesResources() {
     @Test
     fun testParseAnimationDefaults() = runTest {
@@ -37,12 +39,12 @@ class AnimationTest : UsesResources() {
 
     @Test
     fun testIsIgnored() {
-        val animation = Animation()
+        with(Animation(Manifest(config = ParserConfig(supportedFeatures = setOf(FEATURE_ANIMATION))))) {
+            assertFalse(testIsIgnored)
+        }
 
-        LegacyParserConfig.supportedFeatures = setOf(FEATURE_ANIMATION)
-        assertFalse(animation.testIsIgnored)
-
-        LegacyParserConfig.supportedFeatures = emptySet()
-        assertTrue(animation.testIsIgnored)
+        with(Animation(Manifest(config = ParserConfig(supportedFeatures = emptySet())))) {
+            assertTrue(testIsIgnored)
+        }
     }
 }

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ButtonTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ButtonTest.kt
@@ -3,7 +3,7 @@ package org.cru.godtools.tool.model
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.cru.godtools.tool.FEATURE_MULTISELECT
-import org.cru.godtools.tool.ParserConfig
+import org.cru.godtools.tool.LegacyParserConfig
 import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
@@ -72,18 +72,18 @@ class ButtonTest : UsesResources() {
     @Test
     fun testParseButtonRestrictTo() = runTest {
         val button = Button(Manifest(), getTestXmlParser("button_restrictTo.xml"))
-        ParserConfig.supportedDeviceTypes = setOf(DeviceType.WEB)
+        LegacyParserConfig.supportedDeviceTypes = setOf(DeviceType.WEB)
         assertFalse(button.testIsIgnored)
-        ParserConfig.supportedDeviceTypes = setOf(DeviceType.MOBILE)
+        LegacyParserConfig.supportedDeviceTypes = setOf(DeviceType.MOBILE)
         assertTrue(button.testIsIgnored)
     }
 
     @Test
     fun testParseButtonRequiredFeatures() = runTest {
         val button = Button(Manifest(), getTestXmlParser("button_requiredFeatures.xml"))
-        ParserConfig.supportedFeatures = setOf(FEATURE_MULTISELECT)
+        LegacyParserConfig.supportedFeatures = setOf(FEATURE_MULTISELECT)
         assertFalse(button.testIsIgnored)
-        ParserConfig.supportedFeatures = emptySet()
+        LegacyParserConfig.supportedFeatures = emptySet()
         assertTrue(button.testIsIgnored)
     }
 

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ButtonTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ButtonTest.kt
@@ -3,7 +3,7 @@ package org.cru.godtools.tool.model
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.cru.godtools.tool.FEATURE_MULTISELECT
-import org.cru.godtools.tool.LegacyParserConfig
+import org.cru.godtools.tool.ParserConfig
 import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
@@ -71,20 +71,27 @@ class ButtonTest : UsesResources() {
 
     @Test
     fun testParseButtonRestrictTo() = runTest {
-        val button = Button(Manifest(), getTestXmlParser("button_restrictTo.xml"))
-        LegacyParserConfig.supportedDeviceTypes = setOf(DeviceType.WEB)
-        assertFalse(button.testIsIgnored)
-        LegacyParserConfig.supportedDeviceTypes = setOf(DeviceType.MOBILE)
-        assertTrue(button.testIsIgnored)
+        val webConfig = ParserConfig(supportedDeviceTypes = setOf(DeviceType.WEB))
+        with(Button(Manifest(config = webConfig), getTestXmlParser("button_restrictTo.xml"))) {
+            assertFalse(testIsIgnored)
+        }
+
+        val mobileConfig = ParserConfig(supportedDeviceTypes = setOf(DeviceType.MOBILE))
+        with(Button(Manifest(config = mobileConfig), getTestXmlParser("button_restrictTo.xml"))) {
+            assertTrue(testIsIgnored)
+        }
     }
 
     @Test
     fun testParseButtonRequiredFeatures() = runTest {
-        val button = Button(Manifest(), getTestXmlParser("button_requiredFeatures.xml"))
-        LegacyParserConfig.supportedFeatures = setOf(FEATURE_MULTISELECT)
-        assertFalse(button.testIsIgnored)
-        LegacyParserConfig.supportedFeatures = emptySet()
-        assertTrue(button.testIsIgnored)
+        with(Button(Manifest(), getTestXmlParser("button_requiredFeatures.xml"))) {
+            assertTrue(testIsIgnored)
+        }
+
+        val config = ParserConfig(supportedFeatures = setOf(FEATURE_MULTISELECT))
+        with(Button(Manifest(config = config), getTestXmlParser("button_requiredFeatures.xml"))) {
+            assertFalse(testIsIgnored)
+        }
     }
 
     @Test

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/CardTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/CardTest.kt
@@ -2,7 +2,7 @@ package org.cru.godtools.tool.model
 
 import kotlinx.coroutines.test.runTest
 import org.cru.godtools.tool.FEATURE_CONTENT_CARD
-import org.cru.godtools.tool.ParserConfig
+import org.cru.godtools.tool.LegacyParserConfig
 import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
@@ -37,10 +37,10 @@ class CardTest : UsesResources() {
     fun testIsIgnored() {
         val card = Card()
 
-        ParserConfig.supportedFeatures = setOf(FEATURE_CONTENT_CARD)
+        LegacyParserConfig.supportedFeatures = setOf(FEATURE_CONTENT_CARD)
         assertFalse(card.isIgnored)
 
-        ParserConfig.supportedFeatures = emptySet()
+        LegacyParserConfig.supportedFeatures = emptySet()
         assertTrue(card.isIgnored)
     }
 

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/CardTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/CardTest.kt
@@ -1,8 +1,9 @@
 package org.cru.godtools.tool.model
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.cru.godtools.tool.FEATURE_CONTENT_CARD
-import org.cru.godtools.tool.LegacyParserConfig
+import org.cru.godtools.tool.ParserConfig
 import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
@@ -13,6 +14,7 @@ import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 @RunOnAndroidWith(AndroidJUnit4::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 class CardTest : UsesResources() {
     @Test
     fun testParseCard() = runTest {
@@ -35,13 +37,12 @@ class CardTest : UsesResources() {
 
     @Test
     fun testIsIgnored() {
-        val card = Card()
-
-        LegacyParserConfig.supportedFeatures = setOf(FEATURE_CONTENT_CARD)
-        assertFalse(card.isIgnored)
-
-        LegacyParserConfig.supportedFeatures = emptySet()
-        assertTrue(card.isIgnored)
+        with(Card(Manifest(config = ParserConfig(supportedFeatures = setOf(FEATURE_CONTENT_CARD))))) {
+            assertFalse(isIgnored)
+        }
+        with(Card(Manifest(config = ParserConfig(supportedFeatures = emptySet())))) {
+            assertTrue(isIgnored)
+        }
     }
 
     @Test

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/CategoryTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/CategoryTest.kt
@@ -1,6 +1,7 @@
 package org.cru.godtools.tool.model
 
 import kotlinx.coroutines.test.runTest
+import org.cru.godtools.tool.ParserConfig
 import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
@@ -13,7 +14,7 @@ import kotlin.test.assertNotNull
 class CategoryTest : UsesResources() {
     @Test
     fun testParseCategory() = runTest {
-        val category = Manifest.parse("categories.xml") { getTestXmlParser(it) }.categories.single()
+        val category = Manifest.parse("categories.xml", ParserConfig()) { getTestXmlParser(it) }.categories.single()
         assertEquals("testParseCategory", category.id)
         assertNotNull(category.banner).also {
             assertEquals("banner.jpg", it.name)

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ContentTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ContentTest.kt
@@ -52,7 +52,7 @@ class ContentTest : UsesResources() {
     fun verifyRestrictToSupported() {
         LegacyParserConfig.supportedDeviceTypes = setOf(DeviceType.ANDROID)
         assertFalse(object : Content(Manifest(), restrictTo = DeviceType.ALL) {}.testIsIgnored)
-        assertFalse(object : Content(Manifest(), restrictTo = DeviceType.SUPPORTED) {}.testIsIgnored)
+        assertFalse(object : Content(Manifest(), restrictTo = LegacyParserConfig.supportedDeviceTypes) {}.testIsIgnored)
         assertFalse(object : Content(Manifest(), restrictTo = setOf(DeviceType.ANDROID)) {}.testIsIgnored)
     }
 

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ContentTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ContentTest.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.test.runTest
 import org.cru.godtools.expressions.toExpressionOrNull
 import org.cru.godtools.tool.FEATURE_ANIMATION
 import org.cru.godtools.tool.FEATURE_MULTISELECT
-import org.cru.godtools.tool.LegacyParserConfig
+import org.cru.godtools.tool.ParserConfig
 import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
@@ -31,36 +31,40 @@ class ContentTest : UsesResources() {
     // region required-features
     @Test
     fun verifyRequiredFeaturesSupported() {
-        LegacyParserConfig.supportedFeatures = setOf(FEATURE_ANIMATION, FEATURE_MULTISELECT)
-        assertFalse(object : Content(requiredFeatures = setOf(FEATURE_ANIMATION, FEATURE_MULTISELECT)) {}.testIsIgnored)
-        assertFalse(object : Content(requiredFeatures = setOf(FEATURE_ANIMATION)) {}.testIsIgnored)
-        assertFalse(object : Content(requiredFeatures = setOf(FEATURE_MULTISELECT)) {}.testIsIgnored)
-        assertFalse(object : Content(requiredFeatures = emptySet()) {}.testIsIgnored)
+        val manifest = Manifest(ParserConfig(supportedFeatures = setOf(FEATURE_ANIMATION, FEATURE_MULTISELECT)))
+        assertFalse(
+            object : Content(manifest, requiredFeatures = setOf(FEATURE_ANIMATION, FEATURE_MULTISELECT)) {}.isIgnored
+        )
+        assertFalse(object : Content(manifest, requiredFeatures = setOf(FEATURE_ANIMATION)) {}.testIsIgnored)
+        assertFalse(object : Content(manifest, requiredFeatures = setOf(FEATURE_MULTISELECT)) {}.testIsIgnored)
+        assertFalse(object : Content(manifest, requiredFeatures = emptySet()) {}.testIsIgnored)
     }
 
     @Test
     fun verifyRequiredFeaturesNotSupported() {
-        LegacyParserConfig.supportedFeatures = setOf(FEATURE_ANIMATION)
-        assertTrue(object : Content(requiredFeatures = setOf(FEATURE_ANIMATION, FEATURE_MULTISELECT)) {}.testIsIgnored)
-        assertTrue(object : Content(requiredFeatures = setOf(FEATURE_MULTISELECT)) {}.testIsIgnored)
-        assertTrue(object : Content(requiredFeatures = setOf("kjlasdf")) {}.testIsIgnored)
+        val manifest = Manifest(ParserConfig(supportedFeatures = setOf(FEATURE_ANIMATION)))
+        assertTrue(
+            object : Content(manifest, requiredFeatures = setOf(FEATURE_ANIMATION, FEATURE_MULTISELECT)) {}.isIgnored
+        )
+        assertTrue(object : Content(manifest, requiredFeatures = setOf(FEATURE_MULTISELECT)) {}.testIsIgnored)
+        assertTrue(object : Content(manifest, requiredFeatures = setOf("kjlasdf")) {}.testIsIgnored)
     }
     // endregion required-features
 
     // region restrictTo
     @Test
     fun verifyRestrictToSupported() {
-        LegacyParserConfig.supportedDeviceTypes = setOf(DeviceType.ANDROID)
-        assertFalse(object : Content(Manifest(), restrictTo = DeviceType.ALL) {}.testIsIgnored)
-        assertFalse(object : Content(Manifest(), restrictTo = LegacyParserConfig.supportedDeviceTypes) {}.testIsIgnored)
-        assertFalse(object : Content(Manifest(), restrictTo = setOf(DeviceType.ANDROID)) {}.testIsIgnored)
+        val config = ParserConfig(supportedDeviceTypes = setOf(DeviceType.ANDROID))
+        assertFalse(object : Content(Manifest(config), restrictTo = DeviceType.ALL) {}.testIsIgnored)
+        assertFalse(object : Content(Manifest(config), restrictTo = config.supportedDeviceTypes) {}.testIsIgnored)
+        assertFalse(object : Content(Manifest(config), restrictTo = setOf(DeviceType.ANDROID)) {}.testIsIgnored)
     }
 
     @Test
     fun verifyRestrictToNotSupported() {
-        LegacyParserConfig.supportedDeviceTypes = setOf(DeviceType.ANDROID)
-        assertTrue(object : Content(Manifest(), restrictTo = setOf(DeviceType.UNKNOWN)) {}.testIsIgnored)
-        assertTrue(object : Content(Manifest(), restrictTo = setOf(DeviceType.IOS)) {}.testIsIgnored)
+        val config = ParserConfig(supportedDeviceTypes = setOf(DeviceType.ANDROID))
+        assertTrue(object : Content(Manifest(config), restrictTo = setOf(DeviceType.UNKNOWN)) {}.testIsIgnored)
+        assertTrue(object : Content(Manifest(config), restrictTo = setOf(DeviceType.IOS)) {}.testIsIgnored)
     }
     // endregion restrictTo
 

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ContentTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ContentTest.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.test.runTest
 import org.cru.godtools.expressions.toExpressionOrNull
 import org.cru.godtools.tool.FEATURE_ANIMATION
 import org.cru.godtools.tool.FEATURE_MULTISELECT
-import org.cru.godtools.tool.ParserConfig
+import org.cru.godtools.tool.LegacyParserConfig
 import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
@@ -31,7 +31,7 @@ class ContentTest : UsesResources() {
     // region required-features
     @Test
     fun verifyRequiredFeaturesSupported() {
-        ParserConfig.supportedFeatures = setOf(FEATURE_ANIMATION, FEATURE_MULTISELECT)
+        LegacyParserConfig.supportedFeatures = setOf(FEATURE_ANIMATION, FEATURE_MULTISELECT)
         assertFalse(object : Content(requiredFeatures = setOf(FEATURE_ANIMATION, FEATURE_MULTISELECT)) {}.testIsIgnored)
         assertFalse(object : Content(requiredFeatures = setOf(FEATURE_ANIMATION)) {}.testIsIgnored)
         assertFalse(object : Content(requiredFeatures = setOf(FEATURE_MULTISELECT)) {}.testIsIgnored)
@@ -40,7 +40,7 @@ class ContentTest : UsesResources() {
 
     @Test
     fun verifyRequiredFeaturesNotSupported() {
-        ParserConfig.supportedFeatures = setOf(FEATURE_ANIMATION)
+        LegacyParserConfig.supportedFeatures = setOf(FEATURE_ANIMATION)
         assertTrue(object : Content(requiredFeatures = setOf(FEATURE_ANIMATION, FEATURE_MULTISELECT)) {}.testIsIgnored)
         assertTrue(object : Content(requiredFeatures = setOf(FEATURE_MULTISELECT)) {}.testIsIgnored)
         assertTrue(object : Content(requiredFeatures = setOf("kjlasdf")) {}.testIsIgnored)
@@ -50,7 +50,7 @@ class ContentTest : UsesResources() {
     // region restrictTo
     @Test
     fun verifyRestrictToSupported() {
-        ParserConfig.supportedDeviceTypes = setOf(DeviceType.ANDROID)
+        LegacyParserConfig.supportedDeviceTypes = setOf(DeviceType.ANDROID)
         assertFalse(object : Content(Manifest(), restrictTo = DeviceType.ALL) {}.testIsIgnored)
         assertFalse(object : Content(Manifest(), restrictTo = DeviceType.SUPPORTED) {}.testIsIgnored)
         assertFalse(object : Content(Manifest(), restrictTo = setOf(DeviceType.ANDROID)) {}.testIsIgnored)
@@ -58,7 +58,7 @@ class ContentTest : UsesResources() {
 
     @Test
     fun verifyRestrictToNotSupported() {
-        ParserConfig.supportedDeviceTypes = setOf(DeviceType.ANDROID)
+        LegacyParserConfig.supportedDeviceTypes = setOf(DeviceType.ANDROID)
         assertTrue(object : Content(Manifest(), restrictTo = setOf(DeviceType.UNKNOWN)) {}.testIsIgnored)
         assertTrue(object : Content(Manifest(), restrictTo = setOf(DeviceType.IOS)) {}.testIsIgnored)
     }

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/FallbackTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/FallbackTest.kt
@@ -1,14 +1,12 @@
 package org.cru.godtools.tool.model
 
 import kotlinx.coroutines.test.runTest
-import org.cru.godtools.tool.LegacyParserConfig
 import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
 import org.cru.godtools.tool.model.tips.InlineTip
 import org.cru.godtools.tool.model.tips.Tip
 import org.cru.godtools.tool.xml.XmlPullParserException
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -17,11 +15,6 @@ import kotlin.test.assertTrue
 
 @RunOnAndroidWith(AndroidJUnit4::class)
 class FallbackTest : UsesResources() {
-    @BeforeTest
-    fun setupConfig() {
-        LegacyParserConfig.supportedDeviceTypes = setOf(DeviceType.ANDROID)
-    }
-
     @Test
     fun testParseFallback() = runTest {
         val fallback = Fallback(Manifest(), getTestXmlParser("fallback.xml"))

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/FallbackTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/FallbackTest.kt
@@ -1,7 +1,7 @@
 package org.cru.godtools.tool.model
 
 import kotlinx.coroutines.test.runTest
-import org.cru.godtools.tool.ParserConfig
+import org.cru.godtools.tool.LegacyParserConfig
 import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
@@ -19,7 +19,7 @@ import kotlin.test.assertTrue
 class FallbackTest : UsesResources() {
     @BeforeTest
     fun setupConfig() {
-        ParserConfig.supportedDeviceTypes = setOf(DeviceType.ANDROID)
+        LegacyParserConfig.supportedDeviceTypes = setOf(DeviceType.ANDROID)
     }
 
     @Test

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/FormTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/FormTest.kt
@@ -2,7 +2,7 @@ package org.cru.godtools.tool.model
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
-import org.cru.godtools.tool.LegacyParserConfig
+import org.cru.godtools.tool.ParserConfig
 import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
@@ -25,8 +25,8 @@ class FormTest : UsesResources() {
 
     @Test
     fun testParseParagraphIgnoredContent() = runTest {
-        LegacyParserConfig.supportedDeviceTypes = setOf(DeviceType.MOBILE)
-        val form = Form(Manifest(), getTestXmlParser("form_ignored_content.xml"))
+        val manifest = Manifest(ParserConfig(supportedDeviceTypes = setOf(DeviceType.MOBILE)))
+        val form = Form(manifest, getTestXmlParser("form_ignored_content.xml"))
         assertEquals(1, form.content.size)
         assertIs<Text>(form.content[0])
     }

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/FormTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/FormTest.kt
@@ -2,7 +2,7 @@ package org.cru.godtools.tool.model
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
-import org.cru.godtools.tool.ParserConfig
+import org.cru.godtools.tool.LegacyParserConfig
 import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
@@ -25,7 +25,7 @@ class FormTest : UsesResources() {
 
     @Test
     fun testParseParagraphIgnoredContent() = runTest {
-        ParserConfig.supportedDeviceTypes = setOf(DeviceType.MOBILE)
+        LegacyParserConfig.supportedDeviceTypes = setOf(DeviceType.MOBILE)
         val form = Form(Manifest(), getTestXmlParser("form_ignored_content.xml"))
         assertEquals(1, form.content.size)
         assertIs<Text>(form.content[0])

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ImageTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ImageTest.kt
@@ -1,7 +1,7 @@
 package org.cru.godtools.tool.model
 
 import kotlinx.coroutines.test.runTest
-import org.cru.godtools.tool.ParserConfig
+import org.cru.godtools.tool.LegacyParserConfig
 import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
@@ -52,7 +52,7 @@ class ImageTest : UsesResources() {
 
     @Test
     fun testParseImageRestricted() = runTest {
-        ParserConfig.supportedDeviceTypes = setOf(DeviceType.MOBILE)
+        LegacyParserConfig.supportedDeviceTypes = setOf(DeviceType.MOBILE)
         val manifest = Manifest(resources = { listOf(Resource(it, "image.png")) })
         val image = Image(manifest, getTestXmlParser("image_restricted.xml"))
         assertTrue(image.testIsIgnored)

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ImageTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ImageTest.kt
@@ -1,7 +1,7 @@
 package org.cru.godtools.tool.model
 
 import kotlinx.coroutines.test.runTest
-import org.cru.godtools.tool.LegacyParserConfig
+import org.cru.godtools.tool.ParserConfig
 import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
@@ -52,8 +52,10 @@ class ImageTest : UsesResources() {
 
     @Test
     fun testParseImageRestricted() = runTest {
-        LegacyParserConfig.supportedDeviceTypes = setOf(DeviceType.MOBILE)
-        val manifest = Manifest(resources = { listOf(Resource(it, "image.png")) })
+        val manifest = Manifest(
+            config = ParserConfig(supportedDeviceTypes = setOf(DeviceType.MOBILE)),
+            resources = { listOf(Resource(it, "image.png")) }
+        )
         val image = Image(manifest, getTestXmlParser("image_restricted.xml"))
         assertTrue(image.testIsIgnored)
     }

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ManifestTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ManifestTest.kt
@@ -3,6 +3,7 @@ package org.cru.godtools.tool.model
 import io.fluidsonic.locale.Locale
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
+import org.cru.godtools.tool.ParserConfig
 import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
@@ -170,7 +171,7 @@ class ManifestTest : UsesResources() {
         }
     }
 
-    private suspend fun parseManifest(name: String) = Manifest.parse(name) { getTestXmlParser(it) }
+    private suspend fun parseManifest(name: String) = Manifest.parse(name, ParserConfig()) { getTestXmlParser(it) }
     // endregion parse Manifest
 
     @Test

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/MultiselectTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/MultiselectTest.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.test.runTest
 import org.cru.godtools.tool.FEATURE_MULTISELECT
-import org.cru.godtools.tool.LegacyParserConfig
+import org.cru.godtools.tool.ParserConfig
 import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
@@ -71,13 +71,12 @@ class MultiselectTest : UsesResources() {
 
     @Test
     fun testIsIgnored() {
-        val multiselect = Multiselect()
-
-        LegacyParserConfig.supportedFeatures = setOf(FEATURE_MULTISELECT)
-        assertFalse(multiselect.testIsIgnored)
-
-        LegacyParserConfig.supportedFeatures = emptySet()
-        assertTrue(multiselect.testIsIgnored)
+        with(Multiselect(Manifest(ParserConfig(supportedFeatures = setOf(FEATURE_MULTISELECT))))) {
+            assertFalse(testIsIgnored)
+        }
+        with(Multiselect(Manifest(ParserConfig(supportedFeatures = emptySet())))) {
+            assertTrue(testIsIgnored)
+        }
     }
 
     @Test

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/MultiselectTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/MultiselectTest.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.test.runTest
 import org.cru.godtools.tool.FEATURE_MULTISELECT
-import org.cru.godtools.tool.ParserConfig
+import org.cru.godtools.tool.LegacyParserConfig
 import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
@@ -73,10 +73,10 @@ class MultiselectTest : UsesResources() {
     fun testIsIgnored() {
         val multiselect = Multiselect()
 
-        ParserConfig.supportedFeatures = setOf(FEATURE_MULTISELECT)
+        LegacyParserConfig.supportedFeatures = setOf(FEATURE_MULTISELECT)
         assertFalse(multiselect.testIsIgnored)
 
-        ParserConfig.supportedFeatures = emptySet()
+        LegacyParserConfig.supportedFeatures = emptySet()
         assertTrue(multiselect.testIsIgnored)
     }
 

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ParagraphTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ParagraphTest.kt
@@ -2,13 +2,12 @@ package org.cru.godtools.tool.model
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
-import org.cru.godtools.tool.LegacyParserConfig
+import org.cru.godtools.tool.ParserConfig
 import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
 import org.cru.godtools.tool.model.tips.InlineTip
 import org.cru.godtools.tool.model.tips.Tip
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -16,11 +15,6 @@ import kotlin.test.assertIs
 @RunOnAndroidWith(AndroidJUnit4::class)
 @OptIn(ExperimentalCoroutinesApi::class)
 class ParagraphTest : UsesResources() {
-    @BeforeTest
-    fun setupConfig() {
-        LegacyParserConfig.supportedDeviceTypes = setOf(DeviceType.ANDROID, DeviceType.MOBILE)
-    }
-
     @Test
     fun testParseParagraph() = runTest {
         val paragraph = Paragraph(Manifest(), getTestXmlParser("paragraph.xml"))
@@ -31,7 +25,8 @@ class ParagraphTest : UsesResources() {
 
     @Test
     fun testParseParagraphIgnoredContent() = runTest {
-        val paragraph = Paragraph(Manifest(), getTestXmlParser("paragraph_ignored_content.xml"))
+        val manifest = Manifest(ParserConfig(supportedDeviceTypes = setOf(DeviceType.ANDROID, DeviceType.MOBILE)))
+        val paragraph = Paragraph(manifest, getTestXmlParser("paragraph_ignored_content.xml"))
         assertEquals(3, paragraph.content.size)
         assertEquals("Test", assertIs<Text>(paragraph.content[0]).text)
         assertEquals("Android", assertIs<Text>(paragraph.content[1]).text)

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ParagraphTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ParagraphTest.kt
@@ -2,7 +2,7 @@ package org.cru.godtools.tool.model
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
-import org.cru.godtools.tool.ParserConfig
+import org.cru.godtools.tool.LegacyParserConfig
 import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
@@ -18,7 +18,7 @@ import kotlin.test.assertIs
 class ParagraphTest : UsesResources() {
     @BeforeTest
     fun setupConfig() {
-        ParserConfig.supportedDeviceTypes = setOf(DeviceType.ANDROID, DeviceType.MOBILE)
+        LegacyParserConfig.supportedDeviceTypes = setOf(DeviceType.ANDROID, DeviceType.MOBILE)
     }
 
     @Test

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/TabsTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/TabsTest.kt
@@ -2,12 +2,11 @@ package org.cru.godtools.tool.model
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
-import org.cru.godtools.tool.LegacyParserConfig
+import org.cru.godtools.tool.ParserConfig
 import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
 import org.cru.godtools.tool.model.AnalyticsEvent.Trigger
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -16,11 +15,6 @@ import kotlin.test.assertIs
 @RunOnAndroidWith(AndroidJUnit4::class)
 @OptIn(ExperimentalCoroutinesApi::class)
 class TabsTest : UsesResources() {
-    @BeforeTest
-    fun setupConfig() {
-        LegacyParserConfig.supportedDeviceTypes = setOf(DeviceType.MOBILE)
-    }
-
     @Test
     fun testParseTabsEmpty() = runTest {
         val tabs = Tabs(Manifest(), getTestXmlParser("tabs_empty.xml"))
@@ -50,7 +44,8 @@ class TabsTest : UsesResources() {
 
     @Test
     fun testParseTabsIgnoredContent() = runTest {
-        val tab = Tabs(Manifest(), getTestXmlParser("tabs_ignored_content.xml")).tabs.single()
+        val manifest = Manifest(ParserConfig(supportedDeviceTypes = setOf(DeviceType.MOBILE)))
+        val tab = Tabs(manifest, getTestXmlParser("tabs_ignored_content.xml")).tabs.single()
         assertEquals(1, tab.content.size)
         assertIs<Paragraph>(tab.content[0])
     }

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/TabsTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/TabsTest.kt
@@ -2,7 +2,7 @@ package org.cru.godtools.tool.model
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
-import org.cru.godtools.tool.ParserConfig
+import org.cru.godtools.tool.LegacyParserConfig
 import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
@@ -18,7 +18,7 @@ import kotlin.test.assertIs
 class TabsTest : UsesResources() {
     @BeforeTest
     fun setupConfig() {
-        ParserConfig.supportedDeviceTypes = setOf(DeviceType.MOBILE)
+        LegacyParserConfig.supportedDeviceTypes = setOf(DeviceType.MOBILE)
     }
 
     @Test

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/HeroTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/HeroTest.kt
@@ -2,7 +2,7 @@ package org.cru.godtools.tool.model.tract
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
-import org.cru.godtools.tool.ParserConfig
+import org.cru.godtools.tool.LegacyParserConfig
 import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
@@ -28,7 +28,7 @@ import kotlin.test.assertNotNull
 class HeroTest : UsesResources("model/tract") {
     @BeforeTest
     fun setupConfig() {
-        ParserConfig.supportedDeviceTypes = setOf(DeviceType.ANDROID, DeviceType.MOBILE)
+        LegacyParserConfig.supportedDeviceTypes = setOf(DeviceType.ANDROID, DeviceType.MOBILE)
     }
 
     @Test

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/HeroTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/HeroTest.kt
@@ -2,7 +2,7 @@ package org.cru.godtools.tool.model.tract
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
-import org.cru.godtools.tool.LegacyParserConfig
+import org.cru.godtools.tool.ParserConfig
 import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
@@ -15,7 +15,6 @@ import org.cru.godtools.tool.model.Paragraph
 import org.cru.godtools.tool.model.Tabs
 import org.cru.godtools.tool.model.TestColors
 import org.cru.godtools.tool.model.Text
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -26,11 +25,6 @@ import kotlin.test.assertNotNull
 @RunOnAndroidWith(AndroidJUnit4::class)
 @OptIn(ExperimentalCoroutinesApi::class)
 class HeroTest : UsesResources("model/tract") {
-    @BeforeTest
-    fun setupConfig() {
-        LegacyParserConfig.supportedDeviceTypes = setOf(DeviceType.ANDROID, DeviceType.MOBILE)
-    }
-
     @Test
     fun testParseHero() = runTest {
         val hero = assertNotNull(TractPage(Manifest(), null, getTestXmlParser("hero.xml")).hero)
@@ -46,10 +40,13 @@ class HeroTest : UsesResources("model/tract") {
 
     @Test
     fun testParseHeroIgnoredContent() = runTest {
-        val hero = assertNotNull(TractPage(Manifest(), null, getTestXmlParser("hero_ignored_content.xml")).hero)
-        assertEquals(2, hero.content.size)
-        assertIs<Paragraph>(hero.content[0])
-        assertIs<Tabs>(hero.content[1])
+        val config = ParserConfig(supportedDeviceTypes = setOf(DeviceType.ANDROID, DeviceType.MOBILE))
+        val page = TractPage(Manifest(config = config), null, getTestXmlParser("hero_ignored_content.xml"))
+        with(assertNotNull(page.hero)) {
+            assertEquals(2, content.size)
+            assertIs<Paragraph>(content[0])
+            assertIs<Tabs>(content[1])
+        }
     }
 
     @Test

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/service/ManifestParserTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/service/ManifestParserTest.kt
@@ -2,6 +2,7 @@ package org.cru.godtools.tool.service
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
+import org.cru.godtools.tool.ParserConfig
 import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.TEST_XML_PULL_PARSER_FACTORY
@@ -14,7 +15,7 @@ import kotlin.test.assertIs
 @RunOnAndroidWith(AndroidJUnit4::class)
 @OptIn(ExperimentalCoroutinesApi::class)
 class ManifestParserTest : UsesResources("service") {
-    private val parser = ManifestParser(TEST_XML_PULL_PARSER_FACTORY)
+    private val parser = ManifestParser(TEST_XML_PULL_PARSER_FACTORY, ParserConfig())
 
     @Test
     fun testParseManifest() = runTest {
@@ -54,7 +55,8 @@ class ManifestParserTest : UsesResources("service") {
     }
 
     private suspend fun parseTool(prefix: String, manifest: String) =
-        ManifestParser(PrefixXmlPullParserFactory(prefix, TEST_XML_PULL_PARSER_FACTORY)).parseManifest(manifest)
+        ManifestParser(PrefixXmlPullParserFactory(prefix, TEST_XML_PULL_PARSER_FACTORY), ParserConfig())
+            .parseManifest(manifest)
 
     internal class PrefixXmlPullParserFactory(
         private val prefix: String,

--- a/module/parser/src/iosMain/kotlin/org/cru/godtools/tool/IosParserConfig.kt
+++ b/module/parser/src/iosMain/kotlin/org/cru/godtools/tool/IosParserConfig.kt
@@ -6,7 +6,7 @@ import kotlin.native.concurrent.SharedImmutable
 import kotlin.native.concurrent.freeze
 import kotlin.native.concurrent.isFrozen
 
-actual object ParserConfig {
+actual object LegacyParserConfig {
     private val _supportedDeviceTypes = AtomicReference(DEFAULT_SUPPORTED_DEVICE_TYPES)
     actual var supportedDeviceTypes: Set<DeviceType>
         get() = _supportedDeviceTypes.value

--- a/module/parser/src/iosMain/kotlin/org/cru/godtools/tool/IosParserConfig.kt
+++ b/module/parser/src/iosMain/kotlin/org/cru/godtools/tool/IosParserConfig.kt
@@ -1,26 +1,7 @@
 package org.cru.godtools.tool
 
 import org.cru.godtools.tool.model.DeviceType
-import kotlin.native.concurrent.AtomicReference
 import kotlin.native.concurrent.SharedImmutable
-import kotlin.native.concurrent.freeze
-import kotlin.native.concurrent.isFrozen
-
-actual object LegacyParserConfig : ParserConfig() {
-    private val _supportedDeviceTypes = AtomicReference(DEFAULT_SUPPORTED_DEVICE_TYPES)
-    actual override var supportedDeviceTypes: Set<DeviceType>
-        get() = _supportedDeviceTypes.value
-        set(value) {
-            _supportedDeviceTypes.value = if (value.isFrozen) value else value.toSet().freeze()
-        }
-
-    private val _supportedFeatures = AtomicReference(emptySet<String>())
-    actual override var supportedFeatures: Set<String>
-        get() = _supportedFeatures.value
-        set(value) {
-            _supportedFeatures.value = if (value.isFrozen) value else value.toSet().freeze()
-        }
-}
 
 @SharedImmutable
 internal actual val DEFAULT_SUPPORTED_DEVICE_TYPES = setOf(DeviceType.IOS, DeviceType.MOBILE)

--- a/module/parser/src/iosMain/kotlin/org/cru/godtools/tool/IosParserConfig.kt
+++ b/module/parser/src/iosMain/kotlin/org/cru/godtools/tool/IosParserConfig.kt
@@ -6,16 +6,16 @@ import kotlin.native.concurrent.SharedImmutable
 import kotlin.native.concurrent.freeze
 import kotlin.native.concurrent.isFrozen
 
-actual object LegacyParserConfig {
+actual object LegacyParserConfig : ParserConfig() {
     private val _supportedDeviceTypes = AtomicReference(DEFAULT_SUPPORTED_DEVICE_TYPES)
-    actual var supportedDeviceTypes: Set<DeviceType>
+    actual override var supportedDeviceTypes: Set<DeviceType>
         get() = _supportedDeviceTypes.value
         set(value) {
             _supportedDeviceTypes.value = if (value.isFrozen) value else value.toSet().freeze()
         }
 
     private val _supportedFeatures = AtomicReference(emptySet<String>())
-    actual var supportedFeatures: Set<String>
+    actual override var supportedFeatures: Set<String>
         get() = _supportedFeatures.value
         set(value) {
             _supportedFeatures.value = if (value.isFrozen) value else value.toSet().freeze()

--- a/module/parser/src/iosMain/kotlin/org/cru/godtools/tool/service/IosManifestParser.kt
+++ b/module/parser/src/iosMain/kotlin/org/cru/godtools/tool/service/IosManifestParser.kt
@@ -1,8 +1,11 @@
 package org.cru.godtools.tool.service
 
 import kotlinx.coroutines.runBlocking
+import org.cru.godtools.tool.ParserConfig
 import org.cru.godtools.tool.xml.XmlPullParserFactory
 
-class IosManifestParser(parserFactory: XmlPullParserFactory) : ManifestParser(parserFactory) {
-    fun parseManifestBlocking(fileName: String) = runBlocking { parseManifest(fileName) }
+class IosManifestParser(parserFactory: XmlPullParserFactory, config: ParserConfig) :
+    ManifestParser(parserFactory, config) {
+    fun parseManifestBlocking(fileName: String, config: ParserConfig = this.config) =
+        runBlocking { parseManifest(fileName, config) }
 }

--- a/module/parser/src/jsMain/kotlin/org/cru/godtools/tool/JsParserConfig.kt
+++ b/module/parser/src/jsMain/kotlin/org/cru/godtools/tool/JsParserConfig.kt
@@ -2,6 +2,6 @@ package org.cru.godtools.tool
 
 import org.cru.godtools.tool.model.DeviceType
 
-actual typealias ParserConfig = SimpleParserConfig
+actual typealias LegacyParserConfig = SimpleParserConfig
 
 internal actual val DEFAULT_SUPPORTED_DEVICE_TYPES = setOf(DeviceType.WEB)

--- a/module/parser/src/jsMain/kotlin/org/cru/godtools/tool/JsParserConfig.kt
+++ b/module/parser/src/jsMain/kotlin/org/cru/godtools/tool/JsParserConfig.kt
@@ -2,6 +2,4 @@ package org.cru.godtools.tool
 
 import org.cru.godtools.tool.model.DeviceType
 
-actual typealias LegacyParserConfig = SimpleParserConfig
-
 internal actual val DEFAULT_SUPPORTED_DEVICE_TYPES = setOf(DeviceType.WEB)


### PR DESCRIPTION
This moves away from using a `ParserConfig` singleton to instead providing a `ParserConfig` object to the `ManifestParser` service. It is also possible to provide an alternate configuration on a one-off basis when parsing a manifest.

this one-off configuration functionality will be leveraged to provide a mechanism to parse the manifest only and not parse the pages & tips, this will be necessary to enumerate all the associated resources that need to be downloaded for the more granular tool distribution mechanism.