### PR TITLE
GT-1449 Make it possible to skip parsing pages and tips

### DIFF
--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/ParserConfig.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/ParserConfig.kt
@@ -9,12 +9,16 @@ const val FEATURE_MULTISELECT = "multiselect"
 
 data class ParserConfig(
     internal val supportedFeatures: Set<String> = emptySet(),
-    internal val supportedDeviceTypes: Set<DeviceType> = DEFAULT_SUPPORTED_DEVICE_TYPES
+    internal val supportedDeviceTypes: Set<DeviceType> = DEFAULT_SUPPORTED_DEVICE_TYPES,
+    internal val parsePages: Boolean = true,
+    internal val parseTips: Boolean = true
 ) {
     constructor() : this(supportedFeatures = emptySet())
 
     fun withSupportedDeviceTypes(types: Set<DeviceType>) = copy(supportedDeviceTypes = types)
     fun withSupportedFeatures(features: Set<String>) = copy(supportedFeatures = features)
+    fun withParsePages(enabled: Boolean) = copy(parsePages = enabled)
+    fun withParseTips(enabled: Boolean) = copy(parseTips = enabled)
 }
 
 internal expect val DEFAULT_SUPPORTED_DEVICE_TYPES: Set<DeviceType>

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/ParserConfig.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/ParserConfig.kt
@@ -17,6 +17,7 @@ data class ParserConfig(
 
     fun withSupportedDeviceTypes(types: Set<DeviceType>) = copy(supportedDeviceTypes = types)
     fun withSupportedFeatures(features: Set<String>) = copy(supportedFeatures = features)
+    fun withParseRelated(enabled: Boolean) = copy(parsePages = enabled, parseTips = enabled)
     fun withParsePages(enabled: Boolean) = copy(parsePages = enabled)
     fun withParseTips(enabled: Boolean) = copy(parseTips = enabled)
 }

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
@@ -180,6 +180,12 @@ class Manifest : BaseModel, Styles {
     private val pagesToParse: List<Pair<String?, String>>
     private val tipsToParse: List<Pair<String, String>>
 
+    val relatedFiles get() = buildSet {
+        addAll(pagesToParse.map { it.second })
+        addAll(tipsToParse.map { it.second })
+        addAll(resources.values.mapNotNull { it.localName })
+    }
+
     private constructor(parser: XmlPullParser, config: ParserConfig) {
         parser.require(XmlPullParser.START_TAG, XMLNS_MANIFEST, XML_MANIFEST)
 

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Manifest.kt
@@ -83,18 +83,26 @@ class Manifest : BaseModel, Styles {
             val manifest = Manifest(parseFile(fileName), config)
             coroutineScope {
                 // parse pages
-                launch {
-                    manifest.pages = manifest.pagesToParse
-                        .map { (fileName, src) -> async { Page.parse(manifest, fileName, parseFile(src)) } }
-                        .awaitAll().filterNotNull()
+                if (config.parsePages) {
+                    launch {
+                        manifest.pages = manifest.pagesToParse
+                            .map { (fileName, src) -> async { Page.parse(manifest, fileName, parseFile(src)) } }
+                            .awaitAll().filterNotNull()
+                    }
+                } else {
+                    manifest.pages = emptyList()
                 }
 
                 // parse tips
-                launch {
-                    manifest.tips = manifest.tipsToParse
-                        .map { (id, src) -> async { Tip(manifest, id, parseFile(src)) } }
-                        .awaitAll()
-                        .associateBy { it.id }
+                if (config.parseTips) {
+                    launch {
+                        manifest.tips = manifest.tipsToParse
+                            .map { (id, src) -> async { Tip(manifest, id, parseFile(src)) } }
+                            .awaitAll()
+                            .associateBy { it.id }
+                    }
+                } else {
+                    manifest.tips = emptyMap()
                 }
             }
             return manifest

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/ParserConfigTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/ParserConfigTest.kt
@@ -3,6 +3,7 @@ package org.cru.godtools.tool
 import org.cru.godtools.tool.model.DeviceType
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class ParserConfigTest {
@@ -22,5 +23,23 @@ class ParserConfigTest {
 
         assertTrue(orig.supportedFeatures.isEmpty())
         assertEquals(setOf("test"), updated.supportedFeatures)
+    }
+
+    @Test
+    fun testWithParsePages() {
+        val orig = ParserConfig(parsePages = true)
+        val updated = orig.withParsePages(false)
+
+        assertTrue(orig.parsePages)
+        assertFalse(updated.parsePages)
+    }
+
+    @Test
+    fun testWithParseTips() {
+        val orig = ParserConfig(parseTips = true)
+        val updated = orig.withParseTips(false)
+
+        assertTrue(orig.parseTips)
+        assertFalse(updated.parseTips)
     }
 }

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/ParserConfigTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/ParserConfigTest.kt
@@ -26,6 +26,17 @@ class ParserConfigTest {
     }
 
     @Test
+    fun testWithParseRelated() {
+        val orig = ParserConfig(parsePages = true, parseTips = true)
+        val updated = orig.withParseRelated(false)
+
+        assertTrue(orig.parsePages)
+        assertTrue(orig.parseTips)
+        assertFalse(updated.parsePages)
+        assertFalse(updated.parseTips)
+    }
+
+    @Test
     fun testWithParsePages() {
         val orig = ParserConfig(parsePages = true)
         val updated = orig.withParsePages(false)

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ManifestTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ManifestTest.kt
@@ -171,7 +171,26 @@ class ManifestTest : UsesResources() {
         }
     }
 
-    private suspend fun parseManifest(name: String) = Manifest.parse(name, ParserConfig()) { getTestXmlParser(it) }
+    @Test
+    fun testParseManifestButNotPagesOrTips() = runTest {
+        val expectedRelatedFiles = setOf(
+            "page1_sha.xml",
+            "page2_sha.xml",
+            "tip1_sha.xml",
+            "tip2_sha.xml",
+            "file1_sha.png",
+            "file2_sha.png",
+            "common_sha.xml"
+        )
+
+        val manifest = parseManifest("manifest_related_files.xml", ParserConfig().withParseRelated(false))
+        assertTrue(manifest.pages.isEmpty())
+        assertTrue(manifest.tips.isEmpty())
+        assertEquals(expectedRelatedFiles, manifest.relatedFiles)
+    }
+
+    private suspend fun parseManifest(name: String, config: ParserConfig = ParserConfig()) =
+        Manifest.parse(name, config) { getTestXmlParser(it) }
     // endregion parse Manifest
 
     @Test

--- a/module/parser/src/commonTest/resources/org/cru/godtools/tool/model/manifest_related_files.xml
+++ b/module/parser/src/commonTest/resources/org/cru/godtools/tool/model/manifest_related_files.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<manifest xmlns="https://mobile-content-api.cru.org/xmlns/manifest">
+    <pages>
+        <page filename="page1.xml" src="page1_sha.xml" />
+        <page filename="page2.xml" src="page2_sha.xml" />
+        <page filename="common.xml" src="common_sha.xml" />
+    </pages>
+
+    <tips>
+        <tip id="tip1" src="tip1_sha.xml" />
+        <tip id="tip2" src="tip2_sha.xml" />
+        <tip id="common" src="common_sha.xml" />
+    </tips>
+
+    <resources>
+        <resource filename="file1.png" src="file1_sha.png" />
+        <resource filename="file2.png" src="file2_sha.png" />
+        <resource filename="common.xml" src="common_sha.xml" />
+    </resources>
+</manifest>


### PR DESCRIPTION
This PR makes it so that a custom config can be provided when parsing a Manifest that will not parse related xml files. It also provides a method that will enumerate all the related files (pages, tips, and resources) for a manifest.