### PR TITLE
Improve iOS interop for new ParserConfig

### DIFF
--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/ParserConfig.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/ParserConfig.kt
@@ -7,9 +7,14 @@ const val FEATURE_CONTENT_CARD = "content_card"
 const val FEATURE_FLOW = "flow"
 const val FEATURE_MULTISELECT = "multiselect"
 
-class ParserConfig(
-    val supportedFeatures: Set<String> = emptySet(),
-    val supportedDeviceTypes: Set<DeviceType> = DEFAULT_SUPPORTED_DEVICE_TYPES
-)
+data class ParserConfig(
+    internal val supportedFeatures: Set<String> = emptySet(),
+    internal val supportedDeviceTypes: Set<DeviceType> = DEFAULT_SUPPORTED_DEVICE_TYPES
+) {
+    constructor() : this(supportedFeatures = emptySet())
+
+    fun withSupportedDeviceTypes(types: Set<DeviceType>) = copy(supportedDeviceTypes = types)
+    fun withSupportedFeatures(features: Set<String>) = copy(supportedFeatures = features)
+}
 
 internal expect val DEFAULT_SUPPORTED_DEVICE_TYPES: Set<DeviceType>

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/service/ManifestParser.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/service/ManifestParser.kt
@@ -7,8 +7,8 @@ import org.cru.godtools.tool.model.Manifest
 import org.cru.godtools.tool.xml.XmlPullParserException
 import org.cru.godtools.tool.xml.XmlPullParserFactory
 
-open class ManifestParser(private val parserFactory: XmlPullParserFactory, protected val config: ParserConfig) {
-    suspend fun parseManifest(fileName: String, config: ParserConfig = this.config): ParserResult = try {
+open class ManifestParser(private val parserFactory: XmlPullParserFactory, val defaultConfig: ParserConfig) {
+    suspend fun parseManifest(fileName: String, config: ParserConfig = defaultConfig): ParserResult = try {
         val manifest = Manifest.parse(fileName, config) {
             parserFactory.getXmlParser(it)?.apply { nextTag() } ?: throw FileNotFoundException(fileName)
         }

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/ParserConfigTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/ParserConfigTest.kt
@@ -1,0 +1,26 @@
+package org.cru.godtools.tool
+
+import org.cru.godtools.tool.model.DeviceType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ParserConfigTest {
+    @Test
+    fun testWithSupportedDeviceTypes() {
+        val orig = ParserConfig(supportedDeviceTypes = emptySet())
+        val updated = orig.withSupportedDeviceTypes(setOf(DeviceType.ANDROID))
+
+        assertTrue(orig.supportedDeviceTypes.isEmpty())
+        assertEquals(setOf(DeviceType.ANDROID), updated.supportedDeviceTypes)
+    }
+
+    @Test
+    fun testWithSupportedFeatures() {
+        val orig = ParserConfig(supportedFeatures = emptySet())
+        val updated = orig.withSupportedFeatures(setOf("test"))
+
+        assertTrue(orig.supportedFeatures.isEmpty())
+        assertEquals(setOf("test"), updated.supportedFeatures)
+    }
+}

--- a/module/parser/src/iosMain/kotlin/org/cru/godtools/tool/service/IosManifestParser.kt
+++ b/module/parser/src/iosMain/kotlin/org/cru/godtools/tool/service/IosManifestParser.kt
@@ -4,8 +4,8 @@ import kotlinx.coroutines.runBlocking
 import org.cru.godtools.tool.ParserConfig
 import org.cru.godtools.tool.xml.XmlPullParserFactory
 
-class IosManifestParser(parserFactory: XmlPullParserFactory, config: ParserConfig) :
-    ManifestParser(parserFactory, config) {
-    fun parseManifestBlocking(fileName: String, config: ParserConfig = this.config) =
+class IosManifestParser(parserFactory: XmlPullParserFactory, defaultConfig: ParserConfig) :
+    ManifestParser(parserFactory, defaultConfig) {
+    fun parseManifestBlocking(fileName: String, config: ParserConfig = defaultConfig) =
         runBlocking { parseManifest(fileName, config) }
 }

--- a/module/parser/src/iosMain/kotlin/org/cru/godtools/tool/service/IosManifestParser.kt
+++ b/module/parser/src/iosMain/kotlin/org/cru/godtools/tool/service/IosManifestParser.kt
@@ -6,6 +6,7 @@ import org.cru.godtools.tool.xml.XmlPullParserFactory
 
 class IosManifestParser(parserFactory: XmlPullParserFactory, defaultConfig: ParserConfig) :
     ManifestParser(parserFactory, defaultConfig) {
-    fun parseManifestBlocking(fileName: String, config: ParserConfig = defaultConfig) =
+    fun parseManifestBlocking(fileName: String) = parseManifestBlocking(fileName, defaultConfig)
+    fun parseManifestBlocking(fileName: String, config: ParserConfig) =
         runBlocking { parseManifest(fileName, config) }
 }


### PR DESCRIPTION
- support a builder pattern for the ParserConfig on iOS
- expose the defaultConfig for a ManifestParser as a property
- don't use default values for ios only logic
