### PR TITLE
GT-1606 Support parsing Analytics events on Accordion Sections

### DIFF
--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Accordion.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Accordion.kt
@@ -33,8 +33,11 @@ class Accordion : Content {
     }
 
     @RestrictTo(RestrictToScope.TESTS)
-    internal constructor(parent: Base, sections: (Accordion) -> List<Section>) : super(parent) {
-        this.sections = sections(this)
+    internal constructor(
+        parent: Base = Manifest(),
+        sections: ((Accordion) -> List<Section>)? = null
+    ) : super(parent) {
+        this.sections = sections?.invoke(this).orEmpty()
     }
 
     class Section : BaseModel, Parent, HasAnalyticsEvents {
@@ -66,11 +69,15 @@ class Accordion : Content {
         }
 
         @RestrictTo(RestrictToScope.TESTS)
-        internal constructor(accordion: Accordion, content: (Section) -> List<Content>) : super(accordion) {
+        internal constructor(
+            accordion: Accordion = Accordion(),
+            analyticsEvents: List<AnalyticsEvent> = emptyList(),
+            content: ((Section) -> List<Content>)? = null
+        ) : super(accordion) {
             this.accordion = accordion
             header = null
-            analyticsEvents = emptyList()
-            this.content = content(this)
+            this.analyticsEvents = analyticsEvents
+            this.content = content?.invoke(this).orEmpty()
         }
 
         override fun getAnalyticsEvents(type: Trigger) = when (type) {

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/AccordionTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/AccordionTest.kt
@@ -9,6 +9,7 @@ import org.cru.godtools.tool.model.tips.InlineTip
 import org.cru.godtools.tool.model.tips.Tip
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 
 @RunOnAndroidWith(AndroidJUnit4::class)
@@ -58,5 +59,29 @@ class AccordionTest : UsesResources() {
             )
         }
         assertEquals(listOf(manifest.findTip("tip1")!!, manifest.findTip("tip2")!!), accordion.tips)
+    }
+
+    @Test
+    fun testSectionAnalyticsEvents() {
+        val section = Accordion.Section(
+            analyticsEvents = listOf(
+                AnalyticsEvent(action = "default", trigger = AnalyticsEvent.Trigger.DEFAULT),
+                AnalyticsEvent(action = "visible", trigger = AnalyticsEvent.Trigger.VISIBLE),
+                AnalyticsEvent(action = "hidden", trigger = AnalyticsEvent.Trigger.HIDDEN),
+                AnalyticsEvent(action = "unknown", trigger = AnalyticsEvent.Trigger.UNKNOWN),
+            )
+        )
+
+        with(section.getAnalyticsEvents(AnalyticsEvent.Trigger.VISIBLE)) {
+            assertEquals(2, size)
+            assertEquals(setOf("default", "visible"), map { it.action }.toSet())
+        }
+
+        with(section.getAnalyticsEvents(AnalyticsEvent.Trigger.HIDDEN)) {
+            assertEquals(1, size)
+            assertEquals("hidden", single().action)
+        }
+
+        assertFailsWith(IllegalStateException::class) { section.getAnalyticsEvents(AnalyticsEvent.Trigger.UNKNOWN) }
     }
 }

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/AccordionTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/AccordionTest.kt
@@ -33,6 +33,22 @@ class AccordionTest : UsesResources() {
     }
 
     @Test
+    fun testParseAccordionAnalytics() = runTest {
+        val accordion = Accordion(Manifest(), getTestXmlParser("accordion_analytics.xml"))
+        assertEquals(1, accordion.sections.size)
+
+        with(accordion.sections.single()) {
+            val visible = getAnalyticsEvents(AnalyticsEvent.Trigger.VISIBLE)
+            assertEquals(2, visible.size)
+            assertEquals(setOf("default", "visible"), visible.map { it.action }.toSet())
+
+            val hidden = getAnalyticsEvents(AnalyticsEvent.Trigger.HIDDEN)
+            assertEquals(1, hidden.size)
+            assertEquals("hidden", hidden.single().action)
+        }
+    }
+
+    @Test
     fun testTipsProperty() {
         val manifest = Manifest(tips = { listOf(Tip(it, "tip1"), Tip(it, "tip2")) })
         val accordion = Accordion(manifest) {

--- a/module/parser/src/commonTest/resources/org/cru/godtools/tool/model/accordion_analytics.xml
+++ b/module/parser/src/commonTest/resources/org/cru/godtools/tool/model/accordion_analytics.xml
@@ -1,0 +1,14 @@
+<content:accordion xmlns:analytics="https://mobile-content-api.cru.org/xmlns/analytics"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content">
+    <content:section>
+        <content:header>
+            <content:text>Section 1</content:text>
+        </content:header>
+        <analytics:events>
+            <analytics:event action="default" system="firebase" />
+            <analytics:event action="visible" system="firebase" trigger="visible" />
+            <analytics:event action="hidden" system="firebase" trigger="hidden" />
+        </analytics:events>
+        <content:text>Text</content:text>
+    </content:section>
+</content:accordion>


### PR DESCRIPTION
This PR adds the `HasAnalyticsEvents` interface to Accordion sections. This provides a `getAnalyticsEvents(triggerType)` method on the accordion section that will allow you to access any analytics events that need to be fired for a specific Trigger type.