### PR TITLE
GT-1358 Provide Napier glue logic for iOS

### DIFF
--- a/src/iosMain/kotlin/org/cru/godtools/tool/napier/NapierProxy.kt
+++ b/src/iosMain/kotlin/org/cru/godtools/tool/napier/NapierProxy.kt
@@ -1,0 +1,20 @@
+package org.cru.godtools.tool.napier
+
+import io.github.aakira.napier.Antilog
+import io.github.aakira.napier.DebugAntilog
+import io.github.aakira.napier.LogLevel
+import io.github.aakira.napier.Napier
+
+fun enableDebugLogging() {
+    Napier.base(DebugAntilog())
+}
+
+fun enableCustomLogging(
+    onLog: (priority: LogLevel, tag: String?, throwable: Throwable?, message: String?) -> Unit
+) {
+    Napier.base(object : Antilog() {
+        override fun performLog(priority: LogLevel, tag: String?, throwable: Throwable?, message: String?) {
+            onLog(priority, tag, throwable, message)
+        }
+    })
+}


### PR DESCRIPTION
Provides the following swift headers:

```swift
public class NapierProxyKt : KotlinBase {
    open class func enableCustomLogging(onLog: @escaping (NapierLogLevel, String?, KotlinThrowable?, String?) -> Void)
    open class func enableDebugLogging()
}

public class NapierLogLevel : KotlinEnum<NapierLogLevel> {
    open class var verbose: NapierLogLevel { get }
    open class var debug: NapierLogLevel { get }
    open class var info: NapierLogLevel { get }
    open class var warning: NapierLogLevel { get }
    open class var error: NapierLogLevel { get }
    open class var assert: NapierLogLevel { get }

    open class func values() -> KotlinArray<NapierLogLevel>
}
```