### PR TITLE
GT-1569 Support required-android-version and required-ios-version content attributes

### DIFF
--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/ParserConfig.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/ParserConfig.kt
@@ -8,7 +8,7 @@ const val FEATURE_FLOW = "flow"
 const val FEATURE_MULTISELECT = "multiselect"
 
 data class ParserConfig(
-    internal val supportedFeatures: Set<String> = emptySet(),
+    private val supportedFeatures: Set<String> = emptySet(),
     internal val supportedDeviceTypes: Set<DeviceType> = DEFAULT_SUPPORTED_DEVICE_TYPES,
     internal val parsePages: Boolean = true,
     internal val parseTips: Boolean = true
@@ -20,6 +20,8 @@ data class ParserConfig(
     fun withParseRelated(enabled: Boolean) = copy(parsePages = enabled, parseTips = enabled)
     fun withParsePages(enabled: Boolean) = copy(parsePages = enabled)
     fun withParseTips(enabled: Boolean) = copy(parseTips = enabled)
+
+    internal fun supportsFeature(feature: String) = feature in supportedFeatures
 }
 
 internal expect val DEFAULT_SUPPORTED_DEVICE_TYPES: Set<DeviceType>

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/ParserConfig.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/ParserConfig.kt
@@ -1,13 +1,18 @@
 package org.cru.godtools.tool
 
+import org.cru.godtools.tool.internal.VisibleForTesting
 import org.cru.godtools.tool.model.DeviceType
+import org.cru.godtools.tool.model.Version
+import org.cru.godtools.tool.model.Version.Companion.toVersion
 
 const val FEATURE_ANIMATION = "animation"
 const val FEATURE_CONTENT_CARD = "content_card"
 const val FEATURE_FLOW = "flow"
 const val FEATURE_MULTISELECT = "multiselect"
 
-data class ParserConfig(
+data class ParserConfig @VisibleForTesting internal constructor(
+    internal val deviceType: DeviceType = DeviceType.UNKNOWN,
+    internal val appVersion: Version? = null,
     private val supportedFeatures: Set<String> = emptySet(),
     internal val supportedDeviceTypes: Set<DeviceType> = DEFAULT_SUPPORTED_DEVICE_TYPES,
     internal val parsePages: Boolean = true,
@@ -15,6 +20,8 @@ data class ParserConfig(
 ) {
     constructor() : this(supportedFeatures = emptySet())
 
+    fun withAppVersion(deviceType: DeviceType, version: String?) =
+        copy(deviceType = deviceType, appVersion = version?.toVersion())
     fun withSupportedDeviceTypes(types: Set<DeviceType>) = copy(supportedDeviceTypes = types)
     fun withSupportedFeatures(features: Set<String>) = copy(supportedFeatures = features)
     fun withParseRelated(enabled: Boolean) = copy(parsePages = enabled, parseTips = enabled)

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/ParserConfig.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/ParserConfig.kt
@@ -9,6 +9,7 @@ const val FEATURE_ANIMATION = "animation"
 const val FEATURE_CONTENT_CARD = "content_card"
 const val FEATURE_FLOW = "flow"
 const val FEATURE_MULTISELECT = "multiselect"
+internal const val FEATURE_REQUIRED_VERSIONS = "required-versions"
 
 data class ParserConfig @VisibleForTesting internal constructor(
     internal val deviceType: DeviceType = DeviceType.UNKNOWN,
@@ -28,7 +29,10 @@ data class ParserConfig @VisibleForTesting internal constructor(
     fun withParsePages(enabled: Boolean) = copy(parsePages = enabled)
     fun withParseTips(enabled: Boolean) = copy(parseTips = enabled)
 
-    internal fun supportsFeature(feature: String) = feature in supportedFeatures
+    internal fun supportsFeature(feature: String) = when (feature) {
+        FEATURE_REQUIRED_VERSIONS -> appVersion != null
+        else -> feature in supportedFeatures
+    }
 }
 
 internal expect val DEFAULT_SUPPORTED_DEVICE_TYPES: Set<DeviceType>

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Animation.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Animation.kt
@@ -60,5 +60,5 @@ class Animation : Content, Clickable {
         stopListeners = emptySet()
     }
 
-    override val isIgnored get() = FEATURE_ANIMATION !in manifest.config.supportedFeatures || super.isIgnored
+    override val isIgnored get() = !manifest.config.supportsFeature(FEATURE_ANIMATION) || super.isIgnored
 }

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Card.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Card.kt
@@ -40,7 +40,7 @@ class Card : Content, Parent, Clickable {
         url = null
     }
 
-    override val isIgnored get() = FEATURE_CONTENT_CARD !in manifest.config.supportedFeatures || super.isIgnored
+    override val isIgnored get() = !manifest.config.supportsFeature(FEATURE_CONTENT_CARD) || super.isIgnored
 }
 
 val Card?.backgroundColor get() = this?._backgroundColor ?: stylesParent.cardBackgroundColor

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Content.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Content.kt
@@ -6,6 +6,7 @@ import org.cru.godtools.tool.ParserConfig
 import org.cru.godtools.tool.REGEX_SEQUENCE_SEPARATOR
 import org.cru.godtools.tool.internal.RestrictTo
 import org.cru.godtools.tool.internal.RestrictToScope
+import org.cru.godtools.tool.internal.VisibleForTesting
 import org.cru.godtools.tool.model.DeviceType.Companion.toDeviceTypes
 import org.cru.godtools.tool.model.Version.Companion.toVersionOrNull
 import org.cru.godtools.tool.model.tips.InlineTip
@@ -23,8 +24,10 @@ abstract class Content : BaseModel, Visibility {
     private val version: Int
     private val restrictTo: Set<DeviceType>
     private val requiredFeatures: Set<String>
-    private val requiredAndroidVersion: Version?
-    private val requiredIosVersion: Version?
+    @VisibleForTesting
+    internal val requiredAndroidVersion: Version?
+    @VisibleForTesting
+    internal val requiredIosVersion: Version?
 
     final override val invisibleIf: Expression?
     final override val goneIf: Expression?

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Content.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Content.kt
@@ -55,7 +55,7 @@ abstract class Content : BaseModel, Visibility {
      */
     internal open val isIgnored
         get() = version > SCHEMA_VERSION ||
-            !manifest.config.supportedFeatures.containsAll(requiredFeatures) ||
+            requiredFeatures.any { !manifest.config.supportsFeature(it) } ||
             restrictTo.none { it in manifest.config.supportedDeviceTypes } ||
             invisibleIf?.isValid() == false ||
             goneIf?.isValid() == false

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Content.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Content.kt
@@ -1,16 +1,21 @@
 package org.cru.godtools.tool.model
 
 import org.cru.godtools.expressions.Expression
+import org.cru.godtools.tool.FEATURE_REQUIRED_VERSIONS
+import org.cru.godtools.tool.ParserConfig
 import org.cru.godtools.tool.REGEX_SEQUENCE_SEPARATOR
 import org.cru.godtools.tool.internal.RestrictTo
 import org.cru.godtools.tool.internal.RestrictToScope
 import org.cru.godtools.tool.model.DeviceType.Companion.toDeviceTypes
+import org.cru.godtools.tool.model.Version.Companion.toVersionOrNull
 import org.cru.godtools.tool.model.tips.InlineTip
 import org.cru.godtools.tool.model.tips.Tip
 import org.cru.godtools.tool.model.tips.XMLNS_TRAINING
 import org.cru.godtools.tool.xml.XmlPullParser
 
 private const val XML_REQUIRED_FEATURES = "required-features"
+private const val XML_REQUIRED_ANDROID_VERSION = "required-android-version"
+private const val XML_REQUIRED_IOS_VERSION = "required-ios-version"
 private const val XML_RESTRICT_TO = "restrictTo"
 private const val XML_VERSION = "version"
 
@@ -18,6 +23,8 @@ abstract class Content : BaseModel, Visibility {
     private val version: Int
     private val restrictTo: Set<DeviceType>
     private val requiredFeatures: Set<String>
+    private val requiredAndroidVersion: Version?
+    private val requiredIosVersion: Version?
 
     final override val invisibleIf: Expression?
     final override val goneIf: Expression?
@@ -27,6 +34,10 @@ abstract class Content : BaseModel, Visibility {
         restrictTo = parser.getAttributeValue(XML_RESTRICT_TO)?.toDeviceTypes() ?: DeviceType.ALL
         requiredFeatures = parser.getAttributeValue(XML_REQUIRED_FEATURES)
             ?.split(REGEX_SEQUENCE_SEPARATOR)?.filterTo(mutableSetOf()) { it.isNotBlank() }.orEmpty()
+        requiredAndroidVersion = parser.getAttributeValue(XML_REQUIRED_ANDROID_VERSION)
+            ?.let { it.toVersionOrNull() ?: Version.MAX }
+        requiredIosVersion = parser.getAttributeValue(XML_REQUIRED_IOS_VERSION)
+            ?.let { it.toVersionOrNull() ?: Version.MAX }
 
         parser.parseVisibilityAttrs { invisibleIf, goneIf ->
             this.invisibleIf = invisibleIf
@@ -40,12 +51,16 @@ abstract class Content : BaseModel, Visibility {
         version: Int = SCHEMA_VERSION,
         restrictTo: Set<DeviceType> = DeviceType.ALL,
         requiredFeatures: Set<String> = emptySet(),
+        requiredAndroidVersion: Version? = null,
+        requiredIosVersion: Version? = null,
         invisibleIf: Expression? = null,
         goneIf: Expression? = null
     ) : super(parent) {
         this.restrictTo = restrictTo
         this.version = version
         this.requiredFeatures = requiredFeatures
+        this.requiredAndroidVersion = requiredAndroidVersion
+        this.requiredIosVersion = requiredIosVersion
         this.invisibleIf = invisibleIf
         this.goneIf = goneIf
     }
@@ -55,10 +70,15 @@ abstract class Content : BaseModel, Visibility {
      */
     internal open val isIgnored
         get() = version > SCHEMA_VERSION ||
+            !areContentRestrictionsSatisfied ||
             requiredFeatures.any { !manifest.config.supportsFeature(it) } ||
             restrictTo.none { it in manifest.config.supportedDeviceTypes } ||
             invisibleIf?.isValid() == false ||
             goneIf?.isValid() == false
+
+    private val areContentRestrictionsSatisfied
+        get() = manifest.config.isRequiredVersionSatisfied(DeviceType.ANDROID, requiredAndroidVersion) &&
+            manifest.config.isRequiredVersionSatisfied(DeviceType.IOS, requiredIosVersion)
 
     open val tips get() = emptyList<Tip>()
 
@@ -97,4 +117,12 @@ abstract class Content : BaseModel, Visibility {
             }
         }
     }
+}
+
+private fun ParserConfig.isRequiredVersionSatisfied(deviceType: DeviceType, version: Version?) = when {
+    version == null -> true
+    !supportsFeature(FEATURE_REQUIRED_VERSIONS) -> false
+    deviceType != this.deviceType -> true
+    (appVersion ?: Version.MIN) >= version -> true
+    else -> false
 }

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Flow.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Flow.kt
@@ -51,7 +51,7 @@ class Flow : Content {
         }
     }
 
-    override val isIgnored get() = FEATURE_FLOW !in manifest.config.supportedFeatures || super.isIgnored
+    override val isIgnored get() = !manifest.config.supportsFeature(FEATURE_FLOW) || super.isIgnored
 
     class Item : BaseModel, Parent, Visibility {
         companion object {

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Multiselect.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Multiselect.kt
@@ -85,7 +85,7 @@ class Multiselect : Content {
         this.options = options?.invoke(this).orEmpty()
     }
 
-    override val isIgnored get() = FEATURE_MULTISELECT !in manifest.config.supportedFeatures || super.isIgnored
+    override val isIgnored get() = !manifest.config.supportsFeature(FEATURE_MULTISELECT) || super.isIgnored
 
     class Option : Content, Parent, HasAnalyticsEvents {
         internal companion object {

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Version.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Version.kt
@@ -1,0 +1,20 @@
+package org.cru.godtools.tool.model
+
+import kotlin.jvm.JvmInline
+
+@JvmInline
+internal value class Version private constructor(val version: List<UInt>) : Comparable<Version> {
+    companion object {
+        internal fun String.toVersion() = try {
+            Version(split(".").map { it.toUInt() }.dropLastWhile { it == 0U })
+        } catch (e: NumberFormatException) {
+            throw IllegalArgumentException("Invalid version: $this", e)
+        }
+    }
+
+    override fun compareTo(other: Version) =
+        version.zip(other.version) { a, b -> a.compareTo(b) }.firstOrNull { it != 0 }
+            ?: version.size.compareTo(other.version.size)
+
+    override fun toString() = version.joinToString(".")
+}

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Version.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Version.kt
@@ -1,14 +1,25 @@
 package org.cru.godtools.tool.model
 
+import io.github.aakira.napier.Napier
 import kotlin.jvm.JvmInline
 
 @JvmInline
 internal value class Version private constructor(val version: List<UInt>) : Comparable<Version> {
     companion object {
+        internal val MIN = Version(emptyList())
+        internal val MAX = Version(List(4) { UInt.MAX_VALUE })
+
         internal fun String.toVersion() = try {
             Version(split(".").map { it.toUInt() }.dropLastWhile { it == 0U })
         } catch (e: NumberFormatException) {
             throw IllegalArgumentException("Invalid version: $this", e)
+        }
+
+        internal fun String.toVersionOrNull() = try {
+            toVersion()
+        } catch (e: IllegalArgumentException) {
+            Napier.d("Invalid Version: $this", e)
+            null
         }
     }
 

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/ParserConfigTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/ParserConfigTest.kt
@@ -21,8 +21,8 @@ class ParserConfigTest {
         val orig = ParserConfig(supportedFeatures = emptySet())
         val updated = orig.withSupportedFeatures(setOf("test"))
 
-        assertTrue(orig.supportedFeatures.isEmpty())
-        assertEquals(setOf("test"), updated.supportedFeatures)
+        assertFalse(orig.supportsFeature("test"))
+        assertTrue(updated.supportsFeature("test"))
     }
 
     @Test

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/ParserConfigTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/ParserConfigTest.kt
@@ -66,4 +66,11 @@ class ParserConfigTest {
         assertTrue(orig.parseTips)
         assertFalse(updated.parseTips)
     }
+
+    @Test
+    fun testSupportsFeatureRequiredVersions() {
+        val config = ParserConfig()
+        assertFalse(config.supportsFeature(FEATURE_REQUIRED_VERSIONS))
+        assertTrue(config.withAppVersion(DeviceType.values().random(), "1").supportsFeature(FEATURE_REQUIRED_VERSIONS))
+    }
 }

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/ParserConfigTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/ParserConfigTest.kt
@@ -1,12 +1,25 @@
 package org.cru.godtools.tool
 
 import org.cru.godtools.tool.model.DeviceType
+import org.cru.godtools.tool.model.Version.Companion.toVersion
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class ParserConfigTest {
+    @Test
+    fun testWithAppVersion() {
+        val orig = ParserConfig()
+        assertEquals(DeviceType.UNKNOWN, orig.deviceType)
+        assertNull(orig.appVersion)
+
+        val updated = orig.withAppVersion(DeviceType.ANDROID, "10.3.4")
+        assertEquals(DeviceType.ANDROID, updated.deviceType)
+        assertEquals("10.3.4".toVersion(), updated.appVersion)
+    }
+
     @Test
     fun testWithSupportedDeviceTypes() {
         val orig = ParserConfig(supportedDeviceTypes = emptySet())

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ContentTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ContentTest.kt
@@ -15,6 +15,7 @@ import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
 import org.cru.godtools.tool.internal.coroutines.receive
 import org.cru.godtools.tool.model.Content.Companion.parseContentElement
+import org.cru.godtools.tool.model.Version.Companion.toVersion
 import org.cru.godtools.tool.model.tips.InlineTip
 import org.cru.godtools.tool.state.State
 import kotlin.test.Test
@@ -79,6 +80,46 @@ class ContentTest : UsesResources() {
         assertTrue(object : Content(Manifest(), version = SCHEMA_VERSION + 1) {}.isIgnored)
     }
     // endregion version
+
+    // region required-versions
+    @Test
+    fun verifyRequiredAndroidVersion() {
+        // requiredAndroidVersion is not satisfied if the device version hasn't been configured
+        val default = Manifest(ParserConfig())
+        assertTrue(object : Content(default, requiredAndroidVersion = "2".toVersion()) {}.isIgnored)
+
+        // requireAndroidVersion is satisfied for any newer Android app version
+        val android = Manifest(config = ParserConfig().withAppVersion(DeviceType.ANDROID, "2"))
+        assertFalse(object : Content(android) {}.isIgnored)
+        assertFalse(object : Content(android, requiredAndroidVersion = "1".toVersion()) {}.isIgnored)
+        assertFalse(object : Content(android, requiredAndroidVersion = "2".toVersion()) {}.isIgnored)
+        assertTrue(object : Content(android, requiredAndroidVersion = "2.0.0.1".toVersion()) {}.isIgnored)
+        assertTrue(object : Content(android, requiredAndroidVersion = "3".toVersion()) {}.isIgnored)
+
+        // requiredAndroidVersion is satisfied for any ios app version
+        val ios = Manifest(config = ParserConfig().withAppVersion(DeviceType.IOS, "2"))
+        assertFalse(object : Content(ios, requiredAndroidVersion = Version.MAX) {}.isIgnored)
+    }
+
+    @Test
+    fun verifyRequiredIosVersion() {
+        // requiredIosVersion is not satisfied if the device version hasn't been configured
+        val default = Manifest(ParserConfig())
+        assertTrue(object : Content(default, requiredIosVersion = "2".toVersion()) {}.isIgnored)
+
+        // requiredIosVersion is satisfied for any newer ios app version
+        val ios = Manifest(config = ParserConfig().withAppVersion(DeviceType.IOS, "2"))
+        assertFalse(object : Content(ios) {}.isIgnored)
+        assertFalse(object : Content(ios, requiredIosVersion = "1".toVersion()) {}.isIgnored)
+        assertFalse(object : Content(ios, requiredIosVersion = "2".toVersion()) {}.isIgnored)
+        assertTrue(object : Content(ios, requiredIosVersion = "2.0.0.1".toVersion()) {}.isIgnored)
+        assertTrue(object : Content(ios, requiredIosVersion = "3".toVersion()) {}.isIgnored)
+
+        // requiredIosVersion is satisfied for any android app version
+        val android = Manifest(config = ParserConfig().withAppVersion(DeviceType.ANDROID, "2"))
+        assertFalse(object : Content(android, requiredIosVersion = Version.MAX) {}.isIgnored)
+    }
+    // endregion required-versions
 
     // region Visibility Attributes
     @Test

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ContentTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ContentTest.kt
@@ -19,6 +19,7 @@ import org.cru.godtools.tool.model.Version.Companion.toVersion
 import org.cru.godtools.tool.model.tips.InlineTip
 import org.cru.godtools.tool.state.State
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNull
@@ -270,6 +271,22 @@ class ContentTest : UsesResources() {
         }
     }
     // endregion Visibility Attributes
+
+    // region Parsing
+    @Test
+    fun parseRequiredVersions() = runTest {
+        val content = Text(Manifest(), getTestXmlParser("content_required_versions.xml"))
+        assertEquals("1.2".toVersion(), content.requiredAndroidVersion)
+        assertEquals("2.3".toVersion(), content.requiredIosVersion)
+    }
+
+    @Test
+    fun parseRequiredVersionsInvalid() = runTest {
+        val content = Text(Manifest(), getTestXmlParser("content_required_versions_invalid.xml"))
+        assertEquals(Version.MAX, content.requiredAndroidVersion)
+        assertEquals(Version.MAX, content.requiredIosVersion)
+    }
+    // endregion Parsing
 
     // region parseContentElement()
     @Test

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/VersionTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/VersionTest.kt
@@ -1,0 +1,25 @@
+package org.cru.godtools.tool.model
+
+import org.cru.godtools.tool.model.Version.Companion.toVersion
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class VersionTest {
+    @Test
+    fun testCompareTo() {
+        assertTrue("1.0".toVersion() >= "1".toVersion())
+        assertTrue("1.0".toVersion() <= "1".toVersion())
+
+        assertTrue("1.1".toVersion() > "1".toVersion())
+        assertTrue("1".toVersion() < "1.1".toVersion())
+        assertTrue("1.2".toVersion() > "1.1".toVersion())
+        assertTrue("1.1.1".toVersion() > "1.0.20".toVersion())
+    }
+
+    @Test
+    fun testEquals() {
+        assertEquals("1.0".toVersion(), "1.0".toVersion())
+        assertEquals("1".toVersion(), "1.0".toVersion())
+    }
+}

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/VersionTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/VersionTest.kt
@@ -1,6 +1,8 @@
 package org.cru.godtools.tool.model
 
 import org.cru.godtools.tool.model.Version.Companion.toVersion
+import kotlin.random.Random
+import kotlin.random.nextUInt
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -21,5 +23,18 @@ class VersionTest {
     fun testEquals() {
         assertEquals("1.0".toVersion(), "1.0".toVersion())
         assertEquals("1".toVersion(), "1.0".toVersion())
+    }
+
+    @Test
+    fun testMin() {
+        assertEquals(Version.MIN, "0".toVersion())
+        assertEquals(Version.MIN, "0.0".toVersion())
+        assertTrue("0.0.0.0.0.1".toVersion() > Version.MIN)
+    }
+
+    @Test
+    fun testMax() {
+        assertTrue(Version.MAX > "${Random.nextUInt()}".toVersion())
+        assertTrue(Version.MAX >= "${UInt.MAX_VALUE}.${UInt.MAX_VALUE}.${UInt.MAX_VALUE}".toVersion())
     }
 }

--- a/module/parser/src/commonTest/resources/org/cru/godtools/tool/model/content_required_versions.xml
+++ b/module/parser/src/commonTest/resources/org/cru/godtools/tool/model/content_required_versions.xml
@@ -1,0 +1,4 @@
+<content:text xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    required-android-version="1.2" required-ios-version="2.3">
+    required-versions
+</content:text>

--- a/module/parser/src/commonTest/resources/org/cru/godtools/tool/model/content_required_versions_invalid.xml
+++ b/module/parser/src/commonTest/resources/org/cru/godtools/tool/model/content_required_versions_invalid.xml
@@ -1,0 +1,4 @@
+<content:text xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    required-android-version="1.2-SNAPSHOT" required-ios-version="2.3-SNAPSHOT">
+    required-versions
+</content:text>


### PR DESCRIPTION
This PR adds support for new `required-android-version` and `required-ios-version` attributes on content elements. This will allow new features to be hidden on specific versions of the mobile apps