### PR TITLE
GT-1569 rename restrictTo to required-device-type

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=0.6.2
+version=0.7.0
 
 org.gradle.caching=true
 org.gradle.jvmargs=-Xmx4g

--- a/module/parser/src/androidMain/java/org/cru/godtools/tool/AndroidParserConfig.kt
+++ b/module/parser/src/androidMain/java/org/cru/godtools/tool/AndroidParserConfig.kt
@@ -1,5 +1,0 @@
-package org.cru.godtools.tool
-
-import org.cru.godtools.tool.model.DeviceType
-
-internal actual val DEFAULT_SUPPORTED_DEVICE_TYPES = setOf(DeviceType.ANDROID, DeviceType.MOBILE)

--- a/module/parser/src/androidMain/kotlin/org/cru/godtools/tool/model/AndroidDeviceType.kt
+++ b/module/parser/src/androidMain/kotlin/org/cru/godtools/tool/model/AndroidDeviceType.kt
@@ -1,0 +1,3 @@
+package org.cru.godtools.tool.model
+
+internal actual val DeviceType.Companion.DEFAULT get() = DeviceType.ANDROID

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/ParserConfig.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/ParserConfig.kt
@@ -1,6 +1,5 @@
 package org.cru.godtools.tool
 
-import org.cru.godtools.tool.internal.VisibleForTesting
 import org.cru.godtools.tool.model.DEFAULT
 import org.cru.godtools.tool.model.DeviceType
 import org.cru.godtools.tool.model.Version
@@ -12,7 +11,7 @@ const val FEATURE_FLOW = "flow"
 const val FEATURE_MULTISELECT = "multiselect"
 internal const val FEATURE_REQUIRED_VERSIONS = "required-versions"
 
-data class ParserConfig @VisibleForTesting internal constructor(
+data class ParserConfig private constructor(
     internal val deviceType: DeviceType = DeviceType.DEFAULT,
     internal val appVersion: Version? = null,
     private val supportedFeatures: Set<String> = emptySet(),

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/ParserConfig.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/ParserConfig.kt
@@ -16,7 +16,6 @@ data class ParserConfig @VisibleForTesting internal constructor(
     internal val deviceType: DeviceType = DeviceType.DEFAULT,
     internal val appVersion: Version? = null,
     private val supportedFeatures: Set<String> = emptySet(),
-    internal val supportedDeviceTypes: Set<DeviceType> = DEFAULT_SUPPORTED_DEVICE_TYPES,
     internal val parsePages: Boolean = true,
     internal val parseTips: Boolean = true
 ) {
@@ -24,16 +23,23 @@ data class ParserConfig @VisibleForTesting internal constructor(
 
     fun withAppVersion(deviceType: DeviceType, version: String?) =
         copy(deviceType = deviceType, appVersion = version?.toVersion())
-    fun withSupportedDeviceTypes(types: Set<DeviceType>) = copy(supportedDeviceTypes = types)
+    @Deprecated("Since v0.7.0, use withAppVersion(deviceType, version) instead.")
+    fun withSupportedDeviceTypes(types: Set<DeviceType>) = withAppVersion(
+        deviceType = types.firstOrNull { it == DeviceType.ANDROID || it == DeviceType.IOS } ?: DeviceType.DEFAULT,
+        version = null
+    )
     fun withSupportedFeatures(features: Set<String>) = copy(supportedFeatures = features)
     fun withParseRelated(enabled: Boolean) = copy(parsePages = enabled, parseTips = enabled)
     fun withParsePages(enabled: Boolean) = copy(parsePages = enabled)
     fun withParseTips(enabled: Boolean) = copy(parseTips = enabled)
 
+    internal fun supportsDeviceType(type: DeviceType) = when (type) {
+        deviceType -> true
+        DeviceType.MOBILE -> deviceType == DeviceType.ANDROID || deviceType == DeviceType.IOS
+        else -> false
+    }
     internal fun supportsFeature(feature: String) = when (feature) {
         FEATURE_REQUIRED_VERSIONS -> appVersion != null
         else -> feature in supportedFeatures
     }
 }
-
-internal expect val DEFAULT_SUPPORTED_DEVICE_TYPES: Set<DeviceType>

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/ParserConfig.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/ParserConfig.kt
@@ -22,11 +22,6 @@ data class ParserConfig private constructor(
 
     fun withAppVersion(deviceType: DeviceType = DeviceType.DEFAULT, version: String?) =
         copy(deviceType = deviceType, appVersion = version?.toVersion())
-    @Deprecated("Since v0.7.0, use withAppVersion(deviceType, version) instead.")
-    fun withSupportedDeviceTypes(types: Set<DeviceType>) = withAppVersion(
-        deviceType = types.firstOrNull { it == DeviceType.ANDROID || it == DeviceType.IOS } ?: DeviceType.DEFAULT,
-        version = null
-    )
     fun withSupportedFeatures(features: Set<String>) = copy(supportedFeatures = features)
     fun withParseRelated(enabled: Boolean) = copy(parsePages = enabled, parseTips = enabled)
     fun withParsePages(enabled: Boolean) = copy(parsePages = enabled)

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/ParserConfig.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/ParserConfig.kt
@@ -20,7 +20,7 @@ data class ParserConfig private constructor(
 ) {
     constructor() : this(supportedFeatures = emptySet())
 
-    fun withAppVersion(deviceType: DeviceType, version: String?) =
+    fun withAppVersion(deviceType: DeviceType = DeviceType.DEFAULT, version: String?) =
         copy(deviceType = deviceType, appVersion = version?.toVersion())
     @Deprecated("Since v0.7.0, use withAppVersion(deviceType, version) instead.")
     fun withSupportedDeviceTypes(types: Set<DeviceType>) = withAppVersion(

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/ParserConfig.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/ParserConfig.kt
@@ -1,6 +1,7 @@
 package org.cru.godtools.tool
 
 import org.cru.godtools.tool.internal.VisibleForTesting
+import org.cru.godtools.tool.model.DEFAULT
 import org.cru.godtools.tool.model.DeviceType
 import org.cru.godtools.tool.model.Version
 import org.cru.godtools.tool.model.Version.Companion.toVersion
@@ -12,7 +13,7 @@ const val FEATURE_MULTISELECT = "multiselect"
 internal const val FEATURE_REQUIRED_VERSIONS = "required-versions"
 
 data class ParserConfig @VisibleForTesting internal constructor(
-    internal val deviceType: DeviceType = DeviceType.UNKNOWN,
+    internal val deviceType: DeviceType = DeviceType.DEFAULT,
     internal val appVersion: Version? = null,
     private val supportedFeatures: Set<String> = emptySet(),
     internal val supportedDeviceTypes: Set<DeviceType> = DEFAULT_SUPPORTED_DEVICE_TYPES,

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Content.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Content.kt
@@ -15,6 +15,7 @@ import org.cru.godtools.tool.model.tips.XMLNS_TRAINING
 import org.cru.godtools.tool.xml.XmlPullParser
 
 private const val XML_REQUIRED_FEATURES = "required-features"
+private const val XML_REQUIRED_DEVICE_TYPE = "required-device-type"
 private const val XML_REQUIRED_ANDROID_VERSION = "required-android-version"
 private const val XML_REQUIRED_IOS_VERSION = "required-ios-version"
 private const val XML_RESTRICT_TO = "restrictTo"
@@ -23,7 +24,8 @@ private const val XML_VERSION = "version"
 abstract class Content : BaseModel, Visibility {
     private val version: Int
     private val requiredFeatures: Set<String>
-    private val requiredDeviceType: Set<DeviceType>
+    @VisibleForTesting
+    internal val requiredDeviceType: Set<DeviceType>
     @VisibleForTesting
     internal val requiredAndroidVersion: Version?
     @VisibleForTesting
@@ -34,9 +36,11 @@ abstract class Content : BaseModel, Visibility {
 
     internal constructor(parent: Base, parser: XmlPullParser) : super(parent) {
         version = parser.getAttributeValue(null, XML_VERSION)?.toIntOrNull() ?: SCHEMA_VERSION
-        requiredDeviceType = parser.getAttributeValue(XML_RESTRICT_TO)?.toDeviceTypes() ?: DeviceType.ALL
         requiredFeatures = parser.getAttributeValue(XML_REQUIRED_FEATURES)
             ?.split(REGEX_SEQUENCE_SEPARATOR)?.filterTo(mutableSetOf()) { it.isNotBlank() }.orEmpty()
+        requiredDeviceType = parser.getAttributeValue(XML_REQUIRED_DEVICE_TYPE)?.toDeviceTypes()
+            ?: parser.getAttributeValue(XML_RESTRICT_TO)?.toDeviceTypes()
+            ?: DeviceType.ALL
         requiredAndroidVersion = parser.getAttributeValue(XML_REQUIRED_ANDROID_VERSION)
             ?.let { it.toVersionOrNull() ?: Version.MAX }
         requiredIosVersion = parser.getAttributeValue(XML_REQUIRED_IOS_VERSION)

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Content.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Content.kt
@@ -75,7 +75,7 @@ abstract class Content : BaseModel, Visibility {
         get() = version > SCHEMA_VERSION ||
             !areContentRestrictionsSatisfied ||
             requiredFeatures.any { !manifest.config.supportsFeature(it) } ||
-            restrictTo.none { it in manifest.config.supportedDeviceTypes } ||
+            restrictTo.none { manifest.config.supportsDeviceType(it) } ||
             invisibleIf?.isValid() == false ||
             goneIf?.isValid() == false
 

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/DeviceType.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/DeviceType.kt
@@ -25,3 +25,5 @@ enum class DeviceType {
             REGEX_SEQUENCE_SEPARATOR.split(this).mapTo(mutableSetOf()) { it.toDeviceType() }
     }
 }
+
+internal expect val DeviceType.Companion.DEFAULT: DeviceType

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/ParserConfig+Fixtures.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/ParserConfig+Fixtures.kt
@@ -1,0 +1,5 @@
+package org.cru.godtools.tool
+
+import org.cru.godtools.tool.model.DeviceType
+
+internal fun ParserConfig.withDeviceType(deviceType: DeviceType) = copy(deviceType = deviceType, appVersion = null)

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/ParserConfigTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/ParserConfigTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.assertTrue
 class ParserConfigTest {
     @Test
     fun testWithAppVersion() {
-        val orig = ParserConfig(deviceType = DeviceType.UNKNOWN)
+        val orig = ParserConfig().withDeviceType(DeviceType.UNKNOWN)
         assertEquals(DeviceType.UNKNOWN, orig.deviceType)
         assertNull(orig.appVersion)
 
@@ -22,7 +22,7 @@ class ParserConfigTest {
 
     @Test
     fun testWithSupportedFeatures() {
-        val orig = ParserConfig(supportedFeatures = emptySet())
+        val orig = ParserConfig().withSupportedFeatures(emptySet())
         val updated = orig.withSupportedFeatures(setOf("test"))
 
         assertFalse(orig.supportsFeature("test"))
@@ -31,7 +31,7 @@ class ParserConfigTest {
 
     @Test
     fun testWithParseRelated() {
-        val orig = ParserConfig(parsePages = true, parseTips = true)
+        val orig = ParserConfig().withParsePages(true).withParseTips(true)
         val updated = orig.withParseRelated(false)
 
         assertTrue(orig.parsePages)
@@ -42,7 +42,7 @@ class ParserConfigTest {
 
     @Test
     fun testWithParsePages() {
-        val orig = ParserConfig(parsePages = true)
+        val orig = ParserConfig().withParsePages(true)
         val updated = orig.withParsePages(false)
 
         assertTrue(orig.parsePages)
@@ -51,7 +51,7 @@ class ParserConfigTest {
 
     @Test
     fun testWithParseTips() {
-        val orig = ParserConfig(parseTips = true)
+        val orig = ParserConfig().withParseTips(true)
         val updated = orig.withParseTips(false)
 
         assertTrue(orig.parseTips)

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/ParserConfigTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/ParserConfigTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.assertTrue
 class ParserConfigTest {
     @Test
     fun testWithAppVersion() {
-        val orig = ParserConfig()
+        val orig = ParserConfig(deviceType = DeviceType.UNKNOWN)
         assertEquals(DeviceType.UNKNOWN, orig.deviceType)
         assertNull(orig.appVersion)
 

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/ParserConfigTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/ParserConfigTest.kt
@@ -21,15 +21,6 @@ class ParserConfigTest {
     }
 
     @Test
-    fun testWithSupportedDeviceTypes() {
-        val orig = ParserConfig(supportedDeviceTypes = emptySet())
-        val updated = orig.withSupportedDeviceTypes(setOf(DeviceType.ANDROID))
-
-        assertTrue(orig.supportedDeviceTypes.isEmpty())
-        assertEquals(setOf(DeviceType.ANDROID), updated.supportedDeviceTypes)
-    }
-
-    @Test
     fun testWithSupportedFeatures() {
         val orig = ParserConfig(supportedFeatures = emptySet())
         val updated = orig.withSupportedFeatures(setOf("test"))

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/AnimationTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/AnimationTest.kt
@@ -39,11 +39,11 @@ class AnimationTest : UsesResources() {
 
     @Test
     fun testIsIgnored() {
-        with(Animation(Manifest(config = ParserConfig(supportedFeatures = setOf(FEATURE_ANIMATION))))) {
+        with(Animation(Manifest(ParserConfig().withSupportedFeatures(setOf(FEATURE_ANIMATION))))) {
             assertFalse(isIgnored)
         }
 
-        with(Animation(Manifest(config = ParserConfig(supportedFeatures = emptySet())))) {
+        with(Animation(Manifest(ParserConfig().withSupportedFeatures(emptySet())))) {
             assertTrue(isIgnored)
         }
     }

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ButtonTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ButtonTest.kt
@@ -94,7 +94,7 @@ class ButtonTest : UsesResources() {
             assertTrue(isIgnored)
         }
 
-        val config = ParserConfig(supportedFeatures = setOf(FEATURE_MULTISELECT))
+        val config = ParserConfig().withSupportedFeatures(setOf(FEATURE_MULTISELECT))
         with(Button(Manifest(config = config), getTestXmlParser("button_requiredFeatures.xml"))) {
             assertFalse(isIgnored)
         }

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ButtonTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ButtonTest.kt
@@ -11,6 +11,7 @@ import org.cru.godtools.tool.model.AnalyticsEvent.Trigger
 import org.cru.godtools.tool.model.Button.Style.Companion.toButtonStyle
 import org.cru.godtools.tool.model.Button.Type.Companion.toButtonTypeOrNull
 import org.cru.godtools.tool.state.State
+import org.cru.godtools.tool.withDeviceType
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -71,13 +72,18 @@ class ButtonTest : UsesResources() {
 
     @Test
     fun testParseButtonRestrictTo() = runTest {
-        val webConfig = ParserConfig(supportedDeviceTypes = setOf(DeviceType.WEB))
+        val webConfig = ParserConfig().withDeviceType(DeviceType.WEB)
         with(Button(Manifest(config = webConfig), getTestXmlParser("button_restrictTo.xml"))) {
             assertFalse(isIgnored)
         }
 
-        val mobileConfig = ParserConfig(supportedDeviceTypes = setOf(DeviceType.MOBILE))
-        with(Button(Manifest(config = mobileConfig), getTestXmlParser("button_restrictTo.xml"))) {
+        val androidConfig = ParserConfig().withDeviceType(DeviceType.ANDROID)
+        with(Button(Manifest(config = androidConfig), getTestXmlParser("button_restrictTo.xml"))) {
+            assertTrue(isIgnored)
+        }
+
+        val iosConfig = ParserConfig().withDeviceType(DeviceType.IOS)
+        with(Button(Manifest(config = iosConfig), getTestXmlParser("button_restrictTo.xml"))) {
             assertTrue(isIgnored)
         }
     }

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/CardTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/CardTest.kt
@@ -37,10 +37,10 @@ class CardTest : UsesResources() {
 
     @Test
     fun testIsIgnored() {
-        with(Card(Manifest(config = ParserConfig(supportedFeatures = setOf(FEATURE_CONTENT_CARD))))) {
+        with(Card(Manifest(config = ParserConfig().withSupportedFeatures(setOf(FEATURE_CONTENT_CARD))))) {
             assertFalse(isIgnored)
         }
-        with(Card(Manifest(config = ParserConfig(supportedFeatures = emptySet())))) {
+        with(Card(Manifest(config = ParserConfig().withSupportedFeatures(emptySet())))) {
             assertTrue(isIgnored)
         }
     }

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ContentTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ContentTest.kt
@@ -18,6 +18,7 @@ import org.cru.godtools.tool.model.Content.Companion.parseContentElement
 import org.cru.godtools.tool.model.Version.Companion.toVersion
 import org.cru.godtools.tool.model.tips.InlineTip
 import org.cru.godtools.tool.state.State
+import org.cru.godtools.tool.withDeviceType
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -55,18 +56,30 @@ class ContentTest : UsesResources() {
 
     // region restrictTo
     @Test
-    fun verifyRestrictToSupported() {
-        val config = ParserConfig(supportedDeviceTypes = setOf(DeviceType.ANDROID))
-        assertFalse(object : Content(Manifest(config), restrictTo = DeviceType.ALL) {}.isIgnored)
-        assertFalse(object : Content(Manifest(config), restrictTo = config.supportedDeviceTypes) {}.isIgnored)
-        assertFalse(object : Content(Manifest(config), restrictTo = setOf(DeviceType.ANDROID)) {}.isIgnored)
-    }
+    fun verifyRestrictTo() {
+        val android = Manifest(ParserConfig().withDeviceType(DeviceType.ANDROID))
+        assertFalse(object : Content(android, restrictTo = DeviceType.ALL) {}.isIgnored)
+        assertFalse(object : Content(android, restrictTo = setOf(DeviceType.ANDROID)) {}.isIgnored)
+        assertFalse(object : Content(android, restrictTo = setOf(DeviceType.MOBILE)) {}.isIgnored)
+        assertTrue(object : Content(android, restrictTo = setOf(DeviceType.IOS)) {}.isIgnored)
+        assertTrue(object : Content(android, restrictTo = setOf(DeviceType.WEB)) {}.isIgnored)
+        assertTrue(object : Content(android, restrictTo = setOf(DeviceType.UNKNOWN)) {}.isIgnored)
 
-    @Test
-    fun verifyRestrictToNotSupported() {
-        val config = ParserConfig(supportedDeviceTypes = setOf(DeviceType.ANDROID))
-        assertTrue(object : Content(Manifest(config), restrictTo = setOf(DeviceType.UNKNOWN)) {}.isIgnored)
-        assertTrue(object : Content(Manifest(config), restrictTo = setOf(DeviceType.IOS)) {}.isIgnored)
+        val ios = Manifest(ParserConfig().withDeviceType(DeviceType.IOS))
+        assertFalse(object : Content(ios, restrictTo = DeviceType.ALL) {}.isIgnored)
+        assertFalse(object : Content(ios, restrictTo = setOf(DeviceType.IOS)) {}.isIgnored)
+        assertFalse(object : Content(ios, restrictTo = setOf(DeviceType.MOBILE)) {}.isIgnored)
+        assertTrue(object : Content(ios, restrictTo = setOf(DeviceType.ANDROID)) {}.isIgnored)
+        assertTrue(object : Content(ios, restrictTo = setOf(DeviceType.WEB)) {}.isIgnored)
+        assertTrue(object : Content(ios, restrictTo = setOf(DeviceType.UNKNOWN)) {}.isIgnored)
+
+        val web = Manifest(ParserConfig().withDeviceType(DeviceType.WEB))
+        assertFalse(object : Content(web, restrictTo = DeviceType.ALL) {}.isIgnored)
+        assertFalse(object : Content(web, restrictTo = setOf(DeviceType.WEB)) {}.isIgnored)
+        assertTrue(object : Content(web, restrictTo = setOf(DeviceType.ANDROID)) {}.isIgnored)
+        assertTrue(object : Content(web, restrictTo = setOf(DeviceType.IOS)) {}.isIgnored)
+        assertTrue(object : Content(web, restrictTo = setOf(DeviceType.MOBILE)) {}.isIgnored)
+        assertTrue(object : Content(web, restrictTo = setOf(DeviceType.UNKNOWN)) {}.isIgnored)
     }
     // endregion restrictTo
 

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ContentTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ContentTest.kt
@@ -287,6 +287,19 @@ class ContentTest : UsesResources() {
 
     // region Parsing
     @Test
+    fun parseRestrictTo() = runTest {
+        val content = Text(Manifest(), getTestXmlParser("content_restrict_to.xml"))
+        assertEquals(setOf(DeviceType.IOS, DeviceType.WEB), content.requiredDeviceType)
+    }
+
+    @Test
+    fun parseRequiredDeviceType() = runTest {
+        val content = Text(Manifest(), getTestXmlParser("content_required_device_type.xml"))
+        assertEquals(setOf(DeviceType.ANDROID, DeviceType.WEB), content.requiredDeviceType)
+        assertFalse(DeviceType.IOS in content.requiredDeviceType)
+    }
+
+    @Test
     fun parseRequiredVersions() = runTest {
         val content = Text(Manifest(), getTestXmlParser("content_required_versions.xml"))
         assertEquals("1.2".toVersion(), content.requiredAndroidVersion)

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ContentTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ContentTest.kt
@@ -54,34 +54,34 @@ class ContentTest : UsesResources() {
     }
     // endregion required-features
 
-    // region restrictTo
+    // region required-device-type
     @Test
-    fun verifyRestrictTo() {
+    fun verifyRequiredDeviceType() {
         val android = Manifest(ParserConfig().withDeviceType(DeviceType.ANDROID))
-        assertFalse(object : Content(android, restrictTo = DeviceType.ALL) {}.isIgnored)
-        assertFalse(object : Content(android, restrictTo = setOf(DeviceType.ANDROID)) {}.isIgnored)
-        assertFalse(object : Content(android, restrictTo = setOf(DeviceType.MOBILE)) {}.isIgnored)
-        assertTrue(object : Content(android, restrictTo = setOf(DeviceType.IOS)) {}.isIgnored)
-        assertTrue(object : Content(android, restrictTo = setOf(DeviceType.WEB)) {}.isIgnored)
-        assertTrue(object : Content(android, restrictTo = setOf(DeviceType.UNKNOWN)) {}.isIgnored)
+        assertFalse(object : Content(android, requiredDeviceType = DeviceType.ALL) {}.isIgnored)
+        assertFalse(object : Content(android, requiredDeviceType = setOf(DeviceType.ANDROID)) {}.isIgnored)
+        assertFalse(object : Content(android, requiredDeviceType = setOf(DeviceType.MOBILE)) {}.isIgnored)
+        assertTrue(object : Content(android, requiredDeviceType = setOf(DeviceType.IOS)) {}.isIgnored)
+        assertTrue(object : Content(android, requiredDeviceType = setOf(DeviceType.WEB)) {}.isIgnored)
+        assertTrue(object : Content(android, requiredDeviceType = setOf(DeviceType.UNKNOWN)) {}.isIgnored)
 
         val ios = Manifest(ParserConfig().withDeviceType(DeviceType.IOS))
-        assertFalse(object : Content(ios, restrictTo = DeviceType.ALL) {}.isIgnored)
-        assertFalse(object : Content(ios, restrictTo = setOf(DeviceType.IOS)) {}.isIgnored)
-        assertFalse(object : Content(ios, restrictTo = setOf(DeviceType.MOBILE)) {}.isIgnored)
-        assertTrue(object : Content(ios, restrictTo = setOf(DeviceType.ANDROID)) {}.isIgnored)
-        assertTrue(object : Content(ios, restrictTo = setOf(DeviceType.WEB)) {}.isIgnored)
-        assertTrue(object : Content(ios, restrictTo = setOf(DeviceType.UNKNOWN)) {}.isIgnored)
+        assertFalse(object : Content(ios, requiredDeviceType = DeviceType.ALL) {}.isIgnored)
+        assertFalse(object : Content(ios, requiredDeviceType = setOf(DeviceType.IOS)) {}.isIgnored)
+        assertFalse(object : Content(ios, requiredDeviceType = setOf(DeviceType.MOBILE)) {}.isIgnored)
+        assertTrue(object : Content(ios, requiredDeviceType = setOf(DeviceType.ANDROID)) {}.isIgnored)
+        assertTrue(object : Content(ios, requiredDeviceType = setOf(DeviceType.WEB)) {}.isIgnored)
+        assertTrue(object : Content(ios, requiredDeviceType = setOf(DeviceType.UNKNOWN)) {}.isIgnored)
 
         val web = Manifest(ParserConfig().withDeviceType(DeviceType.WEB))
-        assertFalse(object : Content(web, restrictTo = DeviceType.ALL) {}.isIgnored)
-        assertFalse(object : Content(web, restrictTo = setOf(DeviceType.WEB)) {}.isIgnored)
-        assertTrue(object : Content(web, restrictTo = setOf(DeviceType.ANDROID)) {}.isIgnored)
-        assertTrue(object : Content(web, restrictTo = setOf(DeviceType.IOS)) {}.isIgnored)
-        assertTrue(object : Content(web, restrictTo = setOf(DeviceType.MOBILE)) {}.isIgnored)
-        assertTrue(object : Content(web, restrictTo = setOf(DeviceType.UNKNOWN)) {}.isIgnored)
+        assertFalse(object : Content(web, requiredDeviceType = DeviceType.ALL) {}.isIgnored)
+        assertFalse(object : Content(web, requiredDeviceType = setOf(DeviceType.WEB)) {}.isIgnored)
+        assertTrue(object : Content(web, requiredDeviceType = setOf(DeviceType.ANDROID)) {}.isIgnored)
+        assertTrue(object : Content(web, requiredDeviceType = setOf(DeviceType.IOS)) {}.isIgnored)
+        assertTrue(object : Content(web, requiredDeviceType = setOf(DeviceType.MOBILE)) {}.isIgnored)
+        assertTrue(object : Content(web, requiredDeviceType = setOf(DeviceType.UNKNOWN)) {}.isIgnored)
     }
-    // endregion restrictTo
+    // endregion required-device-type
 
     // region version
     @Test

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ContentTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ContentTest.kt
@@ -34,7 +34,7 @@ class ContentTest : UsesResources() {
     // region required-features
     @Test
     fun verifyRequiredFeaturesSupported() {
-        val manifest = Manifest(ParserConfig(supportedFeatures = setOf(FEATURE_ANIMATION, FEATURE_MULTISELECT)))
+        val manifest = Manifest(ParserConfig().withSupportedFeatures(setOf(FEATURE_ANIMATION, FEATURE_MULTISELECT)))
         assertFalse(
             object : Content(manifest, requiredFeatures = setOf(FEATURE_ANIMATION, FEATURE_MULTISELECT)) {}.isIgnored
         )
@@ -45,7 +45,7 @@ class ContentTest : UsesResources() {
 
     @Test
     fun verifyRequiredFeaturesNotSupported() {
-        val manifest = Manifest(ParserConfig(supportedFeatures = setOf(FEATURE_ANIMATION)))
+        val manifest = Manifest(ParserConfig().withSupportedFeatures(setOf(FEATURE_ANIMATION)))
         assertTrue(
             object : Content(manifest, requiredFeatures = setOf(FEATURE_ANIMATION, FEATURE_MULTISELECT)) {}.isIgnored
         )

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/FormTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/FormTest.kt
@@ -8,6 +8,7 @@ import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
 import org.cru.godtools.tool.model.tips.InlineTip
 import org.cru.godtools.tool.model.tips.Tip
+import org.cru.godtools.tool.withDeviceType
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -25,7 +26,7 @@ class FormTest : UsesResources() {
 
     @Test
     fun testParseParagraphIgnoredContent() = runTest {
-        val manifest = Manifest(ParserConfig(supportedDeviceTypes = setOf(DeviceType.MOBILE)))
+        val manifest = Manifest(ParserConfig().withDeviceType(DeviceType.ANDROID))
         val form = Form(manifest, getTestXmlParser("form_ignored_content.xml"))
         assertEquals(1, form.content.size)
         assertIs<Text>(form.content[0])

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ImageTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ImageTest.kt
@@ -6,6 +6,7 @@ import org.cru.godtools.tool.ParserConfig
 import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
+import org.cru.godtools.tool.withDeviceType
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -55,7 +56,7 @@ class ImageTest : UsesResources() {
     @Test
     fun testParseImageRestricted() = runTest {
         val manifest = Manifest(
-            config = ParserConfig(supportedDeviceTypes = setOf(DeviceType.MOBILE)),
+            config = ParserConfig().withDeviceType(DeviceType.IOS),
             resources = { listOf(Resource(it, "image.png")) }
         )
         val image = Image(manifest, getTestXmlParser("image_restricted.xml"))

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/MultiselectTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/MultiselectTest.kt
@@ -71,10 +71,10 @@ class MultiselectTest : UsesResources() {
 
     @Test
     fun testIsIgnored() {
-        with(Multiselect(Manifest(ParserConfig(supportedFeatures = setOf(FEATURE_MULTISELECT))))) {
+        with(Multiselect(Manifest(ParserConfig().withSupportedFeatures(setOf(FEATURE_MULTISELECT))))) {
             assertFalse(isIgnored)
         }
-        with(Multiselect(Manifest(ParserConfig(supportedFeatures = emptySet())))) {
+        with(Multiselect(Manifest(ParserConfig().withSupportedFeatures(emptySet())))) {
             assertTrue(isIgnored)
         }
     }

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ParagraphTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/ParagraphTest.kt
@@ -8,6 +8,7 @@ import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
 import org.cru.godtools.tool.model.tips.InlineTip
 import org.cru.godtools.tool.model.tips.Tip
+import org.cru.godtools.tool.withDeviceType
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -25,7 +26,7 @@ class ParagraphTest : UsesResources() {
 
     @Test
     fun testParseParagraphIgnoredContent() = runTest {
-        val manifest = Manifest(ParserConfig(supportedDeviceTypes = setOf(DeviceType.ANDROID, DeviceType.MOBILE)))
+        val manifest = Manifest(ParserConfig().withDeviceType(DeviceType.ANDROID))
         val paragraph = Paragraph(manifest, getTestXmlParser("paragraph_ignored_content.xml"))
         assertEquals(3, paragraph.content.size)
         assertEquals("Test", assertIs<Text>(paragraph.content[0]).text)

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/TabsTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/TabsTest.kt
@@ -7,6 +7,7 @@ import org.cru.godtools.tool.internal.AndroidJUnit4
 import org.cru.godtools.tool.internal.RunOnAndroidWith
 import org.cru.godtools.tool.internal.UsesResources
 import org.cru.godtools.tool.model.AnalyticsEvent.Trigger
+import org.cru.godtools.tool.withDeviceType
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -44,7 +45,7 @@ class TabsTest : UsesResources() {
 
     @Test
     fun testParseTabsIgnoredContent() = runTest {
-        val manifest = Manifest(ParserConfig(supportedDeviceTypes = setOf(DeviceType.MOBILE)))
+        val manifest = Manifest(ParserConfig().withDeviceType(DeviceType.IOS))
         val tab = Tabs(manifest, getTestXmlParser("tabs_ignored_content.xml")).tabs.single()
         assertEquals(1, tab.content.size)
         assertIs<Paragraph>(tab.content[0])

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/HeroTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/tract/HeroTest.kt
@@ -15,6 +15,7 @@ import org.cru.godtools.tool.model.Paragraph
 import org.cru.godtools.tool.model.Tabs
 import org.cru.godtools.tool.model.TestColors
 import org.cru.godtools.tool.model.Text
+import org.cru.godtools.tool.withDeviceType
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -40,7 +41,7 @@ class HeroTest : UsesResources("model/tract") {
 
     @Test
     fun testParseHeroIgnoredContent() = runTest {
-        val config = ParserConfig(supportedDeviceTypes = setOf(DeviceType.ANDROID, DeviceType.MOBILE))
+        val config = ParserConfig().withDeviceType(DeviceType.ANDROID)
         val page = TractPage(Manifest(config = config), null, getTestXmlParser("hero_ignored_content.xml"))
         with(assertNotNull(page.hero)) {
             assertEquals(2, content.size)

--- a/module/parser/src/commonTest/resources/org/cru/godtools/tool/model/content_required_device_type.xml
+++ b/module/parser/src/commonTest/resources/org/cru/godtools/tool/model/content_required_device_type.xml
@@ -1,0 +1,4 @@
+<content:text xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    required-device-type="android web" restrictTo="ios">
+    required-device-type
+</content:text>

--- a/module/parser/src/commonTest/resources/org/cru/godtools/tool/model/content_restrict_to.xml
+++ b/module/parser/src/commonTest/resources/org/cru/godtools/tool/model/content_restrict_to.xml
@@ -1,0 +1,4 @@
+<content:text xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    restrictTo="ios web">
+    restrictTo
+</content:text>

--- a/module/parser/src/iosMain/kotlin/org/cru/godtools/tool/IosParserConfig.kt
+++ b/module/parser/src/iosMain/kotlin/org/cru/godtools/tool/IosParserConfig.kt
@@ -1,0 +1,7 @@
+package org.cru.godtools.tool
+
+import org.cru.godtools.tool.model.DEFAULT
+import org.cru.godtools.tool.model.DeviceType
+
+// HACK: Kotlin/Native doesn't support optional default args, so we override the method to make the default arg optional
+fun ParserConfig.withAppVersion(version: String?) = withAppVersion(deviceType = DeviceType.DEFAULT, version = version)

--- a/module/parser/src/iosMain/kotlin/org/cru/godtools/tool/IosParserConfig.kt
+++ b/module/parser/src/iosMain/kotlin/org/cru/godtools/tool/IosParserConfig.kt
@@ -1,7 +1,0 @@
-package org.cru.godtools.tool
-
-import org.cru.godtools.tool.model.DeviceType
-import kotlin.native.concurrent.SharedImmutable
-
-@SharedImmutable
-internal actual val DEFAULT_SUPPORTED_DEVICE_TYPES = setOf(DeviceType.IOS, DeviceType.MOBILE)

--- a/module/parser/src/iosMain/kotlin/org/cru/godtools/tool/model/IosDeviceType.kt
+++ b/module/parser/src/iosMain/kotlin/org/cru/godtools/tool/model/IosDeviceType.kt
@@ -1,0 +1,3 @@
+package org.cru.godtools.tool.model
+
+internal actual val DeviceType.Companion.DEFAULT get() = DeviceType.IOS

--- a/module/parser/src/jsMain/kotlin/org/cru/godtools/tool/JsParserConfig.kt
+++ b/module/parser/src/jsMain/kotlin/org/cru/godtools/tool/JsParserConfig.kt
@@ -1,5 +1,0 @@
-package org.cru.godtools.tool
-
-import org.cru.godtools.tool.model.DeviceType
-
-internal actual val DEFAULT_SUPPORTED_DEVICE_TYPES = setOf(DeviceType.WEB)

--- a/module/parser/src/jsMain/kotlin/org/cru/godtools/tool/model/JsDeviceType.kt
+++ b/module/parser/src/jsMain/kotlin/org/cru/godtools/tool/model/JsDeviceType.kt
@@ -1,0 +1,3 @@
+package org.cru.godtools.tool.model
+
+internal actual val DeviceType.Companion.DEFAULT get() = DeviceType.WEB


### PR DESCRIPTION
- define DeviceType.DEFAULT to be automatically set based on which language is consuming this library
- replace supportedDeviceTypes with the singular deviceType property on ParserConfig
- make ParserConfig constructor private
- make the DeviceType optional for withAppVersion()
- rename restrictTo property to requireDeviceType
- add support for parsing required-device-type xml attribute
