### PR TITLE
cleanup

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,6 +31,9 @@ okio-js = { module = "com.squareup.okio:okio-js", version.ref = "okio" }
 okio-nodefilesystem = { module = "com.squareup.okio:okio-nodefilesystem", version.ref = "okio" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 
+# HACK: dependencies used to trigger renovate upgrades
+ktlint = { module = "com.pinterest:ktlint", version.ref = "ktlint" }
+
 [plugins]
 grgit = { id = "org.ajoberstar.grgit", version = "5.0.0" }
 kotlin-kover = { id = "org.jetbrains.kotlinx.kover", version = "0.6.0" }

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/CategoryTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/tool/model/CategoryTest.kt
@@ -1,5 +1,6 @@
 package org.cru.godtools.tool.model
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.cru.godtools.tool.ParserConfig
 import org.cru.godtools.tool.internal.AndroidJUnit4
@@ -11,6 +12,7 @@ import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 
 @RunOnAndroidWith(AndroidJUnit4::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 class CategoryTest : UsesResources() {
     @Test
     fun testParseCategory() = runTest {


### PR DESCRIPTION
- opt-in to experimental coroutines test APIs
- add a dependency to the version catalog to help trigger renovate upgrades for ktlint
