### PR TITLE
cleanup

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,21 +18,6 @@ allprojects {
             ?.let { version = "$version-$it" }
         version = "$version-SNAPSHOT"
     }
-
-    repositories {
-        maven("https://jitpack.io") {
-            content {
-                includeGroup("com.strumenta.antlr-kotlin")
-            }
-        }
-        maven("https://cruglobal.jfrog.io/artifactory/maven-mobile/") {
-            content {
-                includeGroup("org.cru.mobile.fork.antlr-kotlin")
-            }
-        }
-        google()
-        mavenCentral()
-    }
 }
 
 subprojects {

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Version.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Version.kt
@@ -18,7 +18,7 @@ internal value class Version private constructor(val version: List<UInt>) : Comp
         internal fun String.toVersionOrNull() = try {
             toVersion()
         } catch (e: IllegalArgumentException) {
-            Napier.d("Invalid Version: $this", e)
+            Napier.e("Invalid Version: $this", e, "Version")
             null
         }
     }

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/service/ManifestParser.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/service/ManifestParser.kt
@@ -18,7 +18,7 @@ open class ManifestParser(private val parserFactory: XmlPullParserFactory, val d
     } catch (e: XmlPullParserException) {
         ParserResult.Error.Corrupted(e)
     } catch (e: Exception) {
-        Napier.d("Unexpected Parsing Exception", e, "ManifestParser")
+        Napier.e("Unexpected Parsing Exception", e, "ManifestParser")
         ParserResult.Error(e)
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,22 @@
 rootProject.name = "GodtoolsToolParser"
 
+dependencyResolutionManagement {
+    repositories {
+        maven("https://jitpack.io") {
+            content {
+                includeGroup("com.strumenta.antlr-kotlin")
+            }
+        }
+        maven("https://cruglobal.jfrog.io/artifactory/maven-mobile/") {
+            content {
+                includeGroup("org.cru.mobile.fork.antlr-kotlin")
+            }
+        }
+        google()
+        mavenCentral()
+    }
+}
+
 include("module:parser")
 include("module:state")
 include("module:expressions")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,4 @@
 rootProject.name = "GodtoolsToolParser"
-enableFeaturePreview("VERSION_CATALOGS")
 
 include("module:parser")
 include("module:state")


### PR DESCRIPTION
- raise the level of a couple errors to actually be output as errors via the logger
- we no longer need to explictly enable the version catalog
- move repository configuration to settings.gradle.kts
