### PR TITLE
cleanup

### DIFF
--- a/buildSrc/src/main/kotlin/AndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfig.kt
@@ -1,12 +1,9 @@
 import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.LibraryExtension
-import org.gradle.api.Project
 
-fun Project.configureAndroidLibrary() {
-    with(extensions.getByType(LibraryExtension::class.java)) {
-        configureSdk()
-        configureSourceSets()
-    }
+fun LibraryExtension.baseConfiguration() {
+    configureSdk()
+    configureSourceSets()
 }
 
 private fun BaseExtension.configureSdk() {

--- a/module/parser-expressions/build.gradle.kts
+++ b/module/parser-expressions/build.gradle.kts
@@ -4,7 +4,10 @@ plugins {
     alias(libs.plugins.kotlin.kover)
 }
 
-configureAndroidLibrary()
+android {
+    namespace = "org.cru.godtools.shared.tool.parser.expressions"
+    baseConfiguration()
+}
 configureAntlr()
 enablePublishing()
 

--- a/module/parser-expressions/src/androidMain/AndroidManifest.xml
+++ b/module/parser-expressions/src/androidMain/AndroidManifest.xml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.cru.godtools.kotlin.expressions" />

--- a/module/parser/build.gradle.kts
+++ b/module/parser/build.gradle.kts
@@ -4,7 +4,10 @@ plugins {
     alias(libs.plugins.kotlin.kover)
 }
 
-configureAndroidLibrary()
+android {
+    namespace = "org.cru.godtools.shared.tool.parser"
+    baseConfiguration()
+}
 enablePublishing()
 
 kotlin {

--- a/module/parser/src/androidMain/AndroidManifest.xml
+++ b/module/parser/src/androidMain/AndroidManifest.xml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.cru.godtools.android.toolparser" />

--- a/module/parser/src/androidMain/java/org/cru/godtools/tool/model/ImageGravity.kt
+++ b/module/parser/src/androidMain/java/org/cru/godtools/tool/model/ImageGravity.kt
@@ -1,4 +1,0 @@
-package org.cru.godtools.tool.model
-
-@Deprecated("Since v0.4.1, use Gravity instead.")
-typealias ImageGravity = Gravity

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Clickable.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Clickable.kt
@@ -7,6 +7,7 @@ import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
+private const val XML_EVENTS = "events"
 private const val XML_URL = "url"
 
 interface Clickable : Base {

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Constants.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/Constants.kt
@@ -21,7 +21,6 @@ internal const val XML_BACKGROUND_IMAGE_SCALE_TYPE = "background-image-scale-typ
 internal const val XML_DISMISS_LISTENERS = "dismiss-listeners"
 internal const val XML_TEXT_COLOR = "text-color"
 internal const val XML_TEXT_SCALE = "text-scale"
-internal const val XML_EVENTS = "events"
 internal const val XML_LISTENERS = "listeners"
 
 // common colors

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/CallToAction.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/tool/model/tract/CallToAction.kt
@@ -1,25 +1,18 @@
 package org.cru.godtools.tool.model.tract
 
-import io.github.aakira.napier.Napier
 import org.cru.godtools.tool.internal.AndroidColorInt
-import org.cru.godtools.tool.internal.DeprecationException
 import org.cru.godtools.tool.internal.RestrictTo
 import org.cru.godtools.tool.internal.RestrictToScope
 import org.cru.godtools.tool.internal.VisibleForTesting
 import org.cru.godtools.tool.model.BaseModel
-import org.cru.godtools.tool.model.EventId
 import org.cru.godtools.tool.model.PlatformColor
 import org.cru.godtools.tool.model.Text
-import org.cru.godtools.tool.model.XML_EVENTS
 import org.cru.godtools.tool.model.parseTextChild
 import org.cru.godtools.tool.model.primaryColor
 import org.cru.godtools.tool.model.stylesParent
 import org.cru.godtools.tool.model.tips.XMLNS_TRAINING
 import org.cru.godtools.tool.model.toColorOrNull
-import org.cru.godtools.tool.model.toEventIds
 import org.cru.godtools.tool.xml.XmlPullParser
-
-private const val TAG = "CallToAction"
 
 private const val XML_CONTROL_COLOR = "control-color"
 private const val XML_TIP = "tip"
@@ -32,8 +25,6 @@ class CallToAction : BaseModel {
     private val page: TractPage
 
     val label: Text?
-    @Deprecated("Since v0.6.0, call-to-action events are no longer supported")
-    val events: List<EventId>
 
     @AndroidColorInt
     private val _controlColor: PlatformColor?
@@ -47,7 +38,6 @@ class CallToAction : BaseModel {
     internal constructor(parent: TractPage) : super(parent) {
         page = parent
         label = null
-        events = emptyList()
         _controlColor = null
         tipId = null
     }
@@ -56,17 +46,10 @@ class CallToAction : BaseModel {
         parser.require(XmlPullParser.START_TAG, XMLNS_TRACT, XML_CALL_TO_ACTION)
 
         this.page = page
-        events = parser.getAttributeValue(XML_EVENTS).toEventIds()
         _controlColor = parser.getAttributeValue(XML_CONTROL_COLOR)?.toColorOrNull()
         tipId = parser.getAttributeValue(XMLNS_TRAINING, XML_TIP)
 
         label = parser.parseTextChild(this, XMLNS_TRACT, XML_CALL_TO_ACTION)
-
-        if (events.isNotEmpty()) {
-            val message =
-                "tool: ${manifest.code} locale: ${manifest.locale} page: ${page.fileName} has call-to-action events"
-            Napier.e(message, DeprecationException("Deprecated call-to-action events: $message"), TAG)
-        }
     }
 
     @RestrictTo(RestrictToScope.TESTS)
@@ -78,7 +61,6 @@ class CallToAction : BaseModel {
     ) : super(page) {
         this.page = page
         this.label = label?.invoke(this)
-        events = emptyList()
         _controlColor = controlColor
         tipId = tip
     }

--- a/module/parser/src/iosMain/kotlin/org/cru/godtools/tool/util/FlowWatcher.kt
+++ b/module/parser/src/iosMain/kotlin/org/cru/godtools/tool/util/FlowWatcher.kt
@@ -6,18 +6,12 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.plus
 
-class FlowWatcher internal constructor(private val job: Job) {
+class FlowWatcher private constructor(private val job: Job) {
     internal companion object {
         internal fun <T> Flow<T>.watch(block: (T) -> Unit) = watchIn(CoroutineScope(Dispatchers.Main), block)
-        private fun <T> Flow<T>.watchIn(scope: CoroutineScope, block: (T) -> Unit): FlowWatcher {
-            val job = Job()
-
-            onEach { block(it) }.launchIn(scope + job)
-
-            return FlowWatcher(job)
-        }
+        private fun <T> Flow<T>.watchIn(scope: CoroutineScope, block: (T) -> Unit) =
+            FlowWatcher(onEach { block(it) }.launchIn(scope))
     }
 
     fun close() = job.cancel()

--- a/module/parser/src/jsTest/kotlin/org/cru/godtools/tool/model/JsTestConstants.kt
+++ b/module/parser/src/jsTest/kotlin/org/cru/godtools/tool/model/JsTestConstants.kt
@@ -1,3 +1,3 @@
 package org.cru.godtools.tool.model
 
-actual val TEST_URL = "https://www.example.com"
+actual const val TEST_URL = "https://www.example.com"

--- a/module/state/build.gradle.kts
+++ b/module/state/build.gradle.kts
@@ -5,7 +5,10 @@ plugins {
     alias(libs.plugins.kotlin.kover)
 }
 
-configureAndroidLibrary()
+android {
+    namespace = "org.cru.godtools.shared.tool.state"
+    baseConfiguration()
+}
 enablePublishing()
 
 kotlin {

--- a/module/state/src/androidMain/AndroidManifest.xml
+++ b/module/state/src/androidMain/AndroidManifest.xml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.cru.godtools.kotlin.tool.state" />


### PR DESCRIPTION
- simplify the FlowWatcher logic
- configure a module namespace from the build script
- remove deprecated ImageGravity
- remove deprecated events from CallToAction
- the XML_EVENTS constant is only used by Clickable
