### PR TITLE
Centralize several Analytics constants to share between iOS and Android

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,6 +50,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
+                api(project(":module:analytics"))
                 api(project(":module:parser"))
                 api(project(":module:state"))
                 api(project(":module:user-activity"))
@@ -65,6 +66,7 @@ kotlin {
         framework {
             baseName = "GodToolsToolParser"
 
+            export(project(":module:analytics"))
             export(project(":module:parser"))
             export(project(":module:state"))
             export(project(":module:user-activity"))

--- a/module/analytics/build.gradle.kts
+++ b/module/analytics/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    kotlin("multiplatform")
+    id("com.android.library")
+    alias(libs.plugins.kotlin.kover)
+}
+
+android {
+    namespace = "org.cru.godtools.shared.analytics"
+    baseConfiguration()
+}
+enablePublishing()
+
+kotlin {
+    configureAndroidTargets()
+    configureIosTargets()
+}

--- a/module/analytics/build.gradle.kts
+++ b/module/analytics/build.gradle.kts
@@ -13,4 +13,12 @@ enablePublishing()
 kotlin {
     configureAndroidTargets()
     configureIosTargets()
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation(libs.gtoSupport.androidx.annotation)
+            }
+        }
+    }
 }

--- a/module/analytics/src/commonMain/kotlin/org/cru/godtools/shared/analytics/AnalyticsActionNames.kt
+++ b/module/analytics/src/commonMain/kotlin/org/cru/godtools/shared/analytics/AnalyticsActionNames.kt
@@ -1,0 +1,9 @@
+package org.cru.godtools.shared.analytics
+
+object AnalyticsActionNames {
+    // region Miscellaneous Platform Menu Actions
+    const val PLATFORM_CONTACT_US = "Contact Us"
+    const val PLATFORM_SHARE_GODTOOLS = "Share App"
+    const val PLATFORM_SHARE_STORY = "Share Story"
+    // endregion Miscellaneous Platform Menu Actions
+}

--- a/module/analytics/src/commonMain/kotlin/org/cru/godtools/shared/analytics/AnalyticsAppSectionNames.kt
+++ b/module/analytics/src/commonMain/kotlin/org/cru/godtools/shared/analytics/AnalyticsAppSectionNames.kt
@@ -3,7 +3,8 @@ package org.cru.godtools.shared.analytics
 import org.ccci.gto.support.androidx.annotation.VisibleForTesting
 
 object AnalyticsAppSectionNames {
-    private const val MENU = "menu"
+    @VisibleForTesting
+    internal const val MENU = "menu"
     @VisibleForTesting
     internal const val ACCOUNT = "account"
     const val TOOLS = "tools"

--- a/module/analytics/src/commonMain/kotlin/org/cru/godtools/shared/analytics/AnalyticsAppSectionNames.kt
+++ b/module/analytics/src/commonMain/kotlin/org/cru/godtools/shared/analytics/AnalyticsAppSectionNames.kt
@@ -1,0 +1,30 @@
+package org.cru.godtools.shared.analytics
+
+object AnalyticsAppSectionNames {
+    private const val MENU = "menu"
+    const val TOOLS = "tools"
+    private const val SUB_SECTION_LANGUAGE_SETTINGS = "language settings"
+
+    fun forScreen(name: String) = when (name) {
+        AnalyticsScreenNames.DASHBOARD_ALL_TOOLS -> TOOLS
+        AnalyticsScreenNames.SETTINGS_LANGUAGES,
+        AnalyticsScreenNames.SETTINGS_LANGUAGE_SELECTION,
+        AnalyticsScreenNames.PLATFORM_ABOUT,
+        AnalyticsScreenNames.PLATFORM_HELP,
+        AnalyticsScreenNames.PLATFORM_TERMS_OF_USE,
+        AnalyticsScreenNames.PLATFORM_PRIVACY_POLICY,
+        AnalyticsScreenNames.PLATFORM_COPYRIGHT -> MENU
+
+        // These should have been action events, but are handled as screen events 🤦
+        AnalyticsActionNames.PLATFORM_CONTACT_US,
+        AnalyticsActionNames.PLATFORM_SHARE_GODTOOLS,
+        AnalyticsActionNames.PLATFORM_SHARE_STORY -> MENU
+
+        else -> null
+    }
+
+    fun subSectionForScreen(name: String) = when (name) {
+        AnalyticsScreenNames.SETTINGS_LANGUAGE_SELECTION -> SUB_SECTION_LANGUAGE_SETTINGS
+        else -> null
+    }
+}

--- a/module/analytics/src/commonMain/kotlin/org/cru/godtools/shared/analytics/AnalyticsAppSectionNames.kt
+++ b/module/analytics/src/commonMain/kotlin/org/cru/godtools/shared/analytics/AnalyticsAppSectionNames.kt
@@ -1,12 +1,18 @@
 package org.cru.godtools.shared.analytics
 
+import org.ccci.gto.support.androidx.annotation.VisibleForTesting
+
 object AnalyticsAppSectionNames {
     private const val MENU = "menu"
+    @VisibleForTesting
+    internal const val ACCOUNT = "account"
     const val TOOLS = "tools"
     private const val SUB_SECTION_LANGUAGE_SETTINGS = "language settings"
 
     fun forScreen(name: String) = when (name) {
         AnalyticsScreenNames.DASHBOARD_ALL_TOOLS -> TOOLS
+        AnalyticsScreenNames.ACCOUNT_ACTIVITY,
+        AnalyticsScreenNames.ACCOUNT_GLOBAL_ACTIVITY -> ACCOUNT
         AnalyticsScreenNames.SETTINGS_LANGUAGES,
         AnalyticsScreenNames.SETTINGS_LANGUAGE_SELECTION,
         AnalyticsScreenNames.PLATFORM_ABOUT,

--- a/module/analytics/src/commonMain/kotlin/org/cru/godtools/shared/analytics/AnalyticsScreenNames.kt
+++ b/module/analytics/src/commonMain/kotlin/org/cru/godtools/shared/analytics/AnalyticsScreenNames.kt
@@ -1,0 +1,29 @@
+package org.cru.godtools.shared.analytics
+
+object AnalyticsScreenNames {
+    // region Dashboard Screens
+    const val DASHBOARD_HOME = "Favorites"
+    const val DASHBOARD_ALL_TOOLS = "All Tools"
+    const val DASHBOARD_LESSONS = "Lessons"
+    // endregion Dashboard Screens
+
+    // region Account
+    const val ACCOUNT_GLOBAL_ACTIVITY = "Global Dashboard"
+    // endregion Account
+
+    // region Settings
+    const val SETTINGS_LANGUAGES = "Language Settings"
+    const val SETTINGS_LANGUAGE_SELECTION = "Select Language"
+    // endregion Settings
+
+    // region Miscellaneous Platform Menu Screens
+    const val PLATFORM_ABOUT = "About"
+    const val PLATFORM_HELP = "Help"
+    const val PLATFORM_CONTACT_US = "Contact Us"
+    const val PLATFORM_SHARE_GODTOOLS = "Share App"
+    const val PLATFORM_SHARE_STORY = "Share Story"
+    const val PLATFORM_TERMS_OF_USE = "Terms of Use"
+    const val PLATFORM_PRIVACY_POLICY = "Privacy Policy"
+    const val PLATFORM_COPYRIGHT = "Copyright Info"
+    // endregion Miscellaneous Platform Menu Screens
+}

--- a/module/analytics/src/commonMain/kotlin/org/cru/godtools/shared/analytics/AnalyticsScreenNames.kt
+++ b/module/analytics/src/commonMain/kotlin/org/cru/godtools/shared/analytics/AnalyticsScreenNames.kt
@@ -8,6 +8,7 @@ object AnalyticsScreenNames {
     // endregion Dashboard Screens
 
     // region Account
+    const val ACCOUNT_ACTIVITY = "Personal Dashboard"
     const val ACCOUNT_GLOBAL_ACTIVITY = "Global Dashboard"
     // endregion Account
 

--- a/module/analytics/src/commonMain/kotlin/org/cru/godtools/shared/analytics/AnalyticsScreenNames.kt
+++ b/module/analytics/src/commonMain/kotlin/org/cru/godtools/shared/analytics/AnalyticsScreenNames.kt
@@ -8,8 +8,8 @@ object AnalyticsScreenNames {
     // endregion Dashboard Screens
 
     // region Account
-    const val ACCOUNT_ACTIVITY = "Personal Dashboard"
-    const val ACCOUNT_GLOBAL_ACTIVITY = "Global Dashboard"
+    const val ACCOUNT_ACTIVITY = "Account Activity"
+    const val ACCOUNT_GLOBAL_ACTIVITY = "Global Activity"
     // endregion Account
 
     // region Settings

--- a/module/analytics/src/commonMain/kotlin/org/cru/godtools/shared/analytics/AnalyticsScreenNames.kt
+++ b/module/analytics/src/commonMain/kotlin/org/cru/godtools/shared/analytics/AnalyticsScreenNames.kt
@@ -19,9 +19,6 @@ object AnalyticsScreenNames {
     // region Miscellaneous Platform Menu Screens
     const val PLATFORM_ABOUT = "About"
     const val PLATFORM_HELP = "Help"
-    const val PLATFORM_CONTACT_US = "Contact Us"
-    const val PLATFORM_SHARE_GODTOOLS = "Share App"
-    const val PLATFORM_SHARE_STORY = "Share Story"
     const val PLATFORM_TERMS_OF_USE = "Terms of Use"
     const val PLATFORM_PRIVACY_POLICY = "Privacy Policy"
     const val PLATFORM_COPYRIGHT = "Copyright Info"

--- a/module/analytics/src/commonTest/kotlin/org/cru/godtools/shared/analytics/AnalyticsAppSectionNamesTest.kt
+++ b/module/analytics/src/commonTest/kotlin/org/cru/godtools/shared/analytics/AnalyticsAppSectionNamesTest.kt
@@ -1,0 +1,18 @@
+package org.cru.godtools.shared.analytics
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AnalyticsAppSectionNamesTest {
+    @Test
+    fun testAppSectionAccount() {
+        assertEquals(
+            AnalyticsAppSectionNames.ACCOUNT,
+            AnalyticsAppSectionNames.forScreen(AnalyticsScreenNames.ACCOUNT_ACTIVITY)
+        )
+        assertEquals(
+            AnalyticsAppSectionNames.ACCOUNT,
+            AnalyticsAppSectionNames.forScreen(AnalyticsScreenNames.ACCOUNT_GLOBAL_ACTIVITY)
+        )
+    }
+}

--- a/module/analytics/src/commonTest/kotlin/org/cru/godtools/shared/analytics/AnalyticsAppSectionNamesTest.kt
+++ b/module/analytics/src/commonTest/kotlin/org/cru/godtools/shared/analytics/AnalyticsAppSectionNamesTest.kt
@@ -2,6 +2,7 @@ package org.cru.godtools.shared.analytics
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class AnalyticsAppSectionNamesTest {
     @Test
@@ -14,5 +15,50 @@ class AnalyticsAppSectionNamesTest {
             AnalyticsAppSectionNames.ACCOUNT,
             AnalyticsAppSectionNames.forScreen(AnalyticsScreenNames.ACCOUNT_GLOBAL_ACTIVITY)
         )
+    }
+
+    @Test
+    fun testAppSectionTools() {
+        assertEquals(
+            AnalyticsAppSectionNames.TOOLS,
+            AnalyticsAppSectionNames.forScreen(AnalyticsScreenNames.DASHBOARD_ALL_TOOLS)
+        )
+    }
+
+    @Test
+    fun testAppSectionMenu() {
+        assertEquals(
+            AnalyticsAppSectionNames.MENU,
+            AnalyticsAppSectionNames.forScreen(AnalyticsScreenNames.SETTINGS_LANGUAGES)
+        )
+        assertEquals(
+            AnalyticsAppSectionNames.MENU,
+            AnalyticsAppSectionNames.forScreen(AnalyticsScreenNames.SETTINGS_LANGUAGE_SELECTION)
+        )
+        assertEquals(
+            AnalyticsAppSectionNames.MENU,
+            AnalyticsAppSectionNames.forScreen(AnalyticsScreenNames.PLATFORM_ABOUT)
+        )
+        assertEquals(
+            AnalyticsAppSectionNames.MENU,
+            AnalyticsAppSectionNames.forScreen(AnalyticsScreenNames.PLATFORM_HELP)
+        )
+        assertEquals(
+            AnalyticsAppSectionNames.MENU,
+            AnalyticsAppSectionNames.forScreen(AnalyticsScreenNames.PLATFORM_TERMS_OF_USE)
+        )
+        assertEquals(
+            AnalyticsAppSectionNames.MENU,
+            AnalyticsAppSectionNames.forScreen(AnalyticsScreenNames.PLATFORM_PRIVACY_POLICY)
+        )
+        assertEquals(
+            AnalyticsAppSectionNames.MENU,
+            AnalyticsAppSectionNames.forScreen(AnalyticsScreenNames.PLATFORM_COPYRIGHT)
+        )
+    }
+
+    @Test
+    fun testAppSectionUnknown() {
+        assertNull(AnalyticsAppSectionNames.forScreen("hjklasdhjf"))
     }
 }

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/analytics/ToolAnalyticsScreenNames.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/analytics/ToolAnalyticsScreenNames.kt
@@ -1,5 +1,6 @@
 package org.cru.godtools.shared.tool.analytics
 
+import org.cru.godtools.shared.tool.parser.model.tips.TipPage
 import org.cru.godtools.shared.tool.parser.model.tract.TractPage
 
 object ToolAnalyticsScreenNames {
@@ -12,4 +13,7 @@ object ToolAnalyticsScreenNames {
             else -> append('-').append(pos)
         }
     }
+
+    fun forTipPage(page: TipPage) = forTipPage(page.manifest.code.orEmpty(), page.tip.id, page.position)
+    fun forTipPage(tool: String, tipId: String, page: Int) = "$tool-tip-$tipId-$page"
 }

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/analytics/ToolAnalyticsScreenNames.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/analytics/ToolAnalyticsScreenNames.kt
@@ -1,0 +1,15 @@
+package org.cru.godtools.shared.tool.analytics
+
+import org.cru.godtools.shared.tool.parser.model.tract.TractPage
+
+object ToolAnalyticsScreenNames {
+    fun forTractPage(page: TractPage, card: TractPage.Card? = null) = buildString {
+        append(page.manifest.code).append('-').append(page.position)
+        when (val pos = card?.position) {
+            null -> Unit
+            // convert card index to letter 'a'-'z'
+            in 0..25 -> append((97 + pos).toChar())
+            else -> append('-').append(pos)
+        }
+    }
+}

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/analytics/ToolAnalyticsScreenNames.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/analytics/ToolAnalyticsScreenNames.kt
@@ -1,10 +1,18 @@
 package org.cru.godtools.shared.tool.analytics
 
 import org.cru.godtools.shared.tool.parser.model.lesson.LessonPage
+import org.cru.godtools.shared.tool.parser.model.page.CardCollectionPage
+import org.cru.godtools.shared.tool.parser.model.page.Page
 import org.cru.godtools.shared.tool.parser.model.tips.TipPage
 import org.cru.godtools.shared.tool.parser.model.tract.TractPage
 
 object ToolAnalyticsScreenNames {
+    private const val CYOA_PAGE_SEPARATOR = ":"
+
+    fun forCyoaPage(page: Page) = "${page.manifest.code.orEmpty()}$CYOA_PAGE_SEPARATOR${page.id}"
+    fun forCyoaCardCollectionCard(card: CardCollectionPage.Card) =
+        "${forCyoaPage(card.page)}$CYOA_PAGE_SEPARATOR${card.id}"
+
     fun forLessonPage(page: LessonPage) = "${page.manifest.code}-${page.position}"
 
     fun forTractPage(page: TractPage, card: TractPage.Card? = null) = buildString {

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/analytics/ToolAnalyticsScreenNames.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/analytics/ToolAnalyticsScreenNames.kt
@@ -1,9 +1,12 @@
 package org.cru.godtools.shared.tool.analytics
 
+import org.cru.godtools.shared.tool.parser.model.lesson.LessonPage
 import org.cru.godtools.shared.tool.parser.model.tips.TipPage
 import org.cru.godtools.shared.tool.parser.model.tract.TractPage
 
 object ToolAnalyticsScreenNames {
+    fun forLessonPage(page: LessonPage) = "${page.manifest.code}-${page.position}"
+
     fun forTractPage(page: TractPage, card: TractPage.Card? = null) = buildString {
         append(page.manifest.code).append('-').append(page.position)
         when (val pos = card?.position) {

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/page/CardCollectionPage.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/page/CardCollectionPage.kt
@@ -1,5 +1,7 @@
 package org.cru.godtools.shared.tool.parser.model.page
 
+import org.ccci.gto.support.androidx.annotation.RestrictTo
+import org.ccci.gto.support.androidx.annotation.RestrictToScope
 import org.cru.godtools.shared.tool.parser.internal.AndroidColorInt
 import org.cru.godtools.shared.tool.parser.model.AnalyticsEvent
 import org.cru.godtools.shared.tool.parser.model.AnalyticsEvent.Companion.parseAnalyticsEvents
@@ -59,6 +61,16 @@ class CardCollectionPage : Page {
         }
     }
 
+    @RestrictTo(RestrictToScope.TESTS)
+    internal constructor(
+        manifest: Manifest,
+        id: String?,
+        parentPage: String? = null,
+    ) : super(manifest, id = id, parentPage = parentPage) {
+        analyticsEvents = emptyList()
+        cards = emptyList()
+    }
+
     override fun supports(type: Manifest.Type) = type == Manifest.Type.CYOA
 
     class Card : BaseModel, Parent, HasAnalyticsEvents {
@@ -103,6 +115,20 @@ class CardCollectionPage : Page {
                     }
                 }
             }
+        }
+
+        @RestrictTo(RestrictToScope.TESTS)
+        internal constructor(
+            page: CardCollectionPage,
+            id: String?,
+        ) : super(page) {
+            this.page = page
+
+            _id = id
+            _backgroundColor = null
+
+            analyticsEvents = emptyList()
+            content = emptyList()
         }
 
         override fun getAnalyticsEvents(type: Trigger) = when (type) {

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/tips/TipPage.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/tips/TipPage.kt
@@ -1,5 +1,7 @@
 package org.cru.godtools.shared.tool.parser.model.tips
 
+import org.ccci.gto.support.androidx.annotation.RestrictTo
+import org.ccci.gto.support.androidx.annotation.RestrictToScope
 import org.cru.godtools.shared.tool.parser.model.BaseModel
 import org.cru.godtools.shared.tool.parser.model.Content
 import org.cru.godtools.shared.tool.parser.model.Parent
@@ -11,7 +13,7 @@ class TipPage : BaseModel, Parent {
         internal const val XML_PAGE = "page"
     }
 
-    private val tip: Tip
+    internal val tip: Tip
     val position: Int
 
     override val content: List<Content>
@@ -21,6 +23,16 @@ class TipPage : BaseModel, Parent {
         this.tip = tip
         this.position = position
         content = parseContent(parser)
+    }
+
+    @RestrictTo(RestrictToScope.TESTS)
+    internal constructor(
+        tip: Tip,
+        position: Int,
+    ) : super(tip) {
+        this.tip = tip
+        this.position = position
+        content = emptyList()
     }
 
     val isLastPage get() = position == tip.pages.size - 1

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/tract/TractPage.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/tract/TractPage.kt
@@ -217,6 +217,7 @@ class TractPage : Page {
         @RestrictTo(RestrictToScope.TESTS)
         internal constructor(
             page: TractPage = TractPage(),
+            position: Int = 0,
             backgroundColor: PlatformColor? = null,
             backgroundImage: String? = null,
             backgroundImageGravity: Gravity = DEFAULT_BACKGROUND_IMAGE_GRAVITY,
@@ -227,7 +228,7 @@ class TractPage : Page {
             content: ((Card) -> List<Content>?)? = null
         ) : super(page) {
             this.page = page
-            position = 0
+            this.position = position
 
             this.isHidden = isHidden
             listeners = emptySet()

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/analytics/ToolAnalyticsScreenNamesTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/analytics/ToolAnalyticsScreenNamesTest.kt
@@ -1,6 +1,8 @@
 package org.cru.godtools.shared.tool.analytics
 
 import org.cru.godtools.shared.tool.parser.model.Manifest
+import org.cru.godtools.shared.tool.parser.model.tips.Tip
+import org.cru.godtools.shared.tool.parser.model.tips.TipPage
 import org.cru.godtools.shared.tool.parser.model.tract.TractPage
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -20,5 +22,14 @@ class ToolAnalyticsScreenNamesTest {
         assertEquals("tool-0z", ToolAnalyticsScreenNames.forTractPage(page, TractPage.Card(position = 25)))
         assertEquals("tool-0-26", ToolAnalyticsScreenNames.forTractPage(page, TractPage.Card(position = 26)))
         assertEquals("tool-0-100", ToolAnalyticsScreenNames.forTractPage(page, TractPage.Card(position = 100)))
+    }
+
+    @Test
+    fun testForTipPage() {
+        val tip = Tip(Manifest(code = "tool"), id = "tipId")
+
+        assertEquals("tool-tip-tipId-0", ToolAnalyticsScreenNames.forTipPage(TipPage(tip, position = 0)))
+        assertEquals("tool-tip-tipId-0", ToolAnalyticsScreenNames.forTipPage("tool", "tipId", 0))
+        assertEquals("tool-tip-tipId-1", ToolAnalyticsScreenNames.forTipPage(TipPage(tip, position = 1)))
     }
 }

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/analytics/ToolAnalyticsScreenNamesTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/analytics/ToolAnalyticsScreenNamesTest.kt
@@ -1,0 +1,24 @@
+package org.cru.godtools.shared.tool.analytics
+
+import org.cru.godtools.shared.tool.parser.model.Manifest
+import org.cru.godtools.shared.tool.parser.model.tract.TractPage
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ToolAnalyticsScreenNamesTest {
+    @Test
+    fun testForTractPage() {
+        val manifest = Manifest(
+            code = "tool",
+            pages = { listOf(TractPage(it)) }
+        )
+        val page = manifest.pages.filterIsInstance<TractPage>().first()
+
+        assertEquals("tool-0", ToolAnalyticsScreenNames.forTractPage(page))
+        assertEquals("tool-0a", ToolAnalyticsScreenNames.forTractPage(page, TractPage.Card(position = 0)))
+        assertEquals("tool-0b", ToolAnalyticsScreenNames.forTractPage(page, TractPage.Card(position = 1)))
+        assertEquals("tool-0z", ToolAnalyticsScreenNames.forTractPage(page, TractPage.Card(position = 25)))
+        assertEquals("tool-0-26", ToolAnalyticsScreenNames.forTractPage(page, TractPage.Card(position = 26)))
+        assertEquals("tool-0-100", ToolAnalyticsScreenNames.forTractPage(page, TractPage.Card(position = 100)))
+    }
+}

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/analytics/ToolAnalyticsScreenNamesTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/analytics/ToolAnalyticsScreenNamesTest.kt
@@ -1,6 +1,7 @@
 package org.cru.godtools.shared.tool.analytics
 
 import org.cru.godtools.shared.tool.parser.model.Manifest
+import org.cru.godtools.shared.tool.parser.model.lesson.LessonPage
 import org.cru.godtools.shared.tool.parser.model.tips.Tip
 import org.cru.godtools.shared.tool.parser.model.tips.TipPage
 import org.cru.godtools.shared.tool.parser.model.tract.TractPage
@@ -8,6 +9,17 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class ToolAnalyticsScreenNamesTest {
+    @Test
+    fun testForLessonPage() {
+        val manifest = Manifest(
+            code = "lessonhs",
+            pages = { listOf(LessonPage(it), LessonPage(it)) }
+        )
+
+        assertEquals("lessonhs-0", ToolAnalyticsScreenNames.forLessonPage(manifest.pages[0] as LessonPage))
+        assertEquals("lessonhs-1", ToolAnalyticsScreenNames.forLessonPage(manifest.pages[1] as LessonPage))
+    }
+
     @Test
     fun testForTractPage() {
         val manifest = Manifest(

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/analytics/ToolAnalyticsScreenNamesTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/analytics/ToolAnalyticsScreenNamesTest.kt
@@ -2,6 +2,8 @@ package org.cru.godtools.shared.tool.analytics
 
 import org.cru.godtools.shared.tool.parser.model.Manifest
 import org.cru.godtools.shared.tool.parser.model.lesson.LessonPage
+import org.cru.godtools.shared.tool.parser.model.page.CardCollectionPage
+import org.cru.godtools.shared.tool.parser.model.page.ContentPage
 import org.cru.godtools.shared.tool.parser.model.tips.Tip
 import org.cru.godtools.shared.tool.parser.model.tips.TipPage
 import org.cru.godtools.shared.tool.parser.model.tract.TractPage
@@ -9,6 +11,29 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class ToolAnalyticsScreenNamesTest {
+    @Test
+    fun testForCyoaPage() {
+        val page = ContentPage(
+            manifest = Manifest(code = "cyoa"),
+            id = "page"
+        )
+
+        assertEquals("cyoa:page", ToolAnalyticsScreenNames.forCyoaPage(page))
+    }
+
+    @Test
+    fun testForCyoaCardCollectionCard() {
+        val card = CardCollectionPage.Card(
+            page = CardCollectionPage(
+                manifest = Manifest(code = "cyoa"),
+                id = "page"
+            ),
+            id = "card"
+        )
+
+        assertEquals("cyoa:page:card", ToolAnalyticsScreenNames.forCyoaCardCollectionCard(card))
+    }
+
     @Test
     fun testForLessonPage() {
         val manifest = Manifest(

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,6 +18,7 @@ dependencyResolutionManagement {
     }
 }
 
+include("module:analytics")
 include("module:common")
 include("module:parser")
 include("module:parser-expressions")


### PR DESCRIPTION
This provides several objects that can be used to get analytics screen names for most screens. This is just a start and doesn't cover all screen and events yet.