### PR TITLE
GT-1842 Add logic to generate badges based on user activity

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ kotlin-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-co
 kotlin-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinCoroutines" }
 kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 napier = { module = "io.github.aakira:napier", version.ref = "napier" }
+okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 turbine = "app.cash.turbine:turbine:0.8.0"
 

--- a/module/common/build.gradle.kts
+++ b/module/common/build.gradle.kts
@@ -1,0 +1,23 @@
+plugins {
+    kotlin("multiplatform")
+    id("com.android.library")
+    alias(libs.plugins.kotlin.kover)
+}
+
+android {
+    namespace = "org.cru.godtools.shared.common"
+    baseConfiguration()
+}
+enablePublishing()
+
+kotlin {
+    configureTargets()
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation(libs.napier)
+            }
+        }
+    }
+}

--- a/module/common/src/androidMain/kotlin/org/cru/godtools/shared/common/model/Uri.android.kt
+++ b/module/common/src/androidMain/kotlin/org/cru/godtools/shared/common/model/Uri.android.kt
@@ -1,9 +1,10 @@
-package org.cru.godtools.shared.tool.parser.model
+package org.cru.godtools.shared.common.model
+
+import android.net.Uri
 
 // HACK: Suppress expect/actual errors as workaround for differences between Android Uri and iOS NSURL
 //       see: https://discuss.kotlinlang.org/t/feature-request-typealias-for-expected-types/20054/4
 @Suppress("ACTUAL_WITHOUT_EXPECT")
 actual typealias Uri = android.net.Uri
-internal actual inline val Uri.scheme get() = scheme
 
-internal actual fun String?.toUriOrNull() = this?.let { Uri.parse(this) }
+actual fun String?.toUriOrNull() = this?.let { Uri.parse(this) }

--- a/module/common/src/commonMain/kotlin/org/cru/godtools/shared/common/model/Uri.kt
+++ b/module/common/src/commonMain/kotlin/org/cru/godtools/shared/common/model/Uri.kt
@@ -1,0 +1,5 @@
+package org.cru.godtools.shared.common.model
+
+expect class Uri
+
+expect fun String?.toUriOrNull(): Uri?

--- a/module/common/src/iosMain/kotlin/org/cru/godtools/shared/common/model/Uri.ios.kt
+++ b/module/common/src/iosMain/kotlin/org/cru/godtools/shared/common/model/Uri.ios.kt
@@ -1,13 +1,12 @@
-package org.cru.godtools.shared.tool.parser.model
+package org.cru.godtools.shared.common.model
 
 import io.github.aakira.napier.Napier
 import platform.Foundation.NSURL
 
 @Suppress("CONFLICTING_OVERLOADS")
 actual typealias Uri = NSURL
-internal actual inline val Uri.scheme get() = scheme
 
-internal actual fun String?.toUriOrNull() = this?.let {
+actual fun String?.toUriOrNull() = this?.let {
     try {
         NSURL(string = it)
     } catch (e: NullPointerException) {

--- a/module/common/src/jsMain/kotlin/org/cru/godtools/shared/common/model/Uri.js.kt
+++ b/module/common/src/jsMain/kotlin/org/cru/godtools/shared/common/model/Uri.js.kt
@@ -1,0 +1,6 @@
+package org.cru.godtools.shared.common.model
+
+// TODO: switch from String to URL
+actual typealias Uri = String
+
+actual fun String?.toUriOrNull() = this

--- a/module/parser/build.gradle.kts
+++ b/module/parser/build.gradle.kts
@@ -18,6 +18,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 api(project(":module:state"))
+                implementation(project(":module:common"))
                 implementation(project(":module:parser-expressions"))
 
                 implementation(kotlin("stdlib"))

--- a/module/parser/src/androidMain/kotlin/org/cru/godtools/shared/tool/parser/util/Uri.android.kt
+++ b/module/parser/src/androidMain/kotlin/org/cru/godtools/shared/tool/parser/util/Uri.android.kt
@@ -1,0 +1,5 @@
+package org.cru.godtools.shared.tool.parser.util
+
+import android.net.Uri
+
+internal actual inline val Uri.scheme get() = scheme

--- a/module/parser/src/androidTest/kotlin/org/cru/godtools/shared/tool/parser/model/TestConstants.android.kt
+++ b/module/parser/src/androidTest/kotlin/org/cru/godtools/shared/tool/parser/model/TestConstants.android.kt
@@ -1,3 +1,5 @@
 package org.cru.godtools.shared.tool.parser.model
 
+import android.net.Uri
+
 actual val TEST_URL = Uri.parse("https://www.example.com")

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Animation.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Animation.kt
@@ -3,6 +3,7 @@ package org.cru.godtools.shared.tool.parser.model
 import org.ccci.gto.support.androidx.annotation.RestrictTo
 import org.ccci.gto.support.androidx.annotation.RestrictToScope
 import org.ccci.gto.support.androidx.annotation.VisibleForTesting
+import org.cru.godtools.shared.common.model.Uri
 import org.cru.godtools.shared.tool.parser.ParserConfig.Companion.FEATURE_ANIMATION
 import org.cru.godtools.shared.tool.parser.xml.XmlPullParser
 import org.cru.godtools.shared.tool.parser.xml.skipTag

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Button.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Button.kt
@@ -3,6 +3,7 @@ package org.cru.godtools.shared.tool.parser.model
 import io.github.aakira.napier.Napier
 import org.ccci.gto.support.androidx.annotation.RestrictTo
 import org.ccci.gto.support.androidx.annotation.RestrictToScope
+import org.cru.godtools.shared.common.model.Uri
 import org.cru.godtools.shared.tool.parser.internal.AndroidColorInt
 import org.cru.godtools.shared.tool.parser.internal.DeprecationException
 import org.cru.godtools.shared.tool.parser.model.AnalyticsEvent.Companion.parseAnalyticsEvents

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Card.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Card.kt
@@ -2,6 +2,7 @@ package org.cru.godtools.shared.tool.parser.model
 
 import org.ccci.gto.support.androidx.annotation.RestrictTo
 import org.ccci.gto.support.androidx.annotation.RestrictToScope
+import org.cru.godtools.shared.common.model.Uri
 import org.cru.godtools.shared.tool.parser.ParserConfig.Companion.FEATURE_CONTENT_CARD
 import org.cru.godtools.shared.tool.parser.xml.XmlPullParser
 

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Clickable.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Clickable.kt
@@ -1,7 +1,11 @@
 package org.cru.godtools.shared.tool.parser.model
 
 import io.github.aakira.napier.Napier
+import org.cru.godtools.shared.common.model.Uri
+import org.cru.godtools.shared.common.model.toUriOrNull
 import org.cru.godtools.shared.tool.parser.internal.DeprecationException
+import org.cru.godtools.shared.tool.parser.util.hasUriScheme
+import org.cru.godtools.shared.tool.parser.util.toAbsoluteUriOrNull
 import org.cru.godtools.shared.tool.parser.xml.XmlPullParser
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Image.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Image.kt
@@ -3,6 +3,7 @@ package org.cru.godtools.shared.tool.parser.model
 import org.ccci.gto.support.androidx.annotation.RestrictTo
 import org.ccci.gto.support.androidx.annotation.RestrictToScope
 import org.ccci.gto.support.androidx.annotation.VisibleForTesting
+import org.cru.godtools.shared.common.model.Uri
 import org.cru.godtools.shared.tool.parser.model.Dimension.Companion.toDimensionOrNull
 import org.cru.godtools.shared.tool.parser.model.Dimension.Pixels
 import org.cru.godtools.shared.tool.parser.model.Gravity.Companion.toGravityOrNull

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Link.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Link.kt
@@ -2,6 +2,7 @@ package org.cru.godtools.shared.tool.parser.model
 
 import org.ccci.gto.support.androidx.annotation.RestrictTo
 import org.ccci.gto.support.androidx.annotation.RestrictToScope
+import org.cru.godtools.shared.common.model.Uri
 import org.cru.godtools.shared.tool.parser.model.AnalyticsEvent.Companion.parseAnalyticsEvents
 import org.cru.godtools.shared.tool.parser.model.AnalyticsEvent.Trigger
 import org.cru.godtools.shared.tool.parser.xml.XmlPullParser

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Manifest.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Manifest.kt
@@ -9,6 +9,8 @@ import org.ccci.gto.support.androidx.annotation.RestrictTo
 import org.ccci.gto.support.androidx.annotation.RestrictToScope
 import org.ccci.gto.support.androidx.annotation.VisibleForTesting
 import org.ccci.gto.support.fluidsonic.locale.PlatformLocale
+import org.cru.godtools.shared.common.model.Uri
+import org.cru.godtools.shared.common.model.toUriOrNull
 import org.cru.godtools.shared.tool.parser.ParserConfig
 import org.cru.godtools.shared.tool.parser.internal.AndroidColorInt
 import org.cru.godtools.shared.tool.parser.internal.DeprecationException
@@ -28,6 +30,7 @@ import org.cru.godtools.shared.tool.parser.model.shareable.Shareable
 import org.cru.godtools.shared.tool.parser.model.shareable.Shareable.Companion.parseShareableItems
 import org.cru.godtools.shared.tool.parser.model.shareable.XMLNS_SHAREABLE
 import org.cru.godtools.shared.tool.parser.model.tips.Tip
+import org.cru.godtools.shared.tool.parser.util.isHttpUrl
 import org.cru.godtools.shared.tool.parser.util.setOnce
 import org.cru.godtools.shared.tool.parser.xml.XmlPullParser
 import org.cru.godtools.shared.tool.parser.xml.parseChildren

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/util/Uri.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/util/Uri.kt
@@ -1,10 +1,10 @@
-package org.cru.godtools.shared.tool.parser.model
+package org.cru.godtools.shared.tool.parser.util
 
-expect class Uri
+import org.cru.godtools.shared.common.model.Uri
+import org.cru.godtools.shared.common.model.toUriOrNull
+
 internal expect val Uri.scheme: String?
 internal val Uri.isHttpUrl: Boolean get() = scheme?.matches(Regex("https?", RegexOption.IGNORE_CASE)) == true
-
-internal expect fun String?.toUriOrNull(): Uri?
 
 internal fun String?.toAbsoluteUriOrNull(defaultScheme: String = "http") =
     this?.addSchemeIfNecessary(defaultScheme).toUriOrNull()

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/ImageTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/ImageTest.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
 import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
+import org.cru.godtools.shared.common.model.toUriOrNull
 import org.cru.godtools.shared.tool.parser.ParserConfig
 import org.cru.godtools.shared.tool.parser.internal.UsesResources
 import org.cru.godtools.shared.tool.parser.withDeviceType

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/TestConstants.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/TestConstants.kt
@@ -1,5 +1,7 @@
 package org.cru.godtools.shared.tool.parser.model
 
+import org.cru.godtools.shared.common.model.Uri
+
 internal val TEST_GRAVITY = Gravity(Gravity.Horizontal.values().random(), Gravity.Vertical.values().random())
 
 expect val TEST_URL: Uri

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/util/UriTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/util/UriTest.kt
@@ -1,7 +1,8 @@
-package org.cru.godtools.shared.tool.parser.model
+package org.cru.godtools.shared.tool.parser.util
 
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
 import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
+import org.cru.godtools.shared.common.model.toUriOrNull
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse

--- a/module/parser/src/iosMain/kotlin/org/cru/godtools/shared/tool/parser/util/Uri.ios.kt
+++ b/module/parser/src/iosMain/kotlin/org/cru/godtools/shared/tool/parser/util/Uri.ios.kt
@@ -1,0 +1,5 @@
+package org.cru.godtools.shared.tool.parser.util
+
+import platform.Foundation.NSURL
+
+internal actual inline val NSURL.scheme get() = scheme

--- a/module/parser/src/iosTest/kotlin/org/cru/godtools/shared/tool/parser/util/IosUriTest.kt
+++ b/module/parser/src/iosTest/kotlin/org/cru/godtools/shared/tool/parser/util/IosUriTest.kt
@@ -1,4 +1,4 @@
-package org.cru.godtools.shared.tool.parser.model
+package org.cru.godtools.shared.tool.parser.util
 
 import kotlin.test.Test
 import kotlin.test.assertNull

--- a/module/parser/src/jsMain/kotlin/org/cru/godtools/shared/tool/parser/model/Uri.js.kt
+++ b/module/parser/src/jsMain/kotlin/org/cru/godtools/shared/tool/parser/model/Uri.js.kt
@@ -1,6 +1,0 @@
-package org.cru.godtools.shared.tool.parser.model
-
-actual typealias Uri = String
-internal actual inline val Uri.scheme: String? get() = if (contains(":")) substringBefore(":") else null
-
-internal actual fun String?.toUriOrNull() = this

--- a/module/parser/src/jsMain/kotlin/org/cru/godtools/shared/tool/parser/util/Uri.js.kt
+++ b/module/parser/src/jsMain/kotlin/org/cru/godtools/shared/tool/parser/util/Uri.js.kt
@@ -1,0 +1,5 @@
+package org.cru.godtools.shared.tool.parser.util
+
+import org.cru.godtools.shared.common.model.Uri
+
+internal actual inline val Uri.scheme: String? get() = if (contains(":")) substringBefore(":") else null

--- a/module/user-activity/build.gradle.kts
+++ b/module/user-activity/build.gradle.kts
@@ -17,9 +17,17 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
+                implementation(project(":module:common"))
+
                 implementation(libs.fluidLocale)
                 implementation(libs.gtoSupport.androidx.annotation)
                 implementation(libs.gtoSupport.fluidsonic.locale)
+                implementation(libs.okio)
+            }
+        }
+        val commonTest by getting {
+            dependencies {
+                implementation(libs.gtoSupport.androidx.test.junit)
             }
         }
     }

--- a/module/user-activity/build.gradle.kts
+++ b/module/user-activity/build.gradle.kts
@@ -18,6 +18,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation(libs.fluidLocale)
+                implementation(libs.gtoSupport.androidx.annotation)
                 implementation(libs.gtoSupport.fluidsonic.locale)
             }
         }

--- a/module/user-activity/src/commonMain/kotlin/org/cru/godtools/shared/user/activity/UserCounterNames.kt
+++ b/module/user-activity/src/commonMain/kotlin/org/cru/godtools/shared/user/activity/UserCounterNames.kt
@@ -8,6 +8,7 @@ import org.ccci.gto.support.fluidsonic.locale.toCommon
 object UserCounterNames {
     const val SESSION = "sessions"
     const val LINK_SHARED = "link_shares"
+    const val TIPS_COMPLETED = "tips_completed"
     internal const val LANGUAGE_USED_PREFIX = "language_used."
     private const val LESSON_OPENS_PREFIX = "lesson_opens."
     internal const val LESSON_COMPLETIONS_PREFIX = "lesson_completions."

--- a/module/user-activity/src/commonMain/kotlin/org/cru/godtools/shared/user/activity/UserCounterNames.kt
+++ b/module/user-activity/src/commonMain/kotlin/org/cru/godtools/shared/user/activity/UserCounterNames.kt
@@ -21,6 +21,5 @@ object UserCounterNames {
     fun TOOL_OPEN(tool: String) = "$TOOL_OPENS_PREFIX$tool".lowercase()
     fun SCREEN_SHARE(tool: String) = "$SCREEN_SHARES_PREFIX$tool".lowercase()
     fun LANGUAGE_USED(locale: PlatformLocale) = LANGUAGE_USED(locale.toCommon())
-    fun LANGUAGE_USED(locale: String) = LANGUAGE_USED(Locale.forLanguageTag(locale))
     private fun LANGUAGE_USED(locale: Locale) = "$LANGUAGE_USED_PREFIX$locale".lowercase()
 }

--- a/module/user-activity/src/commonMain/kotlin/org/cru/godtools/shared/user/activity/UserCounterNames.kt
+++ b/module/user-activity/src/commonMain/kotlin/org/cru/godtools/shared/user/activity/UserCounterNames.kt
@@ -1,8 +1,10 @@
 package org.cru.godtools.shared.user.activity
 
 import io.fluidsonic.locale.Locale
+import okio.ByteString.Companion.encodeUtf8
 import org.ccci.gto.support.fluidsonic.locale.PlatformLocale
 import org.ccci.gto.support.fluidsonic.locale.toCommon
+import org.cru.godtools.shared.common.model.Uri
 
 @Suppress("FunctionName")
 object UserCounterNames {
@@ -10,6 +12,7 @@ object UserCounterNames {
     const val LINK_SHARED = "link_shares"
     const val IMAGE_SHARED = "image_shares"
     const val TIPS_COMPLETED = "tips_completed"
+    internal const val ARTICLE_OPENS_PREFIX = "article_opens."
     internal const val LANGUAGE_USED_PREFIX = "language_used."
     private const val LESSON_OPENS_PREFIX = "lesson_opens."
     internal const val LESSON_COMPLETIONS_PREFIX = "lesson_completions."
@@ -17,6 +20,8 @@ object UserCounterNames {
     internal const val SHARE_SCREEN_STARTED = "share_screen_engaged"
     internal const val TOOL_OPENS_PREFIX = "tool_opens."
 
+    fun ARTICLE_OPEN(uri: Uri) =
+        "$ARTICLE_OPENS_PREFIX${uri.toString().lowercase().encodeUtf8().md5().hex().lowercase()}"
     fun LESSON_OPEN(tool: String) = "$LESSON_OPENS_PREFIX$tool".lowercase()
     fun TOOL_OPEN(tool: String) = "$TOOL_OPENS_PREFIX$tool".lowercase()
     fun SCREEN_SHARE(tool: String) = "$SCREEN_SHARES_PREFIX$tool".lowercase()

--- a/module/user-activity/src/commonMain/kotlin/org/cru/godtools/shared/user/activity/UserCounterNames.kt
+++ b/module/user-activity/src/commonMain/kotlin/org/cru/godtools/shared/user/activity/UserCounterNames.kt
@@ -8,6 +8,7 @@ import org.ccci.gto.support.fluidsonic.locale.toCommon
 object UserCounterNames {
     const val SESSION = "sessions"
     const val LINK_SHARED = "link_shares"
+    const val IMAGE_SHARED = "image_shares"
     const val TIPS_COMPLETED = "tips_completed"
     internal const val LANGUAGE_USED_PREFIX = "language_used."
     private const val LESSON_OPENS_PREFIX = "lesson_opens."

--- a/module/user-activity/src/commonMain/kotlin/org/cru/godtools/shared/user/activity/model/Badge.kt
+++ b/module/user-activity/src/commonMain/kotlin/org/cru/godtools/shared/user/activity/model/Badge.kt
@@ -1,0 +1,19 @@
+package org.cru.godtools.shared.user.activity.model
+
+import org.ccci.gto.support.androidx.annotation.VisibleForTesting
+
+data class Badge(val type: BadgeType, val progress: Int, val target: Int) {
+    enum class BadgeType(@VisibleForTesting internal vararg val variants: Int) {
+        TOOLS_OPENED(1, 5, 10),
+        LESSONS_COMPLETED(1, 5, 10),
+        ARTICLES_OPENED(1, 5, 10),
+        IMAGES_SHARED(1, 5, 10),
+        TIPS_COMPLETED(5, 10, 20),
+        ;
+
+        internal fun createBadges(progress: Int) =
+            variants.map { Badge(this, progress = progress.coerceAtMost(it), target = it) }
+    }
+
+    val isEarned get() = progress >= target
+}

--- a/module/user-activity/src/commonMain/kotlin/org/cru/godtools/shared/user/activity/model/UserActivity.kt
+++ b/module/user-activity/src/commonMain/kotlin/org/cru/godtools/shared/user/activity/model/UserActivity.kt
@@ -1,5 +1,6 @@
 package org.cru.godtools.shared.user.activity.model
 
+import org.cru.godtools.shared.user.activity.UserCounterNames.ARTICLE_OPENS_PREFIX
 import org.cru.godtools.shared.user.activity.UserCounterNames.IMAGE_SHARED
 import org.cru.godtools.shared.user.activity.UserCounterNames.LANGUAGE_USED_PREFIX
 import org.cru.godtools.shared.user.activity.UserCounterNames.LESSON_COMPLETIONS_PREFIX
@@ -37,6 +38,7 @@ data class UserActivity private constructor(
         private fun generateBadges(counters: Counters) =
             BadgeType.TOOLS_OPENED.createBadges(counters.count(TOOL_OPENS_PREFIX)) +
                 BadgeType.LESSONS_COMPLETED.createBadges(counters.count(LESSON_COMPLETIONS_PREFIX)) +
+                BadgeType.ARTICLES_OPENED.createBadges(counters.count(ARTICLE_OPENS_PREFIX)) +
                 BadgeType.IMAGES_SHARED.createBadges(counters[IMAGE_SHARED] ?: 0) +
                 BadgeType.TIPS_COMPLETED.createBadges(counters[TIPS_COMPLETED] ?: 0)
     }

--- a/module/user-activity/src/commonMain/kotlin/org/cru/godtools/shared/user/activity/model/UserActivity.kt
+++ b/module/user-activity/src/commonMain/kotlin/org/cru/godtools/shared/user/activity/model/UserActivity.kt
@@ -6,8 +6,11 @@ import org.cru.godtools.shared.user.activity.UserCounterNames.LINK_SHARED
 import org.cru.godtools.shared.user.activity.UserCounterNames.SCREEN_SHARES_PREFIX
 import org.cru.godtools.shared.user.activity.UserCounterNames.SESSION
 import org.cru.godtools.shared.user.activity.UserCounterNames.SHARE_SCREEN_STARTED
+import org.cru.godtools.shared.user.activity.UserCounterNames.TIPS_COMPLETED
 import org.cru.godtools.shared.user.activity.UserCounterNames.TOOL_OPENS_PREFIX
+import org.cru.godtools.shared.user.activity.model.Badge.BadgeType
 import org.cru.godtools.shared.user.activity.util.Counters
+import org.cru.godtools.shared.user.activity.util.count
 import org.cru.godtools.shared.user.activity.util.sum
 
 data class UserActivity private constructor(
@@ -17,13 +20,22 @@ data class UserActivity private constructor(
     val linksShared: Int = 0,
     val languagesUsed: Int = 0,
     val sessions: Int = 0,
+    val badges: List<Badge> = emptyList()
 ) {
     constructor(counters: Counters) : this(
         toolOpens = counters.sum(TOOL_OPENS_PREFIX),
         lessonCompletions = counters.sum(LESSON_COMPLETIONS_PREFIX),
         screenShares = counters.sum(SCREEN_SHARES_PREFIX) + (counters[SHARE_SCREEN_STARTED] ?: 0),
         linksShared = counters[LINK_SHARED] ?: 0,
-        languagesUsed = counters.count { (counter, count) -> counter.startsWith(LANGUAGE_USED_PREFIX) && count > 0 },
-        sessions = counters[SESSION] ?: 0
+        languagesUsed = counters.count(LANGUAGE_USED_PREFIX),
+        sessions = counters[SESSION] ?: 0,
+        badges = generateBadges(counters),
     )
+
+    private companion object {
+        private fun generateBadges(counters: Counters) =
+            BadgeType.TOOLS_OPENED.createBadges(counters.count(TOOL_OPENS_PREFIX)) +
+                BadgeType.LESSONS_COMPLETED.createBadges(counters.count(LESSON_COMPLETIONS_PREFIX)) +
+                BadgeType.TIPS_COMPLETED.createBadges(counters[TIPS_COMPLETED] ?: 0)
+    }
 }

--- a/module/user-activity/src/commonMain/kotlin/org/cru/godtools/shared/user/activity/model/UserActivity.kt
+++ b/module/user-activity/src/commonMain/kotlin/org/cru/godtools/shared/user/activity/model/UserActivity.kt
@@ -1,5 +1,6 @@
 package org.cru.godtools.shared.user.activity.model
 
+import org.cru.godtools.shared.user.activity.UserCounterNames.IMAGE_SHARED
 import org.cru.godtools.shared.user.activity.UserCounterNames.LANGUAGE_USED_PREFIX
 import org.cru.godtools.shared.user.activity.UserCounterNames.LESSON_COMPLETIONS_PREFIX
 import org.cru.godtools.shared.user.activity.UserCounterNames.LINK_SHARED
@@ -36,6 +37,7 @@ data class UserActivity private constructor(
         private fun generateBadges(counters: Counters) =
             BadgeType.TOOLS_OPENED.createBadges(counters.count(TOOL_OPENS_PREFIX)) +
                 BadgeType.LESSONS_COMPLETED.createBadges(counters.count(LESSON_COMPLETIONS_PREFIX)) +
+                BadgeType.IMAGES_SHARED.createBadges(counters[IMAGE_SHARED] ?: 0) +
                 BadgeType.TIPS_COMPLETED.createBadges(counters[TIPS_COMPLETED] ?: 0)
     }
 }

--- a/module/user-activity/src/commonMain/kotlin/org/cru/godtools/shared/user/activity/util/Counters.kt
+++ b/module/user-activity/src/commonMain/kotlin/org/cru/godtools/shared/user/activity/util/Counters.kt
@@ -5,3 +5,6 @@ typealias Counters = Map<String, Int>
 internal fun Counters.sum(prefix: String) = entries
     .filter { (counter) -> counter.startsWith(prefix) }
     .sumOf { (_, count) -> count }
+
+internal fun Counters.count(prefix: String) = entries
+    .count { (counter, count) -> counter.startsWith(prefix) && count > 0 }

--- a/module/user-activity/src/commonTest/kotlin/org/cru/godtools/shared/user/activity/UserCounterNamesTest.kt
+++ b/module/user-activity/src/commonTest/kotlin/org/cru/godtools/shared/user/activity/UserCounterNamesTest.kt
@@ -1,10 +1,14 @@
 package org.cru.godtools.shared.user.activity
 
 import io.fluidsonic.locale.Locale
+import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
+import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
 import org.ccci.gto.support.fluidsonic.locale.toPlatform
+import org.cru.godtools.shared.common.model.toUriOrNull
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
+@RunOnAndroidWith(AndroidJUnit4::class)
 class UserCounterNamesTest {
     @Test
     fun verifyCounterNames() {
@@ -12,5 +16,9 @@ class UserCounterNamesTest {
         assertEquals("lesson_opens.lessonhs", UserCounterNames.LESSON_OPEN("lessonhs"))
         assertEquals("screen_shares.kgp", UserCounterNames.SCREEN_SHARE("kgp"))
         assertEquals("language_used.en", UserCounterNames.LANGUAGE_USED(Locale.forLanguageTag("en").toPlatform()))
+        assertEquals(
+            "article_opens.9cefae211bd0f75208e5edd1b86ef23f",
+            UserCounterNames.ARTICLE_OPEN("https://www.example.com/path".toUriOrNull()!!)
+        )
     }
 }

--- a/module/user-activity/src/commonTest/kotlin/org/cru/godtools/shared/user/activity/UserCounterNamesTest.kt
+++ b/module/user-activity/src/commonTest/kotlin/org/cru/godtools/shared/user/activity/UserCounterNamesTest.kt
@@ -1,5 +1,7 @@
 package org.cru.godtools.shared.user.activity
 
+import io.fluidsonic.locale.Locale
+import org.ccci.gto.support.fluidsonic.locale.toPlatform
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -9,7 +11,6 @@ class UserCounterNamesTest {
         assertEquals("tool_opens.kgp", UserCounterNames.TOOL_OPEN("kgp"))
         assertEquals("lesson_opens.lessonhs", UserCounterNames.LESSON_OPEN("lessonhs"))
         assertEquals("screen_shares.kgp", UserCounterNames.SCREEN_SHARE("kgp"))
-        assertEquals("language_used.en", UserCounterNames.LANGUAGE_USED("en"))
-        assertEquals("language_used.en-us", UserCounterNames.LANGUAGE_USED("en-US"))
+        assertEquals("language_used.en", UserCounterNames.LANGUAGE_USED(Locale.forLanguageTag("en").toPlatform()))
     }
 }

--- a/module/user-activity/src/commonTest/kotlin/org/cru/godtools/shared/user/activity/model/BadgeTest.kt
+++ b/module/user-activity/src/commonTest/kotlin/org/cru/godtools/shared/user/activity/model/BadgeTest.kt
@@ -1,0 +1,15 @@
+package org.cru.godtools.shared.user.activity.model
+
+import org.cru.godtools.shared.user.activity.model.Badge.BadgeType
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class BadgeTest {
+    @Test
+    fun testIsEarned() {
+        assertFalse(Badge(BadgeType.TOOLS_OPENED, 4, 5).isEarned)
+        assertTrue(Badge(BadgeType.TOOLS_OPENED, 5, 5).isEarned)
+        assertTrue(Badge(BadgeType.TOOLS_OPENED, 6, 5).isEarned)
+    }
+}

--- a/module/user-activity/src/commonTest/kotlin/org/cru/godtools/shared/user/activity/model/BadgeTypeTest.kt
+++ b/module/user-activity/src/commonTest/kotlin/org/cru/godtools/shared/user/activity/model/BadgeTypeTest.kt
@@ -1,0 +1,22 @@
+package org.cru.godtools.shared.user.activity.model
+
+import org.cru.godtools.shared.user.activity.model.Badge.BadgeType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class BadgeTypeTest {
+    @Test
+    fun testCreateBadges() {
+        val type = BadgeType.TOOLS_OPENED
+        val progress = 7
+        val badges = type.createBadges(progress)
+        assertEquals(type.variants.size, badges.size)
+        type.variants.zip(badges).forEach { (size, badge) ->
+            assertEquals(type, badge.type)
+            assertTrue(badge.progress <= badge.target)
+            assertEquals(progress.coerceAtMost(size), badge.progress)
+            assertEquals(size, badge.target)
+        }
+    }
+}

--- a/module/user-activity/src/commonTest/kotlin/org/cru/godtools/shared/user/activity/model/UserActivityTest.kt
+++ b/module/user-activity/src/commonTest/kotlin/org/cru/godtools/shared/user/activity/model/UserActivityTest.kt
@@ -1,5 +1,7 @@
 package org.cru.godtools.shared.user.activity.model
 
+import io.fluidsonic.locale.Locale
+import org.ccci.gto.support.fluidsonic.locale.toPlatform
 import org.cru.godtools.shared.user.activity.UserCounterNames.LANGUAGE_USED
 import org.cru.godtools.shared.user.activity.UserCounterNames.LESSON_COMPLETIONS_PREFIX
 import org.cru.godtools.shared.user.activity.UserCounterNames.LESSON_OPEN
@@ -89,13 +91,13 @@ class UserActivityTest {
         val counters = mutableMapOf<String, Int>()
         assertEquals(0, UserActivity(counters).languagesUsed)
 
-        counters[LANGUAGE_USED("en")] = 5
+        counters[LANGUAGE_USED(Locale.forLanguageTag("en").toPlatform())] = 5
         assertEquals(1, UserActivity(counters).languagesUsed)
 
-        counters[LANGUAGE_USED("fr")] = 3
+        counters[LANGUAGE_USED(Locale.forLanguageTag("fr").toPlatform())] = 3
         assertEquals(2, UserActivity(counters).languagesUsed)
 
-        counters[LANGUAGE_USED("es")] = 0
+        counters[LANGUAGE_USED(Locale.forLanguageTag("es").toPlatform())] = 0
         assertEquals(2, UserActivity(counters).languagesUsed)
 
         counters[TOOL_OPEN("lessonhs")] = 11
@@ -110,7 +112,7 @@ class UserActivityTest {
         counters[SESSION] = 3
         assertEquals(3, UserActivity(counters).sessions)
 
-        counters[LANGUAGE_USED("fr")] = 3
+        counters[LANGUAGE_USED(Locale.forLanguageTag("fr").toPlatform())] = 3
         assertEquals(3, UserActivity(counters).sessions)
     }
 

--- a/module/user-activity/src/commonTest/kotlin/org/cru/godtools/shared/user/activity/model/UserActivityTest.kt
+++ b/module/user-activity/src/commonTest/kotlin/org/cru/godtools/shared/user/activity/model/UserActivityTest.kt
@@ -113,4 +113,9 @@ class UserActivityTest {
         counters[LANGUAGE_USED("fr")] = 3
         assertEquals(3, UserActivity(counters).sessions)
     }
+
+    @Test
+    fun testEquals() {
+        assertEquals(UserActivity(emptyMap()), UserActivity(emptyMap()))
+    }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,6 +18,7 @@ dependencyResolutionManagement {
     }
 }
 
+include("module:common")
 include("module:parser")
 include("module:parser-expressions")
 include("module:state")


### PR DESCRIPTION
This PR adds a `badges` property to the `UserActivity` model that contains a list of `Badge` objects that indicate if the badge has been earned yet, and if it's not earned yet it will contain the current progress of the badge.