### PR TITLE
enable IR for Kotlin/JS

### DIFF
--- a/buildSrc/src/main/kotlin/TargetsConfig.kt
+++ b/buildSrc/src/main/kotlin/TargetsConfig.kt
@@ -35,7 +35,7 @@ fun KotlinMultiplatformExtension.configureIosTargets() {
 }
 
 fun KotlinMultiplatformExtension.configureJsTargets() {
-    js {
+    js(IR) {
         nodejs { copyTestResources() }
     }
 }

--- a/buildSrc/src/main/kotlin/TargetsConfig.kt
+++ b/buildSrc/src/main/kotlin/TargetsConfig.kt
@@ -35,8 +35,8 @@ fun KotlinMultiplatformExtension.configureIosTargets() {
 }
 
 fun KotlinMultiplatformExtension.configureJsTargets() {
-    js(IR) {
-        nodejs { copyTestResources() }
+    js {
+        nodejs()
     }
 }
 
@@ -58,22 +58,3 @@ private fun KotlinNativeTarget.copyTestResources() {
         }
 }
 // endregion iOS Test Resources
-
-// region Js Test Resources
-private fun KotlinJsSubTargetDsl.copyTestResources() {
-    testTask {
-        // TODO: copy resources out of processedResources instead.
-        val source = project.file("src/commonTest/resources").takeIf { it.exists() && it.isDirectory }
-            ?: return@testTask
-
-        val compileTask = compilation.compileKotlinTaskProvider.get()
-        val target = compileTask.outputFileProperty.get().resolve("../../resources").normalize()
-        compileTask.doLast { source.copyRecursively(target = target, overwrite = true) }
-
-        // add target resources directory to appropriate task inputs/outputs
-        compileTask.inputs.dir(source)
-        compileTask.outputs.dir(target)
-        inputs.dir(target)
-    }
-}
-// endregion Js Test Resources

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,7 @@ org.gradle.jvmargs=-Xmx4g
 org.gradle.parallel=true
 
 kotlin.code.style=official
+kotlin.js.compiler=ir
 kotlin.native.binary.memoryModel=experimental
 
 android.useAndroidX=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ fluidLocale = "0.12.0"
 gtoSupport = "3.14.0-SNAPSHOT"
 kotlin = "1.7.21"
 kotlinCoroutines = "1.6.4"
+goncalossilvaResources = "0.2.2"
 ktlint = "0.42.1"
 napier = "2.6.1"
 okio = "3.2.0"
@@ -23,6 +24,7 @@ antlr-kotlin-runtime = { module = "org.cru.mobile.fork.antlr-kotlin:antlr-kotlin
 colormath = { module = "com.github.ajalt.colormath:colormath", version.ref = "colormath" }
 colormath-android-colorint = { module = "com.github.ajalt.colormath.extensions:colormath-ext-android-colorint", version.ref = "colormath" }
 fluidLocale = { module = "io.fluidsonic.locale:fluid-locale", version.ref = "fluidLocale" }
+goncalossilvaResources = { module = "com.goncalossilva:resources", version.ref = "goncalossilvaResources" }
 gtoSupport-androidx-annotation = { module = "org.ccci.gto.android:gto-support-androidx-annotation", version.ref = "gtoSupport" }
 gtoSupport-androidx-test-junit = { module = "org.ccci.gto.android:gto-support-androidx-test-junit", version.ref = "gtoSupport" }
 gtoSupport-fluidsonic-locale = { module = "org.ccci.gto.android:gto-support-fluidsonic-locale", version.ref = "gtoSupport" }
@@ -30,8 +32,6 @@ kotlin-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-co
 kotlin-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinCoroutines" }
 kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 napier = { module = "io.github.aakira:napier", version.ref = "napier" }
-okio-js = { module = "com.squareup.okio:okio-js", version.ref = "okio" }
-okio-nodefilesystem = { module = "com.squareup.okio:okio-nodefilesystem", version.ref = "okio" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 turbine = "app.cash.turbine:turbine:0.8.0"
 
@@ -39,6 +39,7 @@ turbine = "app.cash.turbine:turbine:0.8.0"
 ktlint = { module = "com.pinterest:ktlint", version.ref = "ktlint" }
 
 [plugins]
+goncalossilvaResources = { id = "com.goncalossilva.resources", version.ref = "goncalossilvaResources" }
 grgit = { id = "org.ajoberstar.grgit", version = "5.0.0" }
 kotlin-kover = { id = "org.jetbrains.kotlinx.kover", version = "0.6.1" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version = "11.0.0" }

--- a/module/parser/build.gradle.kts
+++ b/module/parser/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     kotlin("multiplatform")
     id("com.android.library")
     alias(libs.plugins.kotlin.kover)
+    alias(libs.plugins.goncalossilvaResources)
 }
 
 android {
@@ -48,8 +49,7 @@ kotlin {
         }
         val jsTest by getting {
             dependencies {
-                implementation(libs.okio.js)
-                implementation(libs.okio.nodefilesystem)
+                implementation(libs.goncalossilvaResources)
             }
         }
     }

--- a/module/parser/src/jsTest/kotlin/org/cru/godtools/shared/tool/parser/internal/UsesResources.js.kt
+++ b/module/parser/src/jsTest/kotlin/org/cru/godtools/shared/tool/parser/internal/UsesResources.js.kt
@@ -1,22 +1,18 @@
 package org.cru.godtools.shared.tool.parser.internal
 
-import okio.FileNotFoundException
-import okio.NodeJsFileSystem
-import okio.Path.Companion.toPath
-import okio.buffer
+import com.goncalossilva.resources.Resource
 import org.cru.godtools.shared.tool.parser.xml.JsXmlPullParserFactory
 import org.cru.godtools.shared.tool.parser.xml.XmlPullParserFactory
 
 // HACK: this is currently hardcoded, hopefully at some point there will be a better way to access resources
-private val RESOURCES_ROOT = "resources".toPath()
+private const val RESOURCES_ROOT = "src/commonTest/resources/org/cru/godtools/shared/tool/parser"
 
 internal actual val UsesResources.TEST_XML_PULL_PARSER_FACTORY: XmlPullParserFactory
     get() = object : JsXmlPullParserFactory() {
         override fun readFile(fileName: String) = try {
-            val basePath = RESOURCES_ROOT / "org/cru/godtools/shared/tool/parser"
-            val path = resourcesDir?.let { basePath / it } ?: basePath
-            NodeJsFileSystem.source(path / fileName).buffer().readUtf8()
-        } catch (e: FileNotFoundException) {
+            val path = resourcesDir?.let { "$RESOURCES_ROOT/$it" } ?: RESOURCES_ROOT
+            Resource("$path/$fileName").readText()
+        } catch (e: RuntimeException) {
             null
         }
     }


### PR DESCRIPTION
This switches from the legacy Kotlin/JS compiler to the new IR Kotlin/JS compiler. This was one of the things blocking us from using this library on knowgod.com