### PR TITLE
GT-1866 Define user activity colors centrally

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ gtoSupport-fluidsonic-locale = { module = "org.ccci.gto.android:gto-support-flui
 kotlin-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinCoroutines" }
 kotlin-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinCoroutines" }
 kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+materialColorUtilities = "org.cru.mobile.fork.material-color-utilities:material-color-utilities:0.2.0_75"
 napier = { module = "io.github.aakira:napier", version.ref = "napier" }
 okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ antlr-kotlin-gradle = { module = "com.strumenta.antlr-kotlin:antlr-kotlin-gradle
 antlr-kotlin-runtime = { module = "org.cru.mobile.fork.antlr-kotlin:antlr-kotlin-runtime", version.ref = "antlr-kotlin-fork" }
 colormath = { module = "com.github.ajalt.colormath:colormath", version.ref = "colormath" }
 colormath-android-colorint = { module = "com.github.ajalt.colormath.extensions:colormath-ext-android-colorint", version.ref = "colormath" }
+colormath-jetpack-compose = { module = "com.github.ajalt.colormath.extensions:colormath-ext-jetpack-compose", version.ref = "colormath" }
 fluidLocale = { module = "io.fluidsonic.locale:fluid-locale", version.ref = "fluidLocale" }
 goncalossilvaResources = { module = "com.goncalossilva:resources", version.ref = "goncalossilvaResources" }
 gtoSupport-androidx-annotation = { module = "org.ccci.gto.android:gto-support-androidx-annotation", version.ref = "gtoSupport" }

--- a/module/common/build.gradle.kts
+++ b/module/common/build.gradle.kts
@@ -16,6 +16,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
+                implementation(libs.colormath)
                 implementation(libs.napier)
             }
         }

--- a/module/common/build.gradle.kts
+++ b/module/common/build.gradle.kts
@@ -20,5 +20,10 @@ kotlin {
                 implementation(libs.napier)
             }
         }
+        val androidMain by getting {
+            dependencies {
+                api(libs.colormath.jetpack.compose)
+            }
+        }
     }
 }

--- a/module/common/src/androidMain/kotlin/org/cru/godtools/shared/common/model/PlatformColor.android.kt
+++ b/module/common/src/androidMain/kotlin/org/cru/godtools/shared/common/model/PlatformColor.android.kt
@@ -1,0 +1,11 @@
+package org.cru.godtools.shared.common.model
+
+import com.github.ajalt.colormath.Color
+import com.github.ajalt.colormath.extensions.android.composecolor.toComposeColor
+
+// HACK: Suppress expect/actual errors as workaround for differences between Jetpack Compose Color and iOS UIColor
+//       see: https://discuss.kotlinlang.org/t/feature-request-typealias-for-expected-types/20054/4
+@Suppress("ACTUAL_WITHOUT_EXPECT")
+actual typealias PlatformColor = androidx.compose.ui.graphics.Color
+
+actual fun Color.toPlatformColor() = toComposeColor()

--- a/module/common/src/commonMain/kotlin/org/cru/godtools/shared/common/model/PlatformColor.kt
+++ b/module/common/src/commonMain/kotlin/org/cru/godtools/shared/common/model/PlatformColor.kt
@@ -1,0 +1,7 @@
+package org.cru.godtools.shared.common.model
+
+import com.github.ajalt.colormath.Color
+
+expect class PlatformColor
+
+expect fun Color.toPlatformColor(): PlatformColor

--- a/module/common/src/commonMain/kotlin/org/cru/godtools/shared/common/model/ThemeType.kt
+++ b/module/common/src/commonMain/kotlin/org/cru/godtools/shared/common/model/ThemeType.kt
@@ -1,0 +1,3 @@
+package org.cru.godtools.shared.common.model
+
+enum class ThemeType { DARK, LIGHT }

--- a/module/common/src/iosMain/kotlin/org/cru/godtools/shared/common/internal/colormath/Color.kt
+++ b/module/common/src/iosMain/kotlin/org/cru/godtools/shared/common/internal/colormath/Color.kt
@@ -1,0 +1,28 @@
+package org.cru.godtools.shared.common.internal.colormath
+
+import com.github.ajalt.colormath.Color
+import com.github.ajalt.colormath.model.RGB
+import kotlinx.cinterop.DoubleVar
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.value
+import platform.UIKit.UIColor
+
+fun Color.toUIColor() = toSRGB().let {
+    UIColor(
+        red = it.r.toDouble(),
+        green = it.g.toDouble(),
+        blue = it.b.toDouble(),
+        alpha = alpha.toDouble()
+    )
+}
+
+fun UIColor.toColormathSRGB(): RGB = memScoped {
+    val red = alloc<DoubleVar>()
+    val green = alloc<DoubleVar>()
+    val blue = alloc<DoubleVar>()
+    val alpha = alloc<DoubleVar>()
+    getRed(red.ptr, green.ptr, blue.ptr, alpha.ptr)
+    return RGB(red.value, green.value, blue.value, alpha.value)
+}

--- a/module/common/src/iosMain/kotlin/org/cru/godtools/shared/common/model/PlatformColor.ios.kt
+++ b/module/common/src/iosMain/kotlin/org/cru/godtools/shared/common/model/PlatformColor.ios.kt
@@ -1,0 +1,10 @@
+package org.cru.godtools.shared.common.model
+
+import com.github.ajalt.colormath.Color
+import org.cru.godtools.shared.common.internal.colormath.toUIColor
+import platform.UIKit.UIColor
+
+@Suppress("CONFLICTING_OVERLOADS")
+actual typealias PlatformColor = UIColor
+
+actual fun Color.toPlatformColor() = toUIColor()

--- a/module/common/src/jsMain/kotlin/org/cru/godtools/shared/common/model/PlatformColor.js.kt
+++ b/module/common/src/jsMain/kotlin/org/cru/godtools/shared/common/model/PlatformColor.js.kt
@@ -1,0 +1,13 @@
+package org.cru.godtools.shared.common.model
+
+import com.github.ajalt.colormath.Color
+import com.github.ajalt.colormath.RenderCondition
+import com.github.ajalt.colormath.formatCssString
+
+actual typealias PlatformColor = String
+
+actual fun Color.toPlatformColor() = formatCssString(
+    renderAlpha = RenderCondition.ALWAYS,
+    legacyFormat = true,
+    legacyName = true
+)

--- a/module/parser/src/iosMain/kotlin/org/cru/godtools/shared/tool/parser/model/PlatformColor.ios.kt
+++ b/module/parser/src/iosMain/kotlin/org/cru/godtools/shared/tool/parser/model/PlatformColor.ios.kt
@@ -1,27 +1,12 @@
 package org.cru.godtools.shared.tool.parser.model
 
 import com.github.ajalt.colormath.model.RGB
-import kotlinx.cinterop.DoubleVar
-import kotlinx.cinterop.alloc
-import kotlinx.cinterop.memScoped
-import kotlinx.cinterop.ptr
-import kotlinx.cinterop.value
+import org.cru.godtools.shared.common.internal.colormath.toColormathSRGB
+import org.cru.godtools.shared.common.internal.colormath.toUIColor
 import platform.UIKit.UIColor
 
 @Suppress("CONFLICTING_OVERLOADS")
 actual typealias PlatformColor = UIColor
 
-internal actual fun RGB.toPlatformColor() = UIColor(
-    red = r.toDouble(),
-    green = g.toDouble(),
-    blue = b.toDouble(),
-    alpha = alpha.toDouble()
-)
-internal actual fun PlatformColor.toRGB(): RGB = memScoped {
-    val red = alloc<DoubleVar>()
-    val green = alloc<DoubleVar>()
-    val blue = alloc<DoubleVar>()
-    val alpha = alloc<DoubleVar>()
-    getRed(red.ptr, green.ptr, blue.ptr, alpha.ptr)
-    return RGB(red.value, green.value, blue.value, alpha.value)
-}
+internal actual fun RGB.toPlatformColor() = toUIColor()
+internal actual fun PlatformColor.toRGB() = toColormathSRGB()

--- a/module/user-activity/build.gradle.kts
+++ b/module/user-activity/build.gradle.kts
@@ -16,10 +16,16 @@ kotlin {
     configureCommonSourceSets()
 
     sourceSets {
+        val androidMain by getting {
+            dependencies {
+                implementation(libs.materialColorUtilities)
+            }
+        }
         val commonMain by getting {
             dependencies {
                 implementation(project(":module:common"))
 
+                implementation(libs.colormath)
                 implementation(libs.fluidLocale)
                 implementation(libs.gtoSupport.androidx.annotation)
                 implementation(libs.gtoSupport.fluidsonic.locale)

--- a/module/user-activity/src/androidMain/kotlin/org/cru/godtools/shared/user/activity/model/IconColors.android.kt
+++ b/module/user-activity/src/androidMain/kotlin/org/cru/godtools/shared/user/activity/model/IconColors.android.kt
@@ -1,0 +1,15 @@
+package org.cru.godtools.shared.user.activity.model
+
+import com.github.ajalt.colormath.Color
+import com.github.ajalt.colormath.model.RGBInt
+import palettes.TonalPalette
+
+internal actual fun IconColors(base: Color): IconColors {
+    val palette = TonalPalette.fromInt(RGBInt.convert(base).argb.toInt())
+    return IconColors(
+        light = RGBInt(palette.tone(40).toUInt()),
+        containerLight = RGBInt(palette.tone(90).toUInt()),
+        dark = RGBInt(palette.tone(80).toUInt()),
+        containerDark = RGBInt(palette.tone(30).toUInt()),
+    )
+}

--- a/module/user-activity/src/commonMain/kotlin/org/cru/godtools/shared/user/activity/model/Badge.kt
+++ b/module/user-activity/src/commonMain/kotlin/org/cru/godtools/shared/user/activity/model/Badge.kt
@@ -1,14 +1,22 @@
 package org.cru.godtools.shared.user.activity.model
 
+import com.github.ajalt.colormath.model.RGB
 import org.ccci.gto.support.androidx.annotation.VisibleForTesting
 
-data class Badge(val type: BadgeType, val progress: Int, val target: Int) {
-    enum class BadgeType(@VisibleForTesting internal vararg val variants: Int) {
-        TOOLS_OPENED(1, 5, 10),
-        LESSONS_COMPLETED(1, 5, 10),
-        ARTICLES_OPENED(1, 5, 10),
-        IMAGES_SHARED(1, 5, 10),
-        TIPS_COMPLETED(5, 10, 20),
+data class Badge internal constructor(val type: BadgeType, val progress: Int, val target: Int) {
+    internal companion object {
+        val COLORS_NOT_EARNED = IconColors(base = RGB("#d5d5d5")).alpha(0.38f)
+    }
+
+    enum class BadgeType(
+        @VisibleForTesting internal vararg val variants: Int,
+        internal val colors: IconColors
+    ) {
+        TOOLS_OPENED(1, 5, 10, colors = IconColors(base = RGB("#62CCF3"))),
+        LESSONS_COMPLETED(1, 5, 10, colors = IconColors(base = RGB("#A4D7C8"))),
+        ARTICLES_OPENED(1, 5, 10, colors = IconColors(base = RGB("#292C67"))),
+        IMAGES_SHARED(1, 5, 10, colors = IconColors(base = RGB("#A43E95"))),
+        TIPS_COMPLETED(5, 10, 20, colors = IconColors(base = RGB("#E53660"))),
         ;
 
         internal fun createBadges(progress: Int) =
@@ -16,4 +24,5 @@ data class Badge(val type: BadgeType, val progress: Int, val target: Int) {
     }
 
     val isEarned get() = progress >= target
+    val colors get() = if (isEarned) type.colors else COLORS_NOT_EARNED
 }

--- a/module/user-activity/src/commonMain/kotlin/org/cru/godtools/shared/user/activity/model/IconColors.kt
+++ b/module/user-activity/src/commonMain/kotlin/org/cru/godtools/shared/user/activity/model/IconColors.kt
@@ -1,0 +1,32 @@
+package org.cru.godtools.shared.user.activity.model
+
+import com.github.ajalt.colormath.Color
+import org.cru.godtools.shared.common.model.ThemeType
+import org.cru.godtools.shared.common.model.toPlatformColor
+
+data class IconColors internal constructor(
+    private val light: Color,
+    private val dark: Color,
+    private val containerLight: Color,
+    private val containerDark: Color
+) {
+    fun color(mode: ThemeType) = when (mode) {
+        ThemeType.LIGHT -> light
+        ThemeType.DARK -> dark
+    }.toPlatformColor()
+
+    fun containerColor(mode: ThemeType) = when (mode) {
+        ThemeType.LIGHT -> containerLight
+        ThemeType.DARK -> containerDark
+    }.toPlatformColor()
+
+    override fun toString() = "IconColors(" +
+        "light=${light.toSRGB().toHex()}, " +
+        "dark=${dark.toSRGB().toHex()}, " +
+        "containerLight=${containerLight.toSRGB().toHex()}, " +
+        "containerDark=${containerDark.toSRGB().toHex()}" +
+        ")"
+}
+
+// TODO: Utilize material-color-utils for this if it ever has a kotlin multiplatform version
+internal expect fun IconColors(base: Color): IconColors

--- a/module/user-activity/src/commonMain/kotlin/org/cru/godtools/shared/user/activity/model/IconColors.kt
+++ b/module/user-activity/src/commonMain/kotlin/org/cru/godtools/shared/user/activity/model/IconColors.kt
@@ -1,14 +1,19 @@
 package org.cru.godtools.shared.user.activity.model
 
 import com.github.ajalt.colormath.Color
+import org.ccci.gto.support.androidx.annotation.VisibleForTesting
 import org.cru.godtools.shared.common.model.ThemeType
 import org.cru.godtools.shared.common.model.toPlatformColor
 
 data class IconColors internal constructor(
-    private val light: Color,
-    private val dark: Color,
-    private val containerLight: Color,
-    private val containerDark: Color
+    @VisibleForTesting
+    internal val light: Color,
+    @VisibleForTesting
+    internal val dark: Color,
+    @VisibleForTesting
+    internal val containerLight: Color,
+    @VisibleForTesting
+    internal val containerDark: Color,
 ) {
     fun color(mode: ThemeType) = when (mode) {
         ThemeType.LIGHT -> light
@@ -19,6 +24,13 @@ data class IconColors internal constructor(
         ThemeType.LIGHT -> containerLight
         ThemeType.DARK -> containerDark
     }.toPlatformColor()
+
+    internal fun alpha(alpha: Float) = IconColors(
+        light = light.toSRGB().copy(alpha = alpha),
+        dark = dark.toSRGB().copy(alpha = alpha),
+        containerLight = containerLight.toSRGB().copy(alpha = alpha),
+        containerDark = containerDark.toSRGB().copy(alpha = alpha),
+    )
 
     override fun toString() = "IconColors(" +
         "light=${light.toSRGB().toHex()}, " +

--- a/module/user-activity/src/commonMain/kotlin/org/cru/godtools/shared/user/activity/model/UserActivity.kt
+++ b/module/user-activity/src/commonMain/kotlin/org/cru/godtools/shared/user/activity/model/UserActivity.kt
@@ -1,5 +1,6 @@
 package org.cru.godtools.shared.user.activity.model
 
+import com.github.ajalt.colormath.model.RGB
 import org.cru.godtools.shared.user.activity.UserCounterNames.ARTICLE_OPENS_PREFIX
 import org.cru.godtools.shared.user.activity.UserCounterNames.IMAGE_SHARED
 import org.cru.godtools.shared.user.activity.UserCounterNames.LANGUAGE_USED_PREFIX
@@ -41,5 +42,14 @@ data class UserActivity private constructor(
                 BadgeType.ARTICLES_OPENED.createBadges(counters.count(ARTICLE_OPENS_PREFIX)) +
                 BadgeType.IMAGES_SHARED.createBadges(counters[IMAGE_SHARED] ?: 0) +
                 BadgeType.TIPS_COMPLETED.createBadges(counters[TIPS_COMPLETED] ?: 0)
+    }
+
+    object Colors {
+        val toolOpens = IconColors(base = RGB("#05699B"))
+        val lessonCompletions = IconColors(base = RGB("#A4D7C8"))
+        val screenShares = IconColors(base = RGB("#E55B36"))
+        val linksShared = IconColors(base = RGB("#2F3676"))
+        val languagesUsed = IconColors(base = RGB("#CEFFC1"))
+        val sessions = IconColors(base = RGB("#E0CE26"))
     }
 }

--- a/module/user-activity/src/commonTest/kotlin/org/cru/godtools/shared/user/activity/internal/test/Assertions.kt
+++ b/module/user-activity/src/commonTest/kotlin/org/cru/godtools/shared/user/activity/internal/test/Assertions.kt
@@ -1,0 +1,16 @@
+package org.cru.godtools.shared.user.activity.internal.test
+
+import com.github.ajalt.colormath.Color
+import com.github.ajalt.colormath.model.RGBInt
+import org.cru.godtools.shared.user.activity.model.IconColors
+
+internal fun assertEquals(expected: Color, actual: Color) {
+    kotlin.test.assertEquals(RGBInt.convert(expected), RGBInt.convert(actual))
+}
+
+internal fun assertEquals(expected: IconColors, actual: IconColors) {
+    assertEquals(expected.light, actual.light)
+    assertEquals(expected.dark, actual.dark)
+    assertEquals(expected.containerLight, actual.containerLight)
+    assertEquals(expected.containerDark, actual.containerDark)
+}

--- a/module/user-activity/src/commonTest/kotlin/org/cru/godtools/shared/user/activity/model/BadgeTest.kt
+++ b/module/user-activity/src/commonTest/kotlin/org/cru/godtools/shared/user/activity/model/BadgeTest.kt
@@ -1,5 +1,7 @@
 package org.cru.godtools.shared.user.activity.model
 
+import com.github.ajalt.colormath.model.RGB
+import org.cru.godtools.shared.user.activity.internal.test.assertEquals
 import org.cru.godtools.shared.user.activity.model.Badge.BadgeType
 import kotlin.test.Test
 import kotlin.test.assertFalse
@@ -11,5 +13,27 @@ class BadgeTest {
         assertFalse(Badge(BadgeType.TOOLS_OPENED, 4, 5).isEarned)
         assertTrue(Badge(BadgeType.TOOLS_OPENED, 5, 5).isEarned)
         assertTrue(Badge(BadgeType.TOOLS_OPENED, 6, 5).isEarned)
+    }
+
+    @Test
+    fun testColors() {
+        val notEarned = Badge(BadgeType.TOOLS_OPENED, 1, 2)
+        assertEquals(Badge.COLORS_NOT_EARNED, notEarned.colors)
+
+        val earned = Badge(BadgeType.TOOLS_OPENED, 2, 2)
+        assertEquals(BadgeType.TOOLS_OPENED.colors, earned.colors)
+    }
+
+    @Test
+    fun testColorsNotEarned() {
+        assertEquals(
+            IconColors(
+                light = RGB("#5d5e5f61"),
+                dark = RGB("#c6c6c661"),
+                containerLight = RGB("#e2e2e261"),
+                containerDark = RGB("#45474761"),
+            ),
+            Badge.COLORS_NOT_EARNED
+        )
     }
 }

--- a/module/user-activity/src/commonTest/kotlin/org/cru/godtools/shared/user/activity/model/BadgeTypeTest.kt
+++ b/module/user-activity/src/commonTest/kotlin/org/cru/godtools/shared/user/activity/model/BadgeTypeTest.kt
@@ -1,5 +1,7 @@
 package org.cru.godtools.shared.user.activity.model
 
+import com.github.ajalt.colormath.model.RGB
+import org.cru.godtools.shared.user.activity.internal.test.assertEquals
 import org.cru.godtools.shared.user.activity.model.Badge.BadgeType
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -18,5 +20,54 @@ class BadgeTypeTest {
             assertEquals(progress.coerceAtMost(size), badge.progress)
             assertEquals(size, badge.target)
         }
+    }
+
+    @Test
+    fun testColors() {
+        assertEquals(
+            IconColors(
+                light = RGB("#006782"),
+                dark = RGB("#6ad3fa"),
+                containerLight = RGB("#baeaff"),
+                containerDark = RGB("#004d62"),
+            ),
+            BadgeType.TOOLS_OPENED.colors
+        )
+        assertEquals(
+            IconColors(
+                light = RGB("#36675b"),
+                dark = RGB("#9ed1c2"),
+                containerLight = RGB("#b9edde"),
+                containerDark = RGB("#1d4f44"),
+            ),
+            BadgeType.LESSONS_COMPLETED.colors
+        )
+        assertEquals(
+            IconColors(
+                light = RGB("#555996"),
+                dark = RGB("#bfc1ff"),
+                containerLight = RGB("#e1e0ff"),
+                containerDark = RGB("#3e417d"),
+            ),
+            BadgeType.ARTICLES_OPENED.colors
+        )
+        assertEquals(
+            IconColors(
+                light = RGB("#9a358c"),
+                dark = RGB("#ffaceb"),
+                containerLight = RGB("#ffd7f1"),
+                containerDark = RGB("#7d1972"),
+            ),
+            BadgeType.IMAGES_SHARED.colors
+        )
+        assertEquals(
+            IconColors(
+                light = RGB("#bb0d44"),
+                dark = RGB("#ffb2bb"),
+                containerLight = RGB("#ffd9dc"),
+                containerDark = RGB("#910032"),
+            ),
+            BadgeType.TIPS_COMPLETED.colors
+        )
     }
 }

--- a/module/user-activity/src/commonTest/kotlin/org/cru/godtools/shared/user/activity/model/IconColorsTest.kt
+++ b/module/user-activity/src/commonTest/kotlin/org/cru/godtools/shared/user/activity/model/IconColorsTest.kt
@@ -1,0 +1,46 @@
+package org.cru.godtools.shared.user.activity.model
+
+import com.github.ajalt.colormath.model.RGB
+import org.cru.godtools.shared.common.model.ThemeType
+import org.cru.godtools.shared.common.model.toPlatformColor
+import org.cru.godtools.shared.user.activity.internal.test.assertEquals
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class IconColorsTest {
+    private companion object {
+        val RED = RGB("F00")
+        val GREEN = RGB("0F0")
+        val BLUE = RGB("00F")
+        val BLACK = RGB("000")
+    }
+
+    @Test
+    fun testIconColorsTonalPaletteGeneration() {
+        assertEquals(
+            IconColors(
+                light = RGB("#006494"),
+                dark = RGB("#8fcdff"),
+                containerLight = RGB("#cbe6ff"),
+                containerDark = RGB("#004b71"),
+            ),
+            IconColors(RGB("#05699B"))
+        )
+    }
+
+    @Test
+    fun testColor() {
+        val colors = IconColors(light = RED, dark = GREEN, containerLight = BLACK, containerDark = BLACK)
+
+        assertEquals(RED.toPlatformColor(), colors.color(ThemeType.LIGHT))
+        assertEquals(GREEN.toPlatformColor(), colors.color(ThemeType.DARK))
+    }
+
+    @Test
+    fun testContainerColor() {
+        val colors = IconColors(light = BLACK, dark = BLACK, containerLight = RED, containerDark = GREEN)
+
+        assertEquals(RED.toPlatformColor(), colors.containerColor(ThemeType.LIGHT))
+        assertEquals(GREEN.toPlatformColor(), colors.containerColor(ThemeType.DARK))
+    }
+}

--- a/module/user-activity/src/commonTest/kotlin/org/cru/godtools/shared/user/activity/model/IconColorsTest.kt
+++ b/module/user-activity/src/commonTest/kotlin/org/cru/godtools/shared/user/activity/model/IconColorsTest.kt
@@ -43,4 +43,16 @@ class IconColorsTest {
         assertEquals(RED.toPlatformColor(), colors.containerColor(ThemeType.LIGHT))
         assertEquals(GREEN.toPlatformColor(), colors.containerColor(ThemeType.DARK))
     }
+
+    @Test
+    fun testAlpha() {
+        val alpha = 0.5f
+        val colors = IconColors(light = RED, dark = GREEN, containerLight = BLUE, containerDark = BLACK)
+        val alphaColors = colors.alpha(alpha)
+
+        assertEquals(alpha, alphaColors.light.alpha)
+        assertEquals(alpha, alphaColors.dark.alpha)
+        assertEquals(alpha, alphaColors.containerLight.alpha)
+        assertEquals(alpha, alphaColors.containerDark.alpha)
+    }
 }

--- a/module/user-activity/src/commonTest/kotlin/org/cru/godtools/shared/user/activity/model/UserActivityColorsTest.kt
+++ b/module/user-activity/src/commonTest/kotlin/org/cru/godtools/shared/user/activity/model/UserActivityColorsTest.kt
@@ -1,0 +1,65 @@
+package org.cru.godtools.shared.user.activity.model
+
+import com.github.ajalt.colormath.model.RGB
+import org.cru.godtools.shared.user.activity.internal.test.assertEquals
+import kotlin.test.Test
+
+class UserActivityColorsTest {
+    @Test
+    fun testColors() {
+        assertEquals(
+            IconColors(
+                light = RGB("#006494"),
+                dark = RGB("#8fcdff"),
+                containerLight = RGB("#cbe6ff"),
+                containerDark = RGB("#004b71"),
+            ),
+            UserActivity.Colors.toolOpens
+        )
+        assertEquals(
+            IconColors(
+                light = RGB("#36675b"),
+                dark = RGB("#9ed1c2"),
+                containerLight = RGB("#b9edde"),
+                containerDark = RGB("#1d4f44"),
+            ),
+            UserActivity.Colors.lessonCompletions
+        )
+        assertEquals(
+            IconColors(
+                light = RGB("#ad3310"),
+                dark = RGB("#ffb4a1"),
+                containerLight = RGB("#ffdbd1"),
+                containerDark = RGB("#881f00"),
+            ),
+            UserActivity.Colors.screenShares
+        )
+        assertEquals(
+            IconColors(
+                light = RGB("#52599b"),
+                dark = RGB("#bdc2ff"),
+                containerLight = RGB("#dfe0ff"),
+                containerDark = RGB("#3a4181"),
+            ),
+            UserActivity.Colors.linksShared
+        )
+        assertEquals(
+            IconColors(
+                light = RGB("#3e6838"),
+                dark = RGB("#a4d398"),
+                containerLight = RGB("#bfefb3"),
+                containerDark = RGB("#275023"),
+            ),
+            UserActivity.Colors.languagesUsed
+        )
+        assertEquals(
+            IconColors(
+                light = RGB("#695f00"),
+                dark = RGB("#dac91f"),
+                containerLight = RGB("#f8e53f"),
+                containerDark = RGB("#4f4800"),
+            ),
+            UserActivity.Colors.sessions
+        )
+    }
+}

--- a/module/user-activity/src/iosMain/kotlin/org/cru/godtools/shared/user/activity/model/IconColors.ios.kt
+++ b/module/user-activity/src/iosMain/kotlin/org/cru/godtools/shared/user/activity/model/IconColors.ios.kt
@@ -1,0 +1,45 @@
+package org.cru.godtools.shared.user.activity.model
+
+import com.github.ajalt.colormath.Color
+import com.github.ajalt.colormath.model.RGB
+
+// TODO: Until material-color-utils has an ObjC/Kotlin implementation, we just store the generated values
+internal actual fun IconColors(base: Color): IconColors = when (base.toSRGB()) {
+    RGB("#05699B") -> IconColors(
+        light = RGB("#006494"),
+        dark = RGB("#8fcdff"),
+        containerLight = RGB("#cbe6ff"),
+        containerDark = RGB("#004b71"),
+    )
+    RGB("#2F3676") -> IconColors(
+        light = RGB("#52599b"),
+        dark = RGB("#bdc2ff"),
+        containerLight = RGB("#dfe0ff"),
+        containerDark = RGB("#3a4181"),
+    )
+    RGB("#A4D7C8") -> IconColors(
+        light = RGB("#36675b"),
+        dark = RGB("#9ed1c2"),
+        containerLight = RGB("#b9edde"),
+        containerDark = RGB("#1d4f44"),
+    )
+    RGB("#CEFFC1") -> IconColors(
+        light = RGB("#3e6838"),
+        dark = RGB("#a4d398"),
+        containerLight = RGB("#bfefb3"),
+        containerDark = RGB("#275023"),
+    )
+    RGB("#E0CE26") -> IconColors(
+        light = RGB("#695f00"),
+        dark = RGB("#dac91f"),
+        containerLight = RGB("#f8e53f"),
+        containerDark = RGB("#4f4800"),
+    )
+    RGB("#E55B36") -> IconColors(
+        light = RGB("#ad3310"),
+        dark = RGB("#ffb4a1"),
+        containerLight = RGB("#ffdbd1"),
+        containerDark = RGB("#881f00"),
+    )
+    else -> TODO("Unsupported color: ${base.toSRGB().toHex()}")
+}

--- a/module/user-activity/src/iosMain/kotlin/org/cru/godtools/shared/user/activity/model/IconColors.ios.kt
+++ b/module/user-activity/src/iosMain/kotlin/org/cru/godtools/shared/user/activity/model/IconColors.ios.kt
@@ -11,11 +11,29 @@ internal actual fun IconColors(base: Color): IconColors = when (base.toSRGB()) {
         containerLight = RGB("#cbe6ff"),
         containerDark = RGB("#004b71"),
     )
+    RGB("#292c67") -> IconColors(
+        light = RGB("#555996"),
+        dark = RGB("#bfc1ff"),
+        containerLight = RGB("#e1e0ff"),
+        containerDark = RGB("#3e417d"),
+    )
     RGB("#2F3676") -> IconColors(
         light = RGB("#52599b"),
         dark = RGB("#bdc2ff"),
         containerLight = RGB("#dfe0ff"),
         containerDark = RGB("#3a4181"),
+    )
+    RGB("#62CCF3") -> IconColors(
+        light = RGB("#006782"),
+        dark = RGB("#6ad3fa"),
+        containerLight = RGB("#baeaff"),
+        containerDark = RGB("#004d62"),
+    )
+    RGB("#A43E95") -> IconColors(
+        light = RGB("#9a358c"),
+        dark = RGB("#ffaceb"),
+        containerLight = RGB("#ffd7f1"),
+        containerDark = RGB("#7d1972"),
     )
     RGB("#A4D7C8") -> IconColors(
         light = RGB("#36675b"),
@@ -29,11 +47,23 @@ internal actual fun IconColors(base: Color): IconColors = when (base.toSRGB()) {
         containerLight = RGB("#bfefb3"),
         containerDark = RGB("#275023"),
     )
+    RGB("#d5d5d5") -> IconColors(
+        light = RGB("#5d5e5f"),
+        dark = RGB("#c6c6c6"),
+        containerLight = RGB("#e2e2e2"),
+        containerDark = RGB("#454747"),
+    )
     RGB("#E0CE26") -> IconColors(
         light = RGB("#695f00"),
         dark = RGB("#dac91f"),
         containerLight = RGB("#f8e53f"),
         containerDark = RGB("#4f4800"),
+    )
+    RGB("#E53660") -> IconColors(
+        light = RGB("#bb0d44"),
+        dark = RGB("#ffb2bb"),
+        containerLight = RGB("#ffd9dc"),
+        containerDark = RGB("#910032"),
     )
     RGB("#E55B36") -> IconColors(
         light = RGB("#ad3310"),

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,6 +9,7 @@ dependencyResolutionManagement {
             content {
                 includeGroup("org.ccci.gto.android")
                 includeGroup("org.cru.mobile.fork.antlr-kotlin")
+                includeGroup("org.cru.mobile.fork.material-color-utilities")
             }
         }
         google()


### PR DESCRIPTION
Update User Activity models to expose icon colors to use when coloring the various activity & badge icons.

on iOS they should be access like this:
```swift
UserActivity.Colors.shared.toolOpens.color(mode: .light)
UserActivity.Colors.shared.toolOpens.containerColor(mode: .light)

let userActivity = UserActivity()
userActivity.badge.colors.color(mode: .light)
userActivity.badge.colors.containerColor(mode: .light)
```