### PR TITLE
GT-1909 Support parsing & enforcing a limit on AnalyticsEvents

### DIFF
--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/AnalyticsEvent.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/AnalyticsEvent.kt
@@ -9,6 +9,7 @@ import org.cru.godtools.shared.tool.parser.model.AnalyticsEvent.Trigger.Companio
 import org.cru.godtools.shared.tool.parser.util.REGEX_SEQUENCE_SEPARATOR
 import org.cru.godtools.shared.tool.parser.xml.XmlPullParser
 import org.cru.godtools.shared.tool.parser.xml.parseChildren
+import org.cru.godtools.shared.tool.state.State
 
 private const val TAG = "XmlAnalyticsEvent"
 
@@ -113,6 +114,11 @@ class AnalyticsEvent : BaseModel {
 
     fun isTriggerType(vararg types: Trigger) = types.contains(trigger)
     fun isForSystem(system: System) = systems.contains(system)
+
+    fun shouldTrigger(state: State) = limit == null || id?.let { state.getTriggeredAnalyticsEventsCount(it) < limit } ?: true
+    fun recordTriggered(state: State) {
+        id?.let { state.recordTriggeredAnalyticsEvent(it) }
+    }
 
     enum class System {
         @Deprecated("Since 1/1/21, we no longer use Adobe analytics.")

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/AnalyticsEvent.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/AnalyticsEvent.kt
@@ -13,6 +13,7 @@ import org.cru.godtools.shared.tool.parser.xml.parseChildren
 private const val TAG = "XmlAnalyticsEvent"
 
 private const val XML_EVENT = "event"
+private const val XML_ID = "id"
 private const val XML_ACTION = "action"
 private const val XML_DELAY = "delay"
 private const val XML_SYSTEM = "system"
@@ -27,6 +28,7 @@ private const val XML_TRIGGER_CLICKED = "clicked"
 private const val XML_TRIGGER_SELECTED = "selected"
 private const val XML_TRIGGER_VISIBLE = "visible"
 private const val XML_TRIGGER_HIDDEN = "hidden"
+private const val XML_LIMIT = "limit"
 private const val XML_ATTRIBUTE = "attribute"
 private const val XML_ATTRIBUTE_KEY = "key"
 private const val XML_ATTRIBUTE_VALUE = "value"
@@ -47,19 +49,24 @@ class AnalyticsEvent : BaseModel {
         }
     }
 
+    private val _id: String?
+    internal val id get() = _id ?: action
     val action: String?
     val delay: Int
     val systems: Set<System>
     val trigger: Trigger
+    internal val limit: Int?
     val attributes: Map<String, String>
 
     internal constructor(parent: Base, parser: XmlPullParser) : super(parent) {
         parser.require(XmlPullParser.START_TAG, XMLNS_ANALYTICS, XML_EVENT)
 
+        _id = parser.getAttributeValue(XML_ID)
         action = parser.getAttributeValue(XML_ACTION)
         delay = parser.getAttributeValue(XML_DELAY)?.toIntOrNull() ?: 0
         systems = parser.getAttributeValue(XML_SYSTEM)?.toAnalyticsSystems().orEmpty()
         trigger = parser.getAttributeValue(XML_TRIGGER)?.toTrigger() ?: Trigger.DEFAULT
+        limit = parser.getAttributeValue(XML_LIMIT)?.toIntOrNull()
         attributes = buildMap {
             parser.parseChildren {
                 when (parser.namespace) {
@@ -87,16 +94,20 @@ class AnalyticsEvent : BaseModel {
     @RestrictTo(RestrictToScope.TESTS)
     constructor(
         parent: Base = Manifest(),
+        id: String? = null,
         action: String? = null,
         trigger: Trigger = Trigger.DEFAULT,
         delay: Int = 0,
         systems: Set<System> = emptySet(),
+        limit: Int? = null,
         attributes: Map<String, String> = emptyMap()
     ) : super(parent) {
+        _id = id
         this.action = action
         this.delay = delay
         this.systems = systems
         this.trigger = trigger
+        this.limit = limit
         this.attributes = attributes
     }
 

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/AnalyticsEvent.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/AnalyticsEvent.kt
@@ -52,7 +52,7 @@ class AnalyticsEvent : BaseModel {
 
     private val _id: String?
     internal val id get() = _id ?: action
-    val action: String?
+    val action: String
     val delay: Int
     val systems: Set<System>
     val trigger: Trigger
@@ -63,7 +63,7 @@ class AnalyticsEvent : BaseModel {
         parser.require(XmlPullParser.START_TAG, XMLNS_ANALYTICS, XML_EVENT)
 
         _id = parser.getAttributeValue(XML_ID)
-        action = parser.getAttributeValue(XML_ACTION)
+        action = parser.getAttributeValue(XML_ACTION).orEmpty()
         delay = parser.getAttributeValue(XML_DELAY)?.toIntOrNull() ?: 0
         systems = parser.getAttributeValue(XML_SYSTEM)?.toAnalyticsSystems().orEmpty()
         trigger = parser.getAttributeValue(XML_TRIGGER)?.toTrigger() ?: Trigger.DEFAULT
@@ -96,7 +96,7 @@ class AnalyticsEvent : BaseModel {
     constructor(
         parent: Base = Manifest(),
         id: String? = null,
-        action: String? = null,
+        action: String = "",
         trigger: Trigger = Trigger.DEFAULT,
         delay: Int = 0,
         systems: Set<System> = emptySet(),
@@ -115,10 +115,8 @@ class AnalyticsEvent : BaseModel {
     fun isTriggerType(vararg types: Trigger) = types.contains(trigger)
     fun isForSystem(system: System) = systems.contains(system)
 
-    fun shouldTrigger(state: State) = limit == null || id?.let { state.getTriggeredAnalyticsEventsCount(it) < limit } ?: true
-    fun recordTriggered(state: State) {
-        id?.let { state.recordTriggeredAnalyticsEvent(it) }
-    }
+    fun shouldTrigger(state: State) = limit == null || state.getTriggeredAnalyticsEventsCount(id) < limit
+    fun recordTriggered(state: State) = state.recordTriggeredAnalyticsEvent(id)
 
     enum class System {
         @Deprecated("Since 1/1/21, we no longer use Adobe analytics.")

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/AnalyticsEventTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/AnalyticsEventTest.kt
@@ -23,8 +23,8 @@ class AnalyticsEventTest : UsesResources() {
     @Test
     fun testParseAnalyticsEventDefaults() = runTest {
         val event = AnalyticsEvent(Manifest(), getTestXmlParser("analytics_event_defaults.xml"))
-        assertNull(event.id)
-        assertNull(event.action)
+        assertEquals("", event.id)
+        assertEquals("", event.action)
         assertTrue(event.isForSystem(AnalyticsEvent.System.APPSFLYER))
         AnalyticsEvent.System.values().filterNot { it == AnalyticsEvent.System.APPSFLYER }.forEach {
             assertFalse(event.isForSystem(it))
@@ -111,15 +111,6 @@ class AnalyticsEventTest : UsesResources() {
     @Test
     fun testShouldTriggerNoLimit() {
         val event = AnalyticsEvent(id = "id")
-        assertTrue(event.shouldTrigger(state))
-
-        repeat(50) { event.recordTriggered(state) }
-        assertTrue(event.shouldTrigger(state))
-    }
-
-    @Test
-    fun testShouldTriggerNoId() {
-        val event = AnalyticsEvent(limit = 1)
         assertTrue(event.shouldTrigger(state))
 
         repeat(50) { event.recordTriggered(state) }

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/AnalyticsEventTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/AnalyticsEventTest.kt
@@ -8,6 +8,7 @@ import org.cru.godtools.shared.tool.parser.internal.UsesResources
 import org.cru.godtools.shared.tool.parser.model.AnalyticsEvent.Companion.parseAnalyticsEvents
 import org.cru.godtools.shared.tool.parser.model.AnalyticsEvent.System.Companion.toAnalyticsSystems
 import org.cru.godtools.shared.tool.parser.model.AnalyticsEvent.Trigger.Companion.toTrigger
+import org.cru.godtools.shared.tool.state.State
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
@@ -88,4 +89,41 @@ class AnalyticsEventTest : UsesResources() {
         assertEquals("id", AnalyticsEvent(id = "id", action = "action").id)
     }
     // endregion Property: id
+
+    // region Record Triggered Events
+    private val state = State()
+
+    @Test
+    fun testShouldTrigger() {
+        val event = AnalyticsEvent(
+            id = "id",
+            limit = 2
+        )
+        assertTrue(event.shouldTrigger(state))
+
+        event.recordTriggered(state)
+        assertTrue(event.shouldTrigger(state))
+
+        event.recordTriggered(state)
+        assertFalse(event.shouldTrigger(state))
+    }
+
+    @Test
+    fun testShouldTriggerNoLimit() {
+        val event = AnalyticsEvent(id = "id")
+        assertTrue(event.shouldTrigger(state))
+
+        repeat(50) { event.recordTriggered(state) }
+        assertTrue(event.shouldTrigger(state))
+    }
+
+    @Test
+    fun testShouldTriggerNoId() {
+        val event = AnalyticsEvent(limit = 1)
+        assertTrue(event.shouldTrigger(state))
+
+        repeat(50) { event.recordTriggered(state) }
+        assertTrue(event.shouldTrigger(state))
+    }
+    // endregion Record Triggered Events
 }

--- a/module/parser/src/commonTest/resources/org/cru/godtools/shared/tool/parser/model/analytics_event.xml
+++ b/module/parser/src/commonTest/resources/org/cru/godtools/shared/tool/parser/model/analytics_event.xml
@@ -1,5 +1,5 @@
-<analytics:event xmlns:analytics="https://mobile-content-api.cru.org/xmlns/analytics" action="test" delay="50"
-    system="firebase" trigger="visible">
+<analytics:event xmlns:analytics="https://mobile-content-api.cru.org/xmlns/analytics" id="id" action="test" delay="50"
+    system="firebase" trigger="visible" limit="10">
     <analytics:attribute key="attr" value="value" />
     <analytics:unrecognized />
     <unrecognized />

--- a/module/parser/src/commonTest/resources/org/cru/godtools/shared/tool/parser/model/analytics_event_defaults.xml
+++ b/module/parser/src/commonTest/resources/org/cru/godtools/shared/tool/parser/model/analytics_event_defaults.xml
@@ -1,1 +1,2 @@
-<analytics:event xmlns:analytics="https://mobile-content-api.cru.org/xmlns/analytics" system="appsflyer" />
+<analytics:event xmlns:analytics="https://mobile-content-api.cru.org/xmlns/analytics" action=""
+    system="appsflyer" />

--- a/module/parser/src/commonTest/resources/org/cru/godtools/shared/tool/parser/model/analytics_events.xml
+++ b/module/parser/src/commonTest/resources/org/cru/godtools/shared/tool/parser/model/analytics_events.xml
@@ -2,7 +2,7 @@
     <analytics:event action="event1" delay="1" system="firebase">
         <analytics:attribute key="attr1" value="value" />
     </analytics:event>
-    <analytics:event action="event2" delay="2" system="firebase appsflyer">
+    <analytics:event id="event2-id" action="event2" delay="2" system="firebase appsflyer" limit="1">
         <analytics:attribute key="attr2" value="value" />
     </analytics:event>
     <analytics:unrecognized />

--- a/module/state/src/commonMain/kotlin/org/cru/godtools/shared/tool/state/State.kt
+++ b/module/state/src/commonMain/kotlin/org/cru/godtools/shared/tool/state/State.kt
@@ -16,9 +16,21 @@ import kotlin.native.HiddenFromObjC
 @Parcelize
 @OptIn(ExperimentalObjCRefinement::class)
 class State internal constructor(
+    private val triggeredAnalyticsEvents: MutableMap<String, Int> = mutableMapOf(),
     private val vars: MutableMap<String, List<String>?> = mutableMapOf(),
 ) : Parcelable {
     constructor() : this(vars = mutableMapOf())
+
+    // region Analytics Events Tracking
+    @HiddenFromObjC
+    @RestrictTo(RestrictToScope.LIBRARY_GROUP)
+    fun getTriggeredAnalyticsEventsCount(id: String) = triggeredAnalyticsEvents[id] ?: 0
+    @HiddenFromObjC
+    @RestrictTo(RestrictToScope.LIBRARY_GROUP)
+    fun recordTriggeredAnalyticsEvent(id: String) {
+        triggeredAnalyticsEvents[id] = (triggeredAnalyticsEvents[id] ?: 0) + 1
+    }
+    // endregion Analytics Events Tracking
 
     // region State vars
     private val varsChangeFlow = MutableSharedFlow<String>(extraBufferCapacity = Int.MAX_VALUE)

--- a/module/state/src/commonTest/kotlin/org/cru/godtools/shared/tool/state/StateTest.kt
+++ b/module/state/src/commonTest/kotlin/org/cru/godtools/shared/tool/state/StateTest.kt
@@ -14,6 +14,24 @@ private const val KEY2 = "key2"
 class StateTest {
     private val state = State()
 
+    // region Analytics Events Tracking
+    @Test
+    fun testAnalyticsEventsTracking() {
+        assertEquals(0, state.getTriggeredAnalyticsEventsCount(KEY))
+        assertEquals(0, state.getTriggeredAnalyticsEventsCount(KEY2))
+
+        state.recordTriggeredAnalyticsEvent(KEY)
+        assertEquals(1, state.getTriggeredAnalyticsEventsCount(KEY))
+
+        state.recordTriggeredAnalyticsEvent(KEY)
+        assertEquals(2, state.getTriggeredAnalyticsEventsCount(KEY))
+        assertEquals(0, state.getTriggeredAnalyticsEventsCount(KEY2))
+
+        state.recordTriggeredAnalyticsEvent(KEY2)
+        assertEquals(1, state.getTriggeredAnalyticsEventsCount(KEY2))
+    }
+    // endregion Analytics Events Tracking
+
     // region State Vars
     @Test
     fun testGetVars() {


### PR DESCRIPTION
This supports a new `limit` attribute for analytics events in the content xml. To enforce this limit a consumer will use `shouldTrigger(state)` and `recordTriggered(state)` on the AnalyticsEvent.

Data about if the limit has been reached will be recorded in the `State` object.