### PR TITLE
GT-1957 Correctly handle CancellationExceptions in ManifestParser

### DIFF
--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/ManifestParser.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/ManifestParser.kt
@@ -1,6 +1,7 @@
 package org.cru.godtools.shared.tool.parser
 
 import io.github.aakira.napier.Napier
+import kotlinx.coroutines.CancellationException
 import org.cru.godtools.shared.tool.parser.internal.FileNotFoundException
 import org.cru.godtools.shared.tool.parser.model.Manifest
 import org.cru.godtools.shared.tool.parser.xml.XmlPullParserException
@@ -12,6 +13,8 @@ open class ManifestParser(private val parserFactory: XmlPullParserFactory, val d
             parserFactory.getXmlParser(it)?.apply { nextTag() } ?: throw FileNotFoundException(fileName)
         }
         ParserResult.Data(manifest)
+    } catch (e: CancellationException) {
+        throw e
     } catch (e: FileNotFoundException) {
         ParserResult.Error.NotFound(e)
     } catch (e: XmlPullParserException) {

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/ManifestParserTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/ManifestParserTest.kt
@@ -1,21 +1,36 @@
 package org.cru.godtools.shared.tool.parser
 
+import io.github.aakira.napier.Napier
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
 import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
+import org.cru.godtools.shared.tool.parser.internal.CapturingAntilog
 import org.cru.godtools.shared.tool.parser.internal.TEST_XML_PULL_PARSER_FACTORY
 import org.cru.godtools.shared.tool.parser.internal.UsesResources
+import org.cru.godtools.shared.tool.parser.xml.XmlPullParser
 import org.cru.godtools.shared.tool.parser.xml.XmlPullParserFactory
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertSame
+import kotlin.test.assertTrue
 
 @RunOnAndroidWith(AndroidJUnit4::class)
 @OptIn(ExperimentalCoroutinesApi::class)
 class ManifestParserTest : UsesResources(null) {
+    private val logger = CapturingAntilog()
     private val parser = ManifestParser(TEST_XML_PULL_PARSER_FACTORY, ParserConfig())
+
+    @BeforeTest
+    fun setup() {
+        Napier.base(logger)
+    }
 
     @Test
     fun testParseManifest() = runTest {
@@ -39,6 +54,25 @@ class ManifestParserTest : UsesResources(null) {
     }
 
     @Test
+    fun testParseManifestCancellationException() = runTest {
+        val parser = ManifestParser(
+            object : XmlPullParserFactory() {
+                override suspend fun getXmlParser(fileName: String): XmlPullParser? {
+                    Semaphore(1, 1).acquire()
+                    return null
+                }
+            },
+            ParserConfig()
+        )
+        val task = launch { parser.parseManifest("") }
+        runCurrent()
+        task.cancelAndJoin()
+        assertTrue(task.isCompleted)
+        assertTrue(task.isCancelled)
+        assertTrue(logger.logsSent.isEmpty())
+    }
+
+    @Test
     fun testParseManifestUnrecognizedException() = runTest {
         val exception = Exception()
         val parser = ManifestParser(
@@ -50,6 +84,7 @@ class ManifestParserTest : UsesResources(null) {
         val response = assertIs<ParserResult.Error>(parser.parseManifest(""))
         assertEquals(ParserResult.Error::class, response::class)
         assertSame(exception, response.error)
+        assertSame(exception, logger.logsSent.first().throwable)
     }
 
     @Test

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/internal/CapturingAntilog.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/internal/CapturingAntilog.kt
@@ -1,0 +1,14 @@
+package org.cru.godtools.shared.tool.parser.internal
+
+import io.github.aakira.napier.Antilog
+import io.github.aakira.napier.LogLevel
+
+class CapturingAntilog : Antilog() {
+    data class Log(val priority: LogLevel, val tag: String?, val throwable: Throwable?, val message: String?)
+
+    val logsSent = mutableListOf<Log>()
+
+    override fun performLog(priority: LogLevel, tag: String?, throwable: Throwable?, message: String?) {
+        logsSent += Log(priority, tag, throwable, message)
+    }
+}


### PR DESCRIPTION
Another place we weren't correctly propagating CancellationExceptions