### PR TITLE
cleanup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Build
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: build -x check --scan
+          arguments: assemble --scan
 
   check_metadata:
     name: Check Publication Metadata

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Multiselect.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Multiselect.kt
@@ -163,7 +163,7 @@ class Multiselect : Content {
 
         fun isSelected(state: State) = value in state.getVar(multiselect.stateName)
         fun isSelectedFlow(state: State) =
-            state.varsChangeFlow(multiselect.stateName) { isSelected(it) }.distinctUntilChanged()
+            state.varsChangeFlow(setOf(multiselect.stateName)) { isSelected(it) }.distinctUntilChanged()
         fun toggleSelected(state: State): Boolean {
             val current = state.getVar(multiselect.stateName)
             when {

--- a/module/state/src/commonMain/kotlin/org/cru/godtools/shared/tool/state/State.kt
+++ b/module/state/src/commonMain/kotlin/org/cru/godtools/shared/tool/state/State.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.onSubscription
 import org.ccci.gto.support.androidx.annotation.RestrictTo
 import org.ccci.gto.support.androidx.annotation.RestrictToScope
 import org.cru.godtools.shared.tool.state.internal.Parcelable
@@ -38,7 +38,7 @@ class State internal constructor(
     @RestrictTo(RestrictToScope.LIBRARY_GROUP)
     fun <T> varsChangeFlow(keys: Collection<String>? = emptyList(), block: (State) -> T) = when {
         keys.isNullOrEmpty() -> flowOf(Unit)
-        else -> varsChangeFlow.filter { it in keys }.map {}.onStart { emit(Unit) }.conflate()
+        else -> varsChangeFlow.onSubscription { emit(keys.first()) }.filter { it in keys }.map {}.conflate()
     }.map { block(this) }
 
     @HiddenFromObjC

--- a/module/state/src/commonMain/kotlin/org/cru/godtools/shared/tool/state/State.kt
+++ b/module/state/src/commonMain/kotlin/org/cru/godtools/shared/tool/state/State.kt
@@ -36,10 +36,7 @@ class State internal constructor(
     private val varsChangeFlow = MutableSharedFlow<String>(extraBufferCapacity = Int.MAX_VALUE)
     @HiddenFromObjC
     @RestrictTo(RestrictToScope.LIBRARY_GROUP)
-    fun <T> varsChangeFlow(vararg key: String, block: (State) -> T) = varsChangeFlow(listOf(*key), block)
-    @HiddenFromObjC
-    @RestrictTo(RestrictToScope.LIBRARY_GROUP)
-    fun <T> varsChangeFlow(keys: Collection<String>?, block: (State) -> T) = when {
+    fun <T> varsChangeFlow(keys: Collection<String>? = emptyList(), block: (State) -> T) = when {
         keys.isNullOrEmpty() -> flowOf(Unit)
         else -> varsChangeFlow.filter { it in keys }.map {}.onStart { emit(Unit) }.conflate()
     }.map { block(this) }

--- a/module/state/src/commonTest/kotlin/org/cru/godtools/shared/tool/state/StateTest.kt
+++ b/module/state/src/commonTest/kotlin/org/cru/godtools/shared/tool/state/StateTest.kt
@@ -65,6 +65,24 @@ class StateTest {
     }
 
     @Test
+    fun testVarsChangeFlowChangeDuringStartup() = runTest {
+        state.setVar(KEY, listOf("a"))
+        state.varsChangeFlow(setOf(KEY)) {
+            val value = state.getVar(KEY).single()
+            // when emitting the initial value, update the key to check that changes during startup are handled
+            if (value == "a") state.setVar(KEY, listOf("b"))
+            value
+        }.test {
+            // initial value
+            assertEquals("a", awaitItem())
+
+            // final value
+            assertEquals("b", awaitItem())
+        }
+        assertEquals("b", state.getVar(KEY).single())
+    }
+
+    @Test
     fun testVarsChangeFlowNoKeys() = runTest {
         var count = 0
         state.varsChangeFlow { count++ }.test {

--- a/module/state/src/commonTest/kotlin/org/cru/godtools/shared/tool/state/StateTest.kt
+++ b/module/state/src/commonTest/kotlin/org/cru/godtools/shared/tool/state/StateTest.kt
@@ -45,7 +45,7 @@ class StateTest {
     @Test
     fun testVarsChangeFlow() = runTest {
         var i = 0
-        state.varsChangeFlow(KEY, KEY2) { i++ }.test {
+        state.varsChangeFlow(setOf(KEY, KEY2)) { i++ }.test {
             // initial value
             assertEquals(0, awaitItem())
 


### PR DESCRIPTION
- use assemble task instead of build task so we don't need to exclude other tasks
- remove unnecessary varsChangeFlow overload
- use onSubscription instead of onStart to avoid a startup race condition
