### PR TITLE
GT-1922 update JsXmlPullParserFactory.readFile() to return a Promise

### DIFF
--- a/module/parser/src/jsMain/kotlin/org/cru/godtools/shared/tool/parser/xml/JsXmlPullParserFactory.kt
+++ b/module/parser/src/jsMain/kotlin/org/cru/godtools/shared/tool/parser/xml/JsXmlPullParserFactory.kt
@@ -1,9 +1,12 @@
 package org.cru.godtools.shared.tool.parser.xml
 
+import kotlinx.coroutines.await
+import kotlin.js.Promise
+
 @JsExport
 @OptIn(ExperimentalJsExport::class)
 abstract class JsXmlPullParserFactory : XmlPullParserFactory() {
-    abstract fun readFile(fileName: String): String?
+    abstract fun readFile(fileName: String): Promise<String?>
 
-    override suspend fun getXmlParser(fileName: String) = readFile(fileName)?.let { JsXmlPullParser(it) }
+    override suspend fun getXmlParser(fileName: String) = readFile(fileName).await()?.let { JsXmlPullParser(it) }
 }

--- a/module/parser/src/jsTest/kotlin/org/cru/godtools/shared/tool/parser/internal/UsesResources.js.kt
+++ b/module/parser/src/jsTest/kotlin/org/cru/godtools/shared/tool/parser/internal/UsesResources.js.kt
@@ -3,6 +3,7 @@ package org.cru.godtools.shared.tool.parser.internal
 import com.goncalossilva.resources.Resource
 import org.cru.godtools.shared.tool.parser.xml.JsXmlPullParserFactory
 import org.cru.godtools.shared.tool.parser.xml.XmlPullParserFactory
+import kotlin.js.Promise
 
 // HACK: this is currently hardcoded, hopefully at some point there will be a better way to access resources
 private const val RESOURCES_ROOT = "src/commonTest/resources/org/cru/godtools/shared/tool/parser"
@@ -11,8 +12,8 @@ internal actual val UsesResources.TEST_XML_PULL_PARSER_FACTORY: XmlPullParserFac
     get() = object : JsXmlPullParserFactory() {
         override fun readFile(fileName: String) = try {
             val path = resourcesDir?.let { "$RESOURCES_ROOT/$it" } ?: RESOURCES_ROOT
-            Resource("$path/$fileName").readText()
+            Promise.resolve(Resource("$path/$fileName").readText())
         } catch (e: RuntimeException) {
-            null
+            Promise.resolve(null)
         }
     }


### PR DESCRIPTION
Updated Typescript header:
```typescript
export declare namespace org.cru.godtools.shared.tool.parser.xml {
    abstract class JsXmlPullParserFactory extends org.cru.godtools.shared.tool.parser.xml.XmlPullParserFactory {
        constructor();
        abstract readFile(fileName: string): Promise<Nullable<string>>;
    }
}
```