### PR TITLE
cleanup

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -131,6 +131,10 @@ allprojects {
         apply(plugin = "org.jlleitschuh.gradle.ktlint")
         ktlint {
             version.set(libs.versions.ktlint)
+
+            filter {
+                exclude { it.file.path.startsWith("${buildDir.path}/") }
+            }
         }
     }
 }

--- a/buildSrc/src/main/kotlin/AntlrConfig.kt
+++ b/buildSrc/src/main/kotlin/AntlrConfig.kt
@@ -17,16 +17,16 @@ fun Project.configureAntlr() {
         val antlrDirectoryDelegate = AntlrSourceVirtualDirectoryImpl(name, objects)
         antlrDirectoryDelegate.antlr.srcDir("src/$name/antlr")
 
-        // 3) Set up the Antlr output directory (adding to javac inputs!)
-
+        // 2) Create task to generate the ANTLR grammar parsers
         val generateTask = tasks.register("generate${name.capitalize()}GrammarSource", AntlrKotlinTask::class.java) {
             antlrClasspath = antlrConfiguration
             maxHeapSize = "64m"
             arguments = listOf("-visitor")
             source = antlrDirectoryDelegate.antlr
-            outputDirectory = File(buildDir, "generated-src/antlr/${this@all.name}")
+            outputDirectory = File(buildDir, "generated/antlr/src/${this@all.name}/kotlin")
         }
 
+        // 3) Set up the Antlr output directory (adding to javac inputs!)
         kotlin.srcDir(generateTask.map { it.outputDirectory })
     }
 }

--- a/module/parser-expressions/build.gradle.kts
+++ b/module/parser-expressions/build.gradle.kts
@@ -24,9 +24,3 @@ kotlin {
         }
     }
 }
-
-ktlint {
-    filter {
-        exclude("**/grammar/generated/**/*")
-    }
-}


### PR DESCRIPTION
- exclude any source files in the build directory from ktlint
- use generated build folder when generating the ANTLR parsers
