### PR TITLE
Workaround a fatal npm-publish task dependency issue

### DIFF
--- a/publishing/npm/build.gradle.kts
+++ b/publishing/npm/build.gradle.kts
@@ -1,3 +1,4 @@
+import dev.petuska.npm.publish.task.NpmPublishTask
 import org.ajoberstar.grgit.Grgit
 
 plugins {
@@ -43,4 +44,9 @@ npmPublish {
             }
         }
     }
+}
+
+// HACK: workaround https://github.com/mpetuska/npm-publish/issues/110
+tasks.withType<NpmPublishTask> {
+    dependsOn(rootProject.tasks.named("kotlinNodeJsSetup"))
 }


### PR DESCRIPTION
Gradle 8 requires task dependencies to be correctly declared, which is causing the npm-publish plugin to fail because it depended on files from the `kotlinNodeJsSetup` task without declaring a dependency on the task.

Upstream bug report: https://github.com/mpetuska/npm-publish/issues/110