### PR TITLE
GT-1922 The generated TypeScript headers won't allow a class with an internal constructor to be extended

### DIFF
--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/ManifestParser.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/ManifestParser.kt
@@ -4,6 +4,8 @@ import deezer.kustomexport.KustomExport
 import io.github.aakira.napier.Napier
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.withContext
+import org.ccci.gto.support.androidx.annotation.RestrictTo
+import org.ccci.gto.support.androidx.annotation.RestrictToScope
 import org.cru.godtools.shared.tool.parser.internal.FileNotFoundException
 import org.cru.godtools.shared.tool.parser.model.Manifest
 import org.cru.godtools.shared.tool.parser.xml.XmlPullParserException
@@ -44,7 +46,9 @@ sealed class ParserResult {
     class Data(val manifest: Manifest) : ParserResult()
 
     @JsName("ParserError")
-    open class Error internal constructor(val error: Throwable? = null) : ParserResult() {
+    open class Error
+    @RestrictTo(RestrictToScope.LIBRARY_GROUP)
+    constructor(val error: Throwable? = null) : ParserResult() {
         class Corrupted internal constructor(e: Exception? = null) : Error(e)
         class NotFound internal constructor(e: Exception? = null) : Error(e)
     }


### PR DESCRIPTION
Updated header:
```typescript
export declare namespace org.cru.godtools.shared.tool.parser {
    abstract class ParserResult {
        protected constructor();
    }
    namespace ParserResult {
        class Data extends org.cru.godtools.shared.tool.parser.ParserResult {
            constructor(manifest: any/* org.cru.godtools.shared.tool.parser.model.Manifest */);
            get manifest(): any/* org.cru.godtools.shared.tool.parser.model.Manifest */;
        }
        class ParserError extends org.cru.godtools.shared.tool.parser.ParserResult {
            constructor(error?: Nullable<Error>);
            get error(): Nullable<Error>;
        }
        namespace ParserError {
            class Corrupted extends org.cru.godtools.shared.tool.parser.ParserResult.ParserError {
                private constructor();
            }
            class NotFound extends org.cru.godtools.shared.tool.parser.ParserResult.ParserError {
                private constructor();
            }
        }
    }
}
```