### PR TITLE
GT-1922 make varsChangeFlow an extension method in order to hide it from TypeScript headers

### DIFF
--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Multiselect.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Multiselect.kt
@@ -11,6 +11,7 @@ import org.cru.godtools.shared.tool.parser.model.Multiselect.Option.Style.Compan
 import org.cru.godtools.shared.tool.parser.xml.XmlPullParser
 import org.cru.godtools.shared.tool.parser.xml.parseChildren
 import org.cru.godtools.shared.tool.state.State
+import org.cru.godtools.shared.tool.state.varsChangeFlow
 
 private const val XML_STATE = "state"
 private const val XML_COLUMNS = "columns"

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Visibility.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Visibility.kt
@@ -5,6 +5,7 @@ import org.cru.godtools.shared.tool.parser.expressions.Expression
 import org.cru.godtools.shared.tool.parser.expressions.toExpressionOrNull
 import org.cru.godtools.shared.tool.parser.xml.XmlPullParser
 import org.cru.godtools.shared.tool.state.State
+import org.cru.godtools.shared.tool.state.varsChangeFlow
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract

--- a/module/parser/src/iosMain/kotlin/org/cru/godtools/shared/tool/parser/model/Flow.ios.kt
+++ b/module/parser/src/iosMain/kotlin/org/cru/godtools/shared/tool/parser/model/Flow.ios.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.flow.combine
 import org.cru.godtools.shared.tool.parser.util.FlowWatcher
 import org.cru.godtools.shared.tool.parser.util.FlowWatcher.Companion.watch
 import org.cru.godtools.shared.tool.state.State
+import org.cru.godtools.shared.tool.state.varsChangeFlow
 
 fun Flow.watchItems(state: State, block: (List<Flow.Item>) -> Unit): FlowWatcher {
     val vars = items.flatMapTo(mutableSetOf()) { it.invisibleIf?.vars().orEmpty() + it.goneIf?.vars().orEmpty() }

--- a/module/state/src/commonMain/kotlin/org/cru/godtools/shared/tool/state/State.kt
+++ b/module/state/src/commonMain/kotlin/org/cru/godtools/shared/tool/state/State.kt
@@ -38,13 +38,7 @@ class State internal constructor(
     // endregion Analytics Events Tracking
 
     // region State vars
-    private val varsChangeFlow = MutableSharedFlow<String>(extraBufferCapacity = Int.MAX_VALUE)
-    @HiddenFromObjC
-    @RestrictTo(RestrictToScope.LIBRARY_GROUP)
-    fun <T> varsChangeFlow(keys: Collection<String>? = emptyList(), block: (State) -> T) = when {
-        keys.isNullOrEmpty() -> flowOf(Unit)
-        else -> varsChangeFlow.onSubscription { emit(keys.first()) }.filter { it in keys }.map {}.conflate()
-    }.map { block(this) }
+    internal val varsChangeFlow = MutableSharedFlow<String>(extraBufferCapacity = Int.MAX_VALUE)
 
     @HiddenFromObjC
     @RestrictTo(RestrictToScope.LIBRARY_GROUP)
@@ -71,3 +65,11 @@ class State internal constructor(
     }
     // endregion State vars
 }
+
+@HiddenFromObjC
+@RestrictTo(RestrictToScope.LIBRARY_GROUP)
+@OptIn(ExperimentalObjCRefinement::class)
+fun <T> State.varsChangeFlow(keys: Collection<String>? = emptyList(), block: (State) -> T) = when {
+    keys.isNullOrEmpty() -> flowOf(Unit)
+    else -> varsChangeFlow.onSubscription { emit(keys.first()) }.filter { it in keys }.map {}.conflate()
+}.map { block(this) }


### PR DESCRIPTION
Updated headers:
```typescript
export declare namespace org.cru.godtools.shared.tool.state {
    class State /* implements org.cru.godtools.shared.tool.state.internal.Parcelable */ {
        private constructor();
        static createState(): org.cru.godtools.shared.tool.state.State;
        getTriggeredAnalyticsEventsCount(id: string): number;
        recordTriggeredAnalyticsEvent(id: string): void;
        getVar(key: string): any/* kotlin.collections.List<string> */;
        setVar(key: string, values: Nullable<any>/* Nullable<kotlin.collections.List<string>> */): void;
        addVarValue(key: string, value: string): void;
        removeVarValue(key: string, value: string): void;
    }
}
```