### PR TITLE
GT-1922 Hide ParserConfig.withAppVersion() from Typescript

### DIFF
--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/ParserConfig.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/ParserConfig.kt
@@ -31,6 +31,7 @@ data class ParserConfig private constructor(
         internal const val FEATURE_REQUIRED_VERSIONS = "required-versions"
     }
 
+    @JsExport.Ignore
     fun withAppVersion(deviceType: DeviceType = DeviceType.DEFAULT, version: String?) =
         copy(deviceType = deviceType, appVersion = version?.toVersion())
     fun withSupportedFeatures(features: Set<String>) = copy(supportedFeatures = features)


### PR DESCRIPTION
Updated Typescript Headers:
```typescript
export declare namespace org.cru.godtools.shared.tool.parser {
    class ParserConfig {
        private constructor();
        static createParserConfig(): org.cru.godtools.shared.tool.parser.ParserConfig;
        withSupportedFeatures(features: any/* kotlin.collections.Set<string> */): org.cru.godtools.shared.tool.parser.ParserConfig;
        withParseRelated(enabled: boolean): org.cru.godtools.shared.tool.parser.ParserConfig;
        withParsePages(enabled: boolean): org.cru.godtools.shared.tool.parser.ParserConfig;
        withParseTips(enabled: boolean): org.cru.godtools.shared.tool.parser.ParserConfig;
        copy(deviceType?: any/* org.cru.godtools.shared.tool.parser.model.DeviceType */, appVersion?: Nullable<any>/* Nullable<org.cru.godtools.shared.tool.parser.model.Version> */, supportedFeatures?: any/* kotlin.collections.Set<string> */, parsePages?: boolean, parseTips?: boolean, parserDispatcher?: any/* kotlinx.coroutines.CoroutineDispatcher */): org.cru.godtools.shared.tool.parser.ParserConfig;
        toString(): string;
        hashCode(): number;
        equals(other: Nullable<any>): boolean;
        static get Companion(): {
            get FEATURE_ANIMATION(): string;
            get FEATURE_CONTENT_CARD(): string;
            get FEATURE_FLOW(): string;
            get FEATURE_MULTISELECT(): string;
        };
    }
}
```