### PR TITLE
GT-1922 Don't export State members to TypeScript

### DIFF
--- a/module/state/src/commonMain/kotlin/org/cru/godtools/shared/tool/state/State.kt
+++ b/module/state/src/commonMain/kotlin/org/cru/godtools/shared/tool/state/State.kt
@@ -28,9 +28,11 @@ class State internal constructor(
 
     // region Analytics Events Tracking
     @HiddenFromObjC
+    @JsExport.Ignore
     @RestrictTo(RestrictToScope.LIBRARY_GROUP)
     fun getTriggeredAnalyticsEventsCount(id: String) = triggeredAnalyticsEvents[id] ?: 0
     @HiddenFromObjC
+    @JsExport.Ignore
     @RestrictTo(RestrictToScope.LIBRARY_GROUP)
     fun recordTriggeredAnalyticsEvent(id: String) {
         triggeredAnalyticsEvents[id] = (triggeredAnalyticsEvents[id] ?: 0) + 1
@@ -40,6 +42,7 @@ class State internal constructor(
     // region State vars
     private val varsChangeFlow = MutableSharedFlow<String>(extraBufferCapacity = Int.MAX_VALUE)
     @HiddenFromObjC
+    @JsExport.Ignore
     @RestrictTo(RestrictToScope.LIBRARY_GROUP)
     fun <T> varsChangeFlow(keys: Collection<String>? = emptyList(), block: (State) -> T) = when {
         keys.isNullOrEmpty() -> flowOf(Unit)
@@ -47,10 +50,12 @@ class State internal constructor(
     }.map { block(this) }
 
     @HiddenFromObjC
+    @JsExport.Ignore
     @RestrictTo(RestrictToScope.LIBRARY_GROUP)
     fun getVar(key: String) = vars[key].orEmpty()
 
     @HiddenFromObjC
+    @JsExport.Ignore
     @RestrictTo(RestrictToScope.LIBRARY_GROUP)
     fun setVar(key: String, values: List<String>?) {
         vars[key] = values?.toList()
@@ -58,12 +63,14 @@ class State internal constructor(
     }
 
     @HiddenFromObjC
+    @JsExport.Ignore
     @RestrictTo(RestrictToScope.LIBRARY_GROUP)
     fun addVarValue(key: String, value: String) {
         val values = getVar(key)
         if (!values.contains(value)) setVar(key, (values + value))
     }
     @HiddenFromObjC
+    @JsExport.Ignore
     @RestrictTo(RestrictToScope.LIBRARY_GROUP)
     fun removeVarValue(key: String, value: String) {
         val values = getVar(key)


### PR DESCRIPTION
Updated Typescript Headers:
```typescript
export declare namespace org.cru.godtools.shared.tool.state {
    class State /* implements org.cru.godtools.shared.tool.state.internal.Parcelable */ {
        private constructor();
        static createState(): org.cru.godtools.shared.tool.state.State;
    }
}
```