### PR TITLE
GT-1922 introduce a vararg version of withSupportedFeatures()

### DIFF
--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/ParserConfig.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/ParserConfig.kt
@@ -6,12 +6,14 @@ import org.cru.godtools.shared.tool.parser.model.DEFAULT
 import org.cru.godtools.shared.tool.parser.model.DeviceType
 import org.cru.godtools.shared.tool.parser.model.Version
 import org.cru.godtools.shared.tool.parser.model.Version.Companion.toVersion
+import kotlin.experimental.ExperimentalObjCRefinement
 import kotlin.js.ExperimentalJsExport
 import kotlin.js.JsExport
 import kotlin.js.JsName
+import kotlin.native.HiddenFromObjC
 
 @JsExport
-@OptIn(ExperimentalJsExport::class)
+@OptIn(ExperimentalJsExport::class, ExperimentalObjCRefinement::class)
 data class ParserConfig private constructor(
     internal val deviceType: DeviceType = DeviceType.DEFAULT,
     internal val appVersion: Version? = null,
@@ -34,6 +36,9 @@ data class ParserConfig private constructor(
     @JsExport.Ignore
     fun withAppVersion(deviceType: DeviceType = DeviceType.DEFAULT, version: String?) =
         copy(deviceType = deviceType, appVersion = version?.toVersion())
+    @HiddenFromObjC
+    fun withSupportedFeatures(vararg feature: String) = copy(supportedFeatures = feature.toSet())
+    @JsExport.Ignore
     fun withSupportedFeatures(features: Set<String>) = copy(supportedFeatures = features)
     fun withParseRelated(enabled: Boolean) = copy(parsePages = enabled, parseTips = enabled)
     fun withParsePages(enabled: Boolean) = copy(parsePages = enabled)

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/ParserConfigTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/ParserConfigTest.kt
@@ -23,8 +23,8 @@ class ParserConfigTest {
 
     @Test
     fun testWithSupportedFeatures() {
-        val orig = ParserConfig().withSupportedFeatures(emptySet())
-        val updated = orig.withSupportedFeatures(setOf("test"))
+        val orig = ParserConfig().withSupportedFeatures()
+        val updated = orig.withSupportedFeatures("test")
 
         assertFalse(orig.supportsFeature("test"))
         assertTrue(updated.supportsFeature("test"))

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/AnimationTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/AnimationTest.kt
@@ -39,11 +39,11 @@ class AnimationTest : UsesResources() {
 
     @Test
     fun testIsIgnored() {
-        with(Animation(Manifest(ParserConfig().withSupportedFeatures(setOf(FEATURE_ANIMATION))))) {
+        with(Animation(Manifest(ParserConfig().withSupportedFeatures(FEATURE_ANIMATION)))) {
             assertFalse(isIgnored)
         }
 
-        with(Animation(Manifest(ParserConfig().withSupportedFeatures(emptySet())))) {
+        with(Animation(Manifest(ParserConfig().withSupportedFeatures()))) {
             assertTrue(isIgnored)
         }
     }

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/ButtonTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/ButtonTest.kt
@@ -94,7 +94,7 @@ class ButtonTest : UsesResources() {
             assertTrue(isIgnored)
         }
 
-        val config = ParserConfig().withSupportedFeatures(setOf(FEATURE_MULTISELECT))
+        val config = ParserConfig().withSupportedFeatures(FEATURE_MULTISELECT)
         with(Button(Manifest(config = config), getTestXmlParser("button_requiredFeatures.xml"))) {
             assertFalse(isIgnored)
         }

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/CardTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/CardTest.kt
@@ -37,10 +37,10 @@ class CardTest : UsesResources() {
 
     @Test
     fun testIsIgnored() {
-        with(Card(Manifest(config = ParserConfig().withSupportedFeatures(setOf(FEATURE_CONTENT_CARD))))) {
+        with(Card(Manifest(config = ParserConfig().withSupportedFeatures(FEATURE_CONTENT_CARD)))) {
             assertFalse(isIgnored)
         }
-        with(Card(Manifest(config = ParserConfig().withSupportedFeatures(emptySet())))) {
+        with(Card(Manifest(config = ParserConfig().withSupportedFeatures()))) {
             assertTrue(isIgnored)
         }
     }

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/ContentTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/ContentTest.kt
@@ -31,7 +31,7 @@ class ContentTest : UsesResources() {
     // region required-features
     @Test
     fun verifyRequiredFeaturesSupported() {
-        val manifest = Manifest(ParserConfig().withSupportedFeatures(setOf(FEATURE_ANIMATION, FEATURE_MULTISELECT)))
+        val manifest = Manifest(ParserConfig().withSupportedFeatures(FEATURE_ANIMATION, FEATURE_MULTISELECT))
         assertFalse(
             object : Content(manifest, requiredFeatures = setOf(FEATURE_ANIMATION, FEATURE_MULTISELECT)) {}.isIgnored
         )
@@ -42,7 +42,7 @@ class ContentTest : UsesResources() {
 
     @Test
     fun verifyRequiredFeaturesNotSupported() {
-        val manifest = Manifest(ParserConfig().withSupportedFeatures(setOf(FEATURE_ANIMATION)))
+        val manifest = Manifest(ParserConfig().withSupportedFeatures(FEATURE_ANIMATION))
         assertTrue(
             object : Content(manifest, requiredFeatures = setOf(FEATURE_ANIMATION, FEATURE_MULTISELECT)) {}.isIgnored
         )

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/MultiselectTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/MultiselectTest.kt
@@ -67,10 +67,10 @@ class MultiselectTest : UsesResources() {
 
     @Test
     fun testIsIgnored() {
-        with(Multiselect(Manifest(ParserConfig().withSupportedFeatures(setOf(FEATURE_MULTISELECT))))) {
+        with(Multiselect(Manifest(ParserConfig().withSupportedFeatures(FEATURE_MULTISELECT)))) {
             assertFalse(isIgnored)
         }
-        with(Multiselect(Manifest(ParserConfig().withSupportedFeatures(emptySet())))) {
+        with(Multiselect(Manifest(ParserConfig().withSupportedFeatures()))) {
             assertTrue(isIgnored)
         }
     }


### PR DESCRIPTION
this version will be used for TypeScript and Android. iOS doesn't provide a clean interop with vararg parameters unfortunately

Updated TypeScript headers:
```typescript
export declare namespace org.cru.godtools.shared.tool.parser {
    class ParserConfig {
        private constructor();
        static createParserConfig(): org.cru.godtools.shared.tool.parser.ParserConfig;
        withSupportedFeatures(feature: Array<string>): org.cru.godtools.shared.tool.parser.ParserConfig;
        withParseRelated(enabled: boolean): org.cru.godtools.shared.tool.parser.ParserConfig;
        withParsePages(enabled: boolean): org.cru.godtools.shared.tool.parser.ParserConfig;
        withParseTips(enabled: boolean): org.cru.godtools.shared.tool.parser.ParserConfig;
        copy(deviceType?: any/* org.cru.godtools.shared.tool.parser.model.DeviceType */, appVersion?: Nullable<any>/* Nullable<org.cru.godtools.shared.tool.parser.model.Version> */, supportedFeatures?: any/* kotlin.collections.Set<string> */, parsePages?: boolean, parseTips?: boolean, parserDispatcher?: any/* kotlinx.coroutines.CoroutineDispatcher */): org.cru.godtools.shared.tool.parser.ParserConfig;
        toString(): string;
        hashCode(): number;
        equals(other: Nullable<any>): boolean;
        static get Companion(): {
            get FEATURE_ANIMATION(): string;
            get FEATURE_CONTENT_CARD(): string;
            get FEATURE_FLOW(): string;
            get FEATURE_MULTISELECT(): string;
        };
    }
}
```