### PR TITLE
Hide direct access to AnalyticsEvents for model objects

### DIFF
--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/AnalyticsEvent.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/AnalyticsEvent.kt
@@ -55,7 +55,7 @@ class AnalyticsEvent : BaseModel {
     val action: String
     val delay: Int
     val systems: Set<System>
-    val trigger: Trigger
+    internal val trigger: Trigger
     internal val limit: Int?
     val attributes: Map<String, String>
 
@@ -112,7 +112,7 @@ class AnalyticsEvent : BaseModel {
         this.attributes = attributes
     }
 
-    fun isTriggerType(vararg types: Trigger) = types.contains(trigger)
+    internal fun isTriggerType(vararg types: Trigger) = types.contains(trigger)
     fun isForSystem(system: System) = systems.contains(system)
 
     fun shouldTrigger(state: State) = limit == null || state.getTriggeredAnalyticsEventsCount(id) < limit

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Button.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Button.kt
@@ -3,6 +3,7 @@ package org.cru.godtools.shared.tool.parser.model
 import io.github.aakira.napier.Napier
 import org.ccci.gto.support.androidx.annotation.RestrictTo
 import org.ccci.gto.support.androidx.annotation.RestrictToScope
+import org.ccci.gto.support.androidx.annotation.VisibleForTesting
 import org.cru.godtools.shared.common.model.Uri
 import org.cru.godtools.shared.tool.parser.internal.AndroidColorInt
 import org.cru.godtools.shared.tool.parser.internal.DeprecationException
@@ -81,8 +82,6 @@ class Button : Content, HasAnalyticsEvents, Clickable {
     }
     val text: Text
 
-    val analyticsEvents: List<AnalyticsEvent>
-
     internal constructor(parent: Base, parser: XmlPullParser) : super(parent, parser) {
         parser.require(XmlPullParser.START_TAG, XMLNS_CONTENT, XML_BUTTON)
 
@@ -151,11 +150,16 @@ class Button : Content, HasAnalyticsEvents, Clickable {
 
     override val isIgnored get() = super.isIgnored || !isClickable || style == Style.UNKNOWN
 
+    // region HasAnalyticsEvents
+    @VisibleForTesting
+    internal val analyticsEvents: List<AnalyticsEvent>
+
     override fun getAnalyticsEvents(type: Trigger) = when (type) {
         Trigger.CLICKED ->
             analyticsEvents.filter { it.isTriggerType(Trigger.CLICKED, Trigger.SELECTED, Trigger.DEFAULT) }
         else -> error("The $type trigger type is currently unsupported on Buttons")
     }
+    // endregion HasAnalyticsEvents
 
     enum class Type {
         EVENT, URL, UNKNOWN;

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Link.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Link.kt
@@ -2,6 +2,7 @@ package org.cru.godtools.shared.tool.parser.model
 
 import org.ccci.gto.support.androidx.annotation.RestrictTo
 import org.ccci.gto.support.androidx.annotation.RestrictToScope
+import org.ccci.gto.support.androidx.annotation.VisibleForTesting
 import org.cru.godtools.shared.common.model.Uri
 import org.cru.godtools.shared.tool.parser.model.AnalyticsEvent.Companion.parseAnalyticsEvents
 import org.cru.godtools.shared.tool.parser.model.AnalyticsEvent.Trigger
@@ -12,7 +13,6 @@ class Link : Content, HasAnalyticsEvents, Clickable {
         internal const val XML_LINK = "link"
     }
 
-    val analyticsEvents: List<AnalyticsEvent>
     override val events: List<EventId>
     override val url: Uri?
 
@@ -52,8 +52,13 @@ class Link : Content, HasAnalyticsEvents, Clickable {
         this.text = text?.invoke(defaultTextStyles) ?: Text(defaultTextStyles)
     }
 
+    // region HasAnalyticsEvents
+    @VisibleForTesting
+    internal val analyticsEvents: List<AnalyticsEvent>
+
     override fun getAnalyticsEvents(type: Trigger) = when (type) {
         Trigger.CLICKED -> analyticsEvents.filter { it.isTriggerType(Trigger.CLICKED, Trigger.DEFAULT) }
         else -> error("The $type trigger type is currently unsupported on Links")
     }
+    // endregion HasAnalyticsEvents
 }

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Tabs.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Tabs.kt
@@ -2,6 +2,7 @@ package org.cru.godtools.shared.tool.parser.model
 
 import org.ccci.gto.support.androidx.annotation.RestrictTo
 import org.ccci.gto.support.androidx.annotation.RestrictToScope
+import org.ccci.gto.support.androidx.annotation.VisibleForTesting
 import org.cru.godtools.shared.tool.parser.model.AnalyticsEvent.Companion.parseAnalyticsEvents
 import org.cru.godtools.shared.tool.parser.model.AnalyticsEvent.Trigger
 import org.cru.godtools.shared.tool.parser.xml.XmlPullParser
@@ -41,7 +42,6 @@ class Tabs : Content {
         private val tabs: Tabs
         val position get() = tabs.tabs.indexOf(this)
 
-        val analyticsEvents: List<AnalyticsEvent>
         val listeners: Set<EventId>
         val label: Text?
 
@@ -80,9 +80,14 @@ class Tabs : Content {
             content = emptyList()
         }
 
+        // region HasAnalyticsEvents
+        @VisibleForTesting
+        internal val analyticsEvents: List<AnalyticsEvent>
+
         override fun getAnalyticsEvents(type: Trigger) = when (type) {
             Trigger.CLICKED -> analyticsEvents.filter { it.isTriggerType(Trigger.CLICKED, Trigger.DEFAULT) }
             else -> error("The $type trigger type is currently unsupported on Tabs")
         }
+        // endregion HasAnalyticsEvents
     }
 }

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/tract/Hero.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/tract/Hero.kt
@@ -2,6 +2,7 @@ package org.cru.godtools.shared.tool.parser.model.tract
 
 import org.ccci.gto.support.androidx.annotation.RestrictTo
 import org.ccci.gto.support.androidx.annotation.RestrictToScope
+import org.ccci.gto.support.androidx.annotation.VisibleForTesting
 import org.cru.godtools.shared.tool.parser.model.AnalyticsEvent
 import org.cru.godtools.shared.tool.parser.model.AnalyticsEvent.Companion.parseAnalyticsEvents
 import org.cru.godtools.shared.tool.parser.model.AnalyticsEvent.Trigger
@@ -30,7 +31,6 @@ class Hero : BaseModel, Parent, HasAnalyticsEvents {
         internal const val XML_HERO = "hero"
     }
 
-    val analyticsEvents: List<AnalyticsEvent>
     private val headingParent by lazy { stylesOverride(textColor = { stylesParent.primaryColor }) }
     val heading: Text?
     override val content: List<Content>
@@ -66,9 +66,14 @@ class Hero : BaseModel, Parent, HasAnalyticsEvents {
         content = emptyList()
     }
 
+    // region HasAnalyticsEvents
+    @VisibleForTesting
+    internal val analyticsEvents: List<AnalyticsEvent>
+
     override fun getAnalyticsEvents(type: Trigger) = when (type) {
         Trigger.VISIBLE -> analyticsEvents.filter { it.isTriggerType(Trigger.VISIBLE, Trigger.DEFAULT) }
         Trigger.HIDDEN -> analyticsEvents.filter { it.isTriggerType(Trigger.HIDDEN) }
         else -> error("Analytics trigger type $type is not currently supported on Heroes")
     }
+    // endregion HasAnalyticsEvents
 }

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/tract/TractPage.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/tract/TractPage.kt
@@ -2,6 +2,7 @@ package org.cru.godtools.shared.tool.parser.model.tract
 
 import org.ccci.gto.support.androidx.annotation.RestrictTo
 import org.ccci.gto.support.androidx.annotation.RestrictToScope
+import org.ccci.gto.support.androidx.annotation.VisibleForTesting
 import org.cru.godtools.shared.tool.parser.internal.AndroidColorInt
 import org.cru.godtools.shared.tool.parser.model.AnalyticsEvent
 import org.cru.godtools.shared.tool.parser.model.AnalyticsEvent.Companion.parseAnalyticsEvents
@@ -163,7 +164,6 @@ class TractPage : Page {
         val isHidden: Boolean
         val listeners: Set<EventId>
         val dismissListeners: Set<EventId>
-        val analyticsEvents: List<AnalyticsEvent>
 
         @AndroidColorInt
         private val _backgroundColor: PlatformColor?
@@ -252,11 +252,16 @@ class TractPage : Page {
             this.content = content?.invoke(this).orEmpty()
         }
 
+        // region HasAnalyticsEvents
+        @VisibleForTesting
+        internal val analyticsEvents: List<AnalyticsEvent>
+
         override fun getAnalyticsEvents(type: Trigger) = when (type) {
             Trigger.VISIBLE -> analyticsEvents.filter { it.isTriggerType(Trigger.VISIBLE, Trigger.DEFAULT) }
             Trigger.HIDDEN -> analyticsEvents.filter { it.isTriggerType(Trigger.HIDDEN) }
             else -> error("Analytics trigger type $type is not currently supported on Cards")
         }
+        // endregion HasAnalyticsEvents
     }
 
     private fun XmlPullParser.parseCardsXml() = buildList {


### PR DESCRIPTION
Dependent on:
- [x] https://github.com/CruGlobal/godtools-swift/pull/1565