### PR TITLE
GT-1922 Expose the Clickable type to TypeScript

### DIFF
--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Clickable.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Clickable.kt
@@ -10,10 +10,14 @@ import org.cru.godtools.shared.tool.parser.xml.XmlPullParser
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
+import kotlin.js.ExperimentalJsExport
+import kotlin.js.JsExport
 
 private const val XML_EVENTS = "events"
 private const val XML_URL = "url"
 
+@JsExport
+@OptIn(ExperimentalJsExport::class)
 interface Clickable : Base {
     val isClickable get() = url != null || events.isNotEmpty()
 

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Clickable.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Clickable.kt
@@ -10,19 +10,29 @@ import org.cru.godtools.shared.tool.parser.xml.XmlPullParser
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
+import kotlin.experimental.ExperimentalObjCRefinement
 import kotlin.js.ExperimentalJsExport
 import kotlin.js.JsExport
+import kotlin.js.JsName
+import kotlin.native.HiddenFromObjC
 
 private const val XML_EVENTS = "events"
 private const val XML_URL = "url"
 
 @JsExport
-@OptIn(ExperimentalJsExport::class)
+@OptIn(ExperimentalJsExport::class, ExperimentalObjCRefinement::class)
 interface Clickable : Base {
     val isClickable get() = url != null || events.isNotEmpty()
 
+    @JsName("_events")
     val events: List<EventId>
     val url: Uri?
+
+    // region Kotlin/JS interop
+    @HiddenFromObjC
+    @JsName("events")
+    val jsEvents get() = events.toTypedArray()
+    // endregion Kotlin/JS interop
 }
 
 @OptIn(ExperimentalContracts::class)


### PR DESCRIPTION
- export the Clickable type to TypeScript
- expose Clickable.events as an Array in TypeScript
