### PR TITLE
GT-1922 export Input type to TypeScript

### DIFF
--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Input.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Input.kt
@@ -3,7 +3,6 @@ package org.cru.godtools.shared.tool.parser.model
 import org.cru.godtools.shared.tool.parser.model.Input.Type.Companion.toTypeOrNull
 import org.cru.godtools.shared.tool.parser.xml.XmlPullParser
 import org.cru.godtools.shared.tool.parser.xml.parseChildren
-import kotlin.native.concurrent.SharedImmutable
 
 private const val XML_TYPE = "type"
 private const val XML_TYPE_TEXT = "text"
@@ -16,7 +15,6 @@ private const val XML_VALUE = "value"
 private const val XML_LABEL = "label"
 private const val XML_PLACEHOLDER = "placeholder"
 
-@SharedImmutable
 private val REGEX_VALIDATE_EMAIL = Regex(".+@.+")
 
 class Input : Content {

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Input.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Input.kt
@@ -3,6 +3,8 @@ package org.cru.godtools.shared.tool.parser.model
 import org.cru.godtools.shared.tool.parser.model.Input.Type.Companion.toTypeOrNull
 import org.cru.godtools.shared.tool.parser.xml.XmlPullParser
 import org.cru.godtools.shared.tool.parser.xml.parseChildren
+import kotlin.js.ExperimentalJsExport
+import kotlin.js.JsExport
 
 private const val XML_TYPE = "type"
 private const val XML_TYPE_TEXT = "text"
@@ -17,6 +19,8 @@ private const val XML_PLACEHOLDER = "placeholder"
 
 private val REGEX_VALIDATE_EMAIL = Regex(".+@.+")
 
+@JsExport
+@OptIn(ExperimentalJsExport::class)
 class Input : Content {
     internal companion object {
         internal const val XML_INPUT = "input"


### PR DESCRIPTION
- remove unnecessary SharedImmutable annotation
- export Input type to TypeScript
