### PR TITLE
Adjust Multiselect.Option type

### DIFF
--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Multiselect.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Multiselect.kt
@@ -87,7 +87,7 @@ class Multiselect : Content {
 
     override val isIgnored get() = !manifest.config.supportsFeature(FEATURE_MULTISELECT) || super.isIgnored
 
-    class Option : Content, Parent, HasAnalyticsEvents {
+    class Option : BaseModel, Parent, HasAnalyticsEvents {
         internal companion object {
             private const val XML_SELECTED_COLOR = "selected-color"
 
@@ -117,7 +117,7 @@ class Multiselect : Content {
         internal val analyticsEvents: List<AnalyticsEvent>
         override val content: List<Content>
 
-        internal constructor(multiselect: Multiselect, parser: XmlPullParser) : super(multiselect, parser) {
+        internal constructor(multiselect: Multiselect, parser: XmlPullParser) : super(multiselect) {
             this.multiselect = multiselect
             parser.require(XmlPullParser.START_TAG, XMLNS_CONTENT, XML_OPTION)
 

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Multiselect.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Multiselect.kt
@@ -42,6 +42,7 @@ class Multiselect : Content {
     private val optionSelectedColor get() = _optionSelectedColor ?: stylesParent?.multiselectOptionSelectedColor
 
     val options: List<Option>
+    override val tips get() = options.flatMap { it.contentTips }
 
     internal constructor(parent: Base, parser: XmlPullParser) : super(parent, parser) {
         parser.require(XmlPullParser.START_TAG, XMLNS_CONTENT, XML_MULTISELECT)
@@ -145,7 +146,8 @@ class Multiselect : Content {
             analyticsEvents: List<AnalyticsEvent> = emptyList(),
             backgroundColor: PlatformColor? = null,
             selectedColor: PlatformColor? = null,
-            value: String = ""
+            value: String = "",
+            content: (Option) -> List<Content> = { emptyList() },
         ) : super(multiselect) {
             this.multiselect = multiselect
             _style = style
@@ -153,7 +155,7 @@ class Multiselect : Content {
             _selectedColor = selectedColor
             this.value = value
             this.analyticsEvents = analyticsEvents
-            content = emptyList()
+            this.content = content(this)
         }
 
         override fun getAnalyticsEvents(type: Trigger) = when (type) {

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/MultiselectTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/MultiselectTest.kt
@@ -9,6 +9,8 @@ import org.cru.godtools.shared.tool.parser.ParserConfig
 import org.cru.godtools.shared.tool.parser.ParserConfig.Companion.FEATURE_MULTISELECT
 import org.cru.godtools.shared.tool.parser.internal.UsesResources
 import org.cru.godtools.shared.tool.parser.model.AnalyticsEvent.Trigger
+import org.cru.godtools.shared.tool.parser.model.tips.InlineTip
+import org.cru.godtools.shared.tool.parser.model.tips.Tip
 import org.cru.godtools.shared.tool.state.State
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -22,6 +24,7 @@ import kotlin.test.assertTrue
 class MultiselectTest : UsesResources() {
     private val state by lazy { State() }
 
+    // region parse Multiselect
     @Test
     fun testParseMultiselect() = runTest {
         val multiselect = Multiselect(Manifest(), getTestXmlParser("multiselect.xml"))
@@ -64,6 +67,7 @@ class MultiselectTest : UsesResources() {
             assertTrue(content.isEmpty())
         }
     }
+    // endregion parse Multiselect
 
     @Test
     fun testIsIgnored() {
@@ -73,6 +77,25 @@ class MultiselectTest : UsesResources() {
         with(Multiselect(Manifest(ParserConfig().withSupportedFeatures()))) {
             assertTrue(isIgnored)
         }
+    }
+
+    @Test
+    fun testPropertyTips() {
+        val manifest = Manifest(tips = { listOf(Tip(it, "tip1"), Tip(it, "tip2"), Tip(it, "tip3"), Tip(it, "tip4")) })
+        val multiselect = Multiselect(
+            manifest,
+            options = {
+                listOf(
+                    Multiselect.Option(it) { listOf(InlineTip(it, "tip1")) },
+                    Multiselect.Option(it) { listOf(InlineTip(it, "tip2"), InlineTip(it, "tip3")) },
+                )
+            },
+        )
+
+        assertEquals(
+            listOf(manifest.findTip("tip1"), manifest.findTip("tip2"), manifest.findTip("tip3")),
+            multiselect.tips,
+        )
     }
 
     @Test


### PR DESCRIPTION
- Multiselect.Option does not need to extend the Content type
- expose any nested tips under a multi-select
