### PR TITLE
GT-1922 expose the Card type to TypeScript

### DIFF
--- a/module/parser/src/androidMain/kotlin/org/cru/godtools/shared/tool/parser/model/Card.android.kt
+++ b/module/parser/src/androidMain/kotlin/org/cru/godtools/shared/tool/parser/model/Card.android.kt
@@ -1,0 +1,6 @@
+@file:JvmMultifileClass
+@file:JvmName("CardKt")
+
+package org.cru.godtools.shared.tool.parser.model
+
+val Card?.backgroundColor get() = this?.backgroundColor ?: stylesParent.cardBackgroundColor

--- a/module/parser/src/androidUnitTest/kotlin/org/cru/godtools/shared/tool/parser/model/AndroidCardTest.kt
+++ b/module/parser/src/androidUnitTest/kotlin/org/cru/godtools/shared/tool/parser/model/AndroidCardTest.kt
@@ -1,0 +1,21 @@
+package org.cru.godtools.shared.tool.parser.model
+
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class AndroidCardTest {
+    @Test
+    fun testPropertyBackgroundColor() {
+        with(null as Card?) {
+            assertEquals(Manifest.DEFAULT_BACKGROUND_COLOR, backgroundColor)
+        }
+
+        val parent = Manifest(cardBackgroundColor = TestColors.RANDOM)
+        with(Card(parent) as Card?) {
+            assertEquals(parent.cardBackgroundColor, backgroundColor)
+        }
+        with(Card(parent, backgroundColor = TestColors.GREEN) as Card?) {
+            assertEquals(TestColors.GREEN, backgroundColor)
+        }
+    }
+}

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Card.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Card.kt
@@ -8,9 +8,13 @@ import org.ccci.gto.support.androidx.annotation.RestrictToScope
 import org.cru.godtools.shared.common.model.Uri
 import org.cru.godtools.shared.tool.parser.ParserConfig.Companion.FEATURE_CONTENT_CARD
 import org.cru.godtools.shared.tool.parser.xml.XmlPullParser
+import kotlin.js.ExperimentalJsExport
+import kotlin.js.JsExport
 import kotlin.jvm.JvmMultifileClass
 import kotlin.jvm.JvmName
 
+@JsExport
+@OptIn(ExperimentalJsExport::class)
 class Card : Content, Parent, Clickable {
     internal companion object {
         internal const val XML_CARD = "card"

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Card.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Card.kt
@@ -1,3 +1,6 @@
+@file:JvmMultifileClass
+@file:JvmName("CardKt")
+
 package org.cru.godtools.shared.tool.parser.model
 
 import org.ccci.gto.support.androidx.annotation.RestrictTo
@@ -5,6 +8,8 @@ import org.ccci.gto.support.androidx.annotation.RestrictToScope
 import org.cru.godtools.shared.common.model.Uri
 import org.cru.godtools.shared.tool.parser.ParserConfig.Companion.FEATURE_CONTENT_CARD
 import org.cru.godtools.shared.tool.parser.xml.XmlPullParser
+import kotlin.jvm.JvmMultifileClass
+import kotlin.jvm.JvmName
 
 class Card : Content, Parent, Clickable {
     internal companion object {
@@ -13,7 +18,8 @@ class Card : Content, Parent, Clickable {
         internal const val XML_CARD_BACKGROUND_COLOR = "card-background-color"
     }
 
-    internal val _backgroundColor: PlatformColor?
+    private val _backgroundColor: PlatformColor?
+    val backgroundColor get() = _backgroundColor ?: stylesParent.cardBackgroundColor
 
     override val content: List<Content>
 
@@ -43,5 +49,3 @@ class Card : Content, Parent, Clickable {
 
     override val isIgnored get() = !manifest.config.supportsFeature(FEATURE_CONTENT_CARD) || super.isIgnored
 }
-
-val Card?.backgroundColor get() = this?._backgroundColor ?: stylesParent.cardBackgroundColor

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/CardTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/CardTest.kt
@@ -52,6 +52,5 @@ class CardTest : UsesResources() {
         }
         assertEquals(parent.cardBackgroundColor, Card(parent).backgroundColor)
         assertEquals(TestColors.GREEN, Card(parent, backgroundColor = TestColors.GREEN).backgroundColor)
-        assertEquals(Manifest.DEFAULT_BACKGROUND_COLOR, (null as Card?).backgroundColor)
     }
 }


### PR DESCRIPTION
- make Card?.backgroundColor extension method Android only
- expose the Card type to TypeScript
