### PR TITLE
reduce the visibility of the kustomexport annotation dependency

### DIFF
--- a/module/parser/build.gradle.kts
+++ b/module/parser/build.gradle.kts
@@ -22,12 +22,11 @@ kotlin {
                 implementation(kotlin("stdlib"))
                 implementation(libs.kotlin.coroutines.core)
 
+                compileOnly(libs.kustomExport)
                 implementation(libs.colormath)
                 implementation(libs.fluidLocale)
                 implementation(libs.gtoSupport.androidx.annotation)
                 implementation(libs.gtoSupport.fluidsonic.locale)
-                implementation(libs.kustomExport)
-                implementation(libs.kustomExport.coroutines)
                 implementation(libs.napier)
             }
         }
@@ -39,6 +38,7 @@ kotlin {
         }
         val jsMain by getting {
             dependencies {
+                implementation(libs.kustomExport.coroutines)
                 implementation(npmLibs.sax)
             }
         }


### PR DESCRIPTION
We were getting transitive dependency resolution errors in godtools-android due to KustomExport being hosted on a custom repository. Annotations aren't required to be present on the class path, so we will just not include it as a transitive dependency
