### PR TITLE
Temporarily override the android lint version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -252,7 +252,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Find Version
         id: version
-        run: grep version gradle.properties >> $GITHUB_OUTPUT
+        run: grep ^version= gradle.properties >> $GITHUB_OUTPUT
       - name: Generate Tag Name
         id: tag_name
         run: echo tag=$TAG_NAME >> $GITHUB_OUTPUT

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,6 +12,11 @@ kotlin.native.binary.memoryModel=experimental
 
 android.useAndroidX=true
 
+# Customise the Lint version to use a more recent version than the one bundled with AGP
+# https://googlesamples.github.io/android-custom-lint-rules/usage/newer-lint.md.html
+# TODO: this is necessary to work around a compatibility issue between Kotlin 1.9.0 and AGP 8.0.x
+android.experimental.lint.version=8.1.0-rc01
+
 ### NPM Publishing
 ## WARNING: Do not commit an actual auth token to git
 #npmPublishRegistryNpmjsAuthToken={npm authToken}


### PR DESCRIPTION
This fixes an incompatibility between Kotlin 1.9 and AGP 8.0.x
