### PR TITLE
cleanup

### DIFF
--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/AccordionTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/AccordionTest.kt
@@ -4,7 +4,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
 import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
@@ -13,7 +12,6 @@ import org.cru.godtools.shared.tool.parser.model.tips.InlineTip
 import org.cru.godtools.shared.tool.parser.model.tips.Tip
 
 @RunOnAndroidWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 class AccordionTest : UsesResources() {
     @Test
     fun testParseAccordion() = runTest {

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/AnalyticsEventTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/AnalyticsEventTest.kt
@@ -24,7 +24,7 @@ class AnalyticsEventTest : UsesResources() {
         assertEquals("", event.id)
         assertEquals("", event.action)
         assertTrue(event.isForSystem(AnalyticsEvent.System.USER))
-        AnalyticsEvent.System.values().filterNot { it == AnalyticsEvent.System.USER }.forEach {
+        AnalyticsEvent.System.entries.filterNot { it == AnalyticsEvent.System.USER }.forEach {
             assertFalse(event.isForSystem(it))
         }
         assertTrue(event.isTriggerType(AnalyticsEvent.Trigger.DEFAULT))
@@ -39,7 +39,7 @@ class AnalyticsEventTest : UsesResources() {
         assertEquals("id", event.id)
         assertEquals("test", event.action)
         assertTrue(event.isForSystem(AnalyticsEvent.System.FIREBASE))
-        AnalyticsEvent.System.values().filterNot { it == AnalyticsEvent.System.FIREBASE }.forEach {
+        AnalyticsEvent.System.entries.filterNot { it == AnalyticsEvent.System.FIREBASE }.forEach {
             assertFalse(event.isForSystem(it))
         }
         assertTrue(event.isTriggerType(AnalyticsEvent.Trigger.VISIBLE))

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/AnalyticsEventTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/AnalyticsEventTest.kt
@@ -6,7 +6,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
 import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
@@ -17,7 +16,6 @@ import org.cru.godtools.shared.tool.parser.model.AnalyticsEvent.Trigger.Companio
 import org.cru.godtools.shared.tool.state.State
 
 @RunOnAndroidWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 class AnalyticsEventTest : UsesResources() {
     // region Parsing
     @Test

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/AnimationTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/AnimationTest.kt
@@ -4,7 +4,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
 import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
@@ -13,7 +12,6 @@ import org.cru.godtools.shared.tool.parser.ParserConfig.Companion.FEATURE_ANIMAT
 import org.cru.godtools.shared.tool.parser.internal.UsesResources
 
 @RunOnAndroidWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 class AnimationTest : UsesResources() {
     @Test
     fun testParseAnimationDefaults() = runTest {

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/ButtonTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/ButtonTest.kt
@@ -8,7 +8,6 @@ import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
 import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
@@ -22,7 +21,6 @@ import org.cru.godtools.shared.tool.parser.withDeviceType
 import org.cru.godtools.shared.tool.state.State
 
 @RunOnAndroidWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 class ButtonTest : UsesResources() {
     private val parent = object : BaseModel(), Styles {
         override lateinit var buttonStyle: Button.Style

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/CardTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/CardTest.kt
@@ -5,7 +5,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
 import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
@@ -14,7 +13,6 @@ import org.cru.godtools.shared.tool.parser.ParserConfig.Companion.FEATURE_CONTEN
 import org.cru.godtools.shared.tool.parser.internal.UsesResources
 
 @RunOnAndroidWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 class CardTest : UsesResources() {
     @Test
     fun testParseCard() = runTest {

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/CategoryTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/CategoryTest.kt
@@ -4,7 +4,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
 import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
@@ -12,7 +11,6 @@ import org.cru.godtools.shared.tool.parser.ParserConfig
 import org.cru.godtools.shared.tool.parser.internal.UsesResources
 
 @RunOnAndroidWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 class CategoryTest : UsesResources() {
     @Test
     fun testParseCategory() = runTest {

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/ContentTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/ContentTest.kt
@@ -6,7 +6,6 @@ import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
 import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
@@ -21,7 +20,6 @@ import org.cru.godtools.shared.tool.parser.model.tips.InlineTip
 import org.cru.godtools.shared.tool.parser.withDeviceType
 
 @RunOnAndroidWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 class ContentTest : UsesResources() {
     // region required-features
     @Test

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/FallbackTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/FallbackTest.kt
@@ -5,7 +5,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
 import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
@@ -15,7 +14,6 @@ import org.cru.godtools.shared.tool.parser.model.tips.Tip
 import org.cru.godtools.shared.tool.parser.xml.XmlPullParserException
 
 @RunOnAndroidWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 class FallbackTest : UsesResources() {
     @Test
     fun testParseFallback() = runTest {

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/FlowTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/FlowTest.kt
@@ -6,7 +6,6 @@ import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
 import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
@@ -17,7 +16,6 @@ import org.cru.godtools.shared.tool.parser.model.tips.InlineTip
 import org.cru.godtools.shared.tool.state.State
 
 @RunOnAndroidWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 class FlowTest : UsesResources() {
     private val state = State()
 

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/FormTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/FormTest.kt
@@ -3,7 +3,6 @@ package org.cru.godtools.shared.tool.parser.model
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
 import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
@@ -14,7 +13,6 @@ import org.cru.godtools.shared.tool.parser.model.tips.Tip
 import org.cru.godtools.shared.tool.parser.withDeviceType
 
 @RunOnAndroidWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 class FormTest : UsesResources() {
     @Test
     fun testParseForm() = runTest {

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/ImageTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/ImageTest.kt
@@ -7,7 +7,6 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
 import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
@@ -17,7 +16,6 @@ import org.cru.godtools.shared.tool.parser.internal.UsesResources
 import org.cru.godtools.shared.tool.parser.withDeviceType
 
 @RunOnAndroidWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 class ImageTest : UsesResources() {
     // region parse Image
     @Test

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/InputTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/InputTest.kt
@@ -5,7 +5,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
 import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
@@ -13,7 +12,6 @@ import org.cru.godtools.shared.tool.parser.internal.UsesResources
 import org.cru.godtools.shared.tool.parser.model.Input.Type.Companion.toTypeOrNull
 
 @RunOnAndroidWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 class InputTest : UsesResources() {
     @Test
     fun testParseInputHidden() = runTest {

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/LinkTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/LinkTest.kt
@@ -7,7 +7,6 @@ import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
 import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
@@ -16,7 +15,6 @@ import org.cru.godtools.shared.tool.parser.model.AnalyticsEvent.Trigger
 import org.cru.godtools.shared.tool.parser.model.EventId.Companion.FOLLOWUP
 
 @RunOnAndroidWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 class LinkTest : UsesResources() {
     @Test
     fun testParseLink() = runTest {

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/ManifestTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/ManifestTest.kt
@@ -8,7 +8,6 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
 import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
@@ -22,7 +21,6 @@ import org.cru.godtools.shared.tool.parser.model.shareable.ShareableImage
 import org.cru.godtools.shared.tool.parser.model.tract.TractPage
 
 @RunOnAndroidWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 class ManifestTest : UsesResources() {
     // region parse Manifest
     @Test

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/ParagraphTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/ParagraphTest.kt
@@ -3,7 +3,6 @@ package org.cru.godtools.shared.tool.parser.model
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
 import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
@@ -14,7 +13,6 @@ import org.cru.godtools.shared.tool.parser.model.tips.Tip
 import org.cru.godtools.shared.tool.parser.withDeviceType
 
 @RunOnAndroidWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 class ParagraphTest : UsesResources() {
     @Test
     fun testParseParagraph() = runTest {

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/SpacerTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/SpacerTest.kt
@@ -4,7 +4,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
 import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
@@ -12,7 +11,6 @@ import org.cru.godtools.shared.tool.parser.internal.UsesResources
 import org.cru.godtools.shared.tool.parser.model.Spacer.Mode.Companion.toModeOrNull
 
 @RunOnAndroidWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 class SpacerTest : UsesResources() {
     @Test
     fun testParseSpacerDefaults() = runTest {

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/TabsTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/TabsTest.kt
@@ -4,7 +4,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
 import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
@@ -14,7 +13,6 @@ import org.cru.godtools.shared.tool.parser.model.AnalyticsEvent.Trigger
 import org.cru.godtools.shared.tool.parser.withDeviceType
 
 @RunOnAndroidWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 class TabsTest : UsesResources() {
     @Test
     fun testParseTabsEmpty() = runTest {

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/TextTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/TextTest.kt
@@ -6,7 +6,6 @@ import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
 import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
@@ -16,7 +15,6 @@ import org.cru.godtools.shared.tool.parser.model.Text.Align.Companion.toTextAlig
 import org.cru.godtools.shared.tool.parser.model.Text.Style.Companion.toTextStyles
 
 @RunOnAndroidWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 class TextTest : UsesResources() {
     // region Parsing
     @Test

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/VideoTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/VideoTest.kt
@@ -2,14 +2,12 @@ package org.cru.godtools.shared.tool.parser.model
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
 import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
 import org.cru.godtools.shared.tool.parser.internal.UsesResources
 
 @RunOnAndroidWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 class VideoTest : UsesResources() {
     @Test
     fun testParseVideo() = runTest {

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/lesson/LessonPageTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/lesson/LessonPageTest.kt
@@ -8,7 +8,6 @@ import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
 import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
@@ -32,7 +31,6 @@ import org.cru.godtools.shared.tool.parser.model.page.controlColor
 import org.cru.godtools.shared.tool.parser.model.toEventIds
 
 @RunOnAndroidWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 class LessonPageTest : UsesResources("model/lesson") {
     // region parsePage
     @Test

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/page/CardCollectionPageTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/page/CardCollectionPageTest.kt
@@ -5,7 +5,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
 import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
@@ -18,7 +17,6 @@ import org.cru.godtools.shared.tool.parser.model.TestColors
 import org.cru.godtools.shared.tool.parser.xml.XmlPullParserException
 
 @RunOnAndroidWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 class CardCollectionPageTest : UsesResources("model/page") {
     // region Parse XML
     @Test

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/page/ContentPageTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/page/ContentPageTest.kt
@@ -4,7 +4,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
 import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
@@ -14,7 +13,6 @@ import org.cru.godtools.shared.tool.parser.model.Spacer
 import org.cru.godtools.shared.tool.parser.xml.XmlPullParserException
 
 @RunOnAndroidWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 class ContentPageTest : UsesResources("model/page") {
     // region Parse XML
     @Test

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/page/PageTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/page/PageTest.kt
@@ -5,7 +5,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.assertSame
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
 import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
@@ -18,7 +17,6 @@ import org.cru.godtools.shared.tool.parser.model.lesson.LessonPage
 import org.cru.godtools.shared.tool.parser.model.tract.TractPage
 
 @RunOnAndroidWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 class PageTest : UsesResources("model/page") {
     // region Page.parse()
     @Test

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/shareable/ShareableImageTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/shareable/ShareableImageTest.kt
@@ -4,7 +4,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertSame
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
 import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
@@ -13,7 +12,6 @@ import org.cru.godtools.shared.tool.parser.model.Manifest
 import org.cru.godtools.shared.tool.parser.model.Resource
 
 @RunOnAndroidWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 class ShareableImageTest : UsesResources("model/shareable") {
     // region ShareableImage XML
     @Test

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/shareable/ShareableTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/shareable/ShareableTest.kt
@@ -3,7 +3,6 @@ package org.cru.godtools.shared.tool.parser.model.shareable
 import kotlin.test.Test
 import kotlin.test.assertIs
 import kotlin.test.assertNull
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
 import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
@@ -11,7 +10,6 @@ import org.cru.godtools.shared.tool.parser.internal.UsesResources
 import org.cru.godtools.shared.tool.parser.model.Manifest
 
 @RunOnAndroidWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 class ShareableTest : UsesResources("model/shareable") {
     // region Shareable parsing
     @Test

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/tips/InlineTipTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/tips/InlineTipTest.kt
@@ -4,7 +4,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertSame
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
 import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
@@ -12,7 +11,6 @@ import org.cru.godtools.shared.tool.parser.internal.UsesResources
 import org.cru.godtools.shared.tool.parser.model.Manifest
 
 @RunOnAndroidWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 class InlineTipTest : UsesResources("model/tips") {
     @Test
     fun verifyParseInlineTip() = runTest {

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/tips/TipTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/tips/TipTest.kt
@@ -7,7 +7,6 @@ import kotlin.test.assertIs
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
 import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
@@ -18,7 +17,6 @@ import org.cru.godtools.shared.tool.parser.model.Text
 import org.cru.godtools.shared.tool.parser.model.tips.Tip.Type.Companion.toTypeOrNull
 
 @RunOnAndroidWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 class TipTest : UsesResources("model/tips") {
     // region parseTip
     @Test

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/tract/CallToActionTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/tract/CallToActionTest.kt
@@ -2,7 +2,6 @@ package org.cru.godtools.shared.tool.parser.model.tract
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
 import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
@@ -11,7 +10,6 @@ import org.cru.godtools.shared.tool.parser.model.Manifest
 import org.cru.godtools.shared.tool.parser.model.TestColors
 
 @RunOnAndroidWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 class CallToActionTest : UsesResources("model/tract") {
     @Test
     fun testParseCallToAction() = runTest {

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/tract/HeaderTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/tract/HeaderTest.kt
@@ -4,7 +4,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
 import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
@@ -16,7 +15,6 @@ import org.cru.godtools.shared.tool.parser.model.stylesParent
 import org.cru.godtools.shared.tool.parser.model.tips.Tip
 
 @RunOnAndroidWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 class HeaderTest : UsesResources("model/tract") {
     @Test
     fun testParseHeader() = runTest {

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/tract/HeroTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/tract/HeroTest.kt
@@ -6,7 +6,6 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
 import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
@@ -24,7 +23,6 @@ import org.cru.godtools.shared.tool.parser.model.Text
 import org.cru.godtools.shared.tool.parser.withDeviceType
 
 @RunOnAndroidWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 class HeroTest : UsesResources("model/tract") {
     @Test
     fun testParseHero() = runTest {

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/tract/ModalTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/tract/ModalTest.kt
@@ -3,7 +3,6 @@ package org.cru.godtools.shared.tool.parser.model.tract
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
 import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
@@ -17,7 +16,6 @@ import org.cru.godtools.shared.tool.parser.model.WHITE
 import org.cru.godtools.shared.tool.parser.model.toEventIds
 
 @RunOnAndroidWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 class ModalTest : UsesResources("model/tract") {
     @Test
     fun testParseModal() = runTest {

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/tract/TractPageCardTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/tract/TractPageCardTest.kt
@@ -7,7 +7,6 @@ import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
 import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
@@ -26,7 +25,6 @@ import org.cru.godtools.shared.tool.parser.model.toEventIds
 import org.cru.godtools.shared.tool.parser.model.tract.TractPage.Card
 
 @RunOnAndroidWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 class TractPageCardTest : UsesResources("model/tract") {
     @Test
     fun verifyParseCard() = runTest {

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/tract/TractPageTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/tract/TractPageTest.kt
@@ -5,7 +5,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
 import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
@@ -26,7 +25,6 @@ import org.cru.godtools.shared.tool.parser.model.textColor
 import org.cru.godtools.shared.tool.parser.model.toEventIds
 
 @RunOnAndroidWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 class TractPageTest : UsesResources("model/tract") {
     @Test
     fun verifyParse() = runTest {

--- a/module/state/src/commonTest/kotlin/org/cru/godtools/shared/tool/state/StateTest.kt
+++ b/module/state/src/commonTest/kotlin/org/cru/godtools/shared/tool/state/StateTest.kt
@@ -4,13 +4,11 @@ import app.cash.turbine.test
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 
 private const val KEY = "key"
 private const val KEY2 = "key2"
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class StateTest {
     private val state = State()
 


### PR DESCRIPTION
- remove unnecessary OptIn annotations
- use Enum.entries instead of Enum.values()
