### PR TITLE
Update the Uri actual for Android in preparation for Kotlin 2

### DIFF
--- a/module/common/build.gradle.kts
+++ b/module/common/build.gradle.kts
@@ -16,6 +16,11 @@ kotlin {
                 implementation(libs.kermit)
             }
         }
+        val commonTest by getting {
+            dependencies {
+                implementation(libs.gtoSupport.androidx.test.junit)
+            }
+        }
         val androidMain by getting {
             dependencies {
                 api(libs.colormath.jetpack.compose)

--- a/module/common/src/androidMain/kotlin/org/cru/godtools/shared/common/model/Uri.android.kt
+++ b/module/common/src/androidMain/kotlin/org/cru/godtools/shared/common/model/Uri.android.kt
@@ -8,4 +8,4 @@ import android.net.Uri as AndroidUri
 actual typealias Uri = AndroidUri
 actual val Uri.scheme: String? get() = scheme
 
-actual fun String?.toUriOrNull() = this?.let { AndroidUri.parse(this) }
+actual fun String.toUriOrNull() = AndroidUri.parse(this)

--- a/module/common/src/androidMain/kotlin/org/cru/godtools/shared/common/model/Uri.android.kt
+++ b/module/common/src/androidMain/kotlin/org/cru/godtools/shared/common/model/Uri.android.kt
@@ -2,10 +2,8 @@ package org.cru.godtools.shared.common.model
 
 import android.net.Uri as AndroidUri
 
-// HACK: Suppress expect/actual errors as workaround for differences between Android Uri and iOS NSURL
-//       see: https://discuss.kotlinlang.org/t/feature-request-typealias-for-expected-types/20054/4
-@Suppress("ACTUAL_WITHOUT_EXPECT")
-actual typealias Uri = AndroidUri
-actual val Uri.scheme: String? get() = scheme
+// TODO: switch to the Android Uri if Kotlin ever supports varying types between expect & actual
+actual typealias Uri = String
+actual val Uri.scheme get() = AndroidUri.parse(this).scheme
 
-actual fun String.toUriOrNull() = AndroidUri.parse(this)
+actual fun String.toUriOrNull(): Uri? = this

--- a/module/common/src/androidMain/kotlin/org/cru/godtools/shared/common/model/Uri.android.kt
+++ b/module/common/src/androidMain/kotlin/org/cru/godtools/shared/common/model/Uri.android.kt
@@ -1,10 +1,11 @@
 package org.cru.godtools.shared.common.model
 
-import android.net.Uri
+import android.net.Uri as AndroidUri
 
 // HACK: Suppress expect/actual errors as workaround for differences between Android Uri and iOS NSURL
 //       see: https://discuss.kotlinlang.org/t/feature-request-typealias-for-expected-types/20054/4
 @Suppress("ACTUAL_WITHOUT_EXPECT")
-actual typealias Uri = android.net.Uri
+actual typealias Uri = AndroidUri
+actual val Uri.scheme: String? get() = scheme
 
-actual fun String?.toUriOrNull() = this?.let { Uri.parse(this) }
+actual fun String?.toUriOrNull() = this?.let { AndroidUri.parse(this) }

--- a/module/common/src/commonMain/kotlin/org/cru/godtools/shared/common/model/Uri.kt
+++ b/module/common/src/commonMain/kotlin/org/cru/godtools/shared/common/model/Uri.kt
@@ -1,5 +1,7 @@
 package org.cru.godtools.shared.common.model
 
 expect class Uri
+expect val Uri.scheme: String?
+val Uri.isHttpUrl: Boolean get() = scheme?.matches(Regex("https?", RegexOption.IGNORE_CASE)) == true
 
 expect fun String?.toUriOrNull(): Uri?

--- a/module/common/src/commonMain/kotlin/org/cru/godtools/shared/common/model/Uri.kt
+++ b/module/common/src/commonMain/kotlin/org/cru/godtools/shared/common/model/Uri.kt
@@ -4,4 +4,4 @@ expect class Uri
 expect val Uri.scheme: String?
 val Uri.isHttpUrl: Boolean get() = scheme?.matches(Regex("https?", RegexOption.IGNORE_CASE)) == true
 
-expect fun String?.toUriOrNull(): Uri?
+expect fun String.toUriOrNull(): Uri?

--- a/module/common/src/commonTest/kotlin/org/cru/godtools/shared/common/model/UriTest.kt
+++ b/module/common/src/commonTest/kotlin/org/cru/godtools/shared/common/model/UriTest.kt
@@ -1,0 +1,30 @@
+package org.cru.godtools.shared.common.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
+import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
+
+@RunOnAndroidWith(AndroidJUnit4::class)
+class UriTest {
+    @Test
+    fun testScheme() {
+        assertEquals("http", "http://example.com".toUriOrNull()!!.scheme)
+        assertEquals("https", "https://example.com".toUriOrNull()!!.scheme)
+        assertEquals("mailto", "mailto:user@example.com".toUriOrNull()!!.scheme)
+        assertEquals("godtools", "godtools://org.cru.godtools/dashboard/lessons".toUriOrNull()!!.scheme)
+        assertNull("invalid-uri".toUriOrNull()!!.scheme)
+    }
+
+    @Test
+    fun testIsHttpUrl() {
+        assertTrue("http://example.com".toUriOrNull()!!.isHttpUrl)
+        assertTrue("https://example.com".toUriOrNull()!!.isHttpUrl)
+        assertFalse("mailto:user@example.com".toUriOrNull()!!.isHttpUrl)
+        assertFalse("godtools://org.cru.godtools/dashboard/lessons".toUriOrNull()!!.isHttpUrl)
+        assertFalse("invalid-uri".toUriOrNull()!!.isHttpUrl)
+    }
+}

--- a/module/common/src/iosMain/kotlin/org/cru/godtools/shared/common/model/Uri.ios.kt
+++ b/module/common/src/iosMain/kotlin/org/cru/godtools/shared/common/model/Uri.ios.kt
@@ -7,11 +7,9 @@ import platform.Foundation.NSURL
 actual typealias Uri = NSURL
 actual val Uri.scheme get() = scheme
 
-actual fun String?.toUriOrNull() = this?.let {
-    try {
-        NSURL(string = it)
-    } catch (e: NullPointerException) {
-        Logger.e(e) { "Error parsing URL '$it'" }
-        null
-    }
+actual fun String.toUriOrNull() = try {
+    NSURL(string = this)
+} catch (e: NullPointerException) {
+    Logger.e(e) { "Error parsing URL '$this'" }
+    null
 }

--- a/module/common/src/iosMain/kotlin/org/cru/godtools/shared/common/model/Uri.ios.kt
+++ b/module/common/src/iosMain/kotlin/org/cru/godtools/shared/common/model/Uri.ios.kt
@@ -5,6 +5,7 @@ import platform.Foundation.NSURL
 
 @Suppress("CONFLICTING_OVERLOADS")
 actual typealias Uri = NSURL
+actual val Uri.scheme get() = scheme
 
 actual fun String?.toUriOrNull() = this?.let {
     try {

--- a/module/common/src/jsMain/kotlin/org/cru/godtools/shared/common/model/Uri.js.kt
+++ b/module/common/src/jsMain/kotlin/org/cru/godtools/shared/common/model/Uri.js.kt
@@ -4,4 +4,4 @@ package org.cru.godtools.shared.common.model
 actual typealias Uri = String
 actual val Uri.scheme get() = if (contains(":")) substringBefore(":") else null
 
-actual fun String?.toUriOrNull() = this
+actual fun String.toUriOrNull(): Uri? = this

--- a/module/common/src/jsMain/kotlin/org/cru/godtools/shared/common/model/Uri.js.kt
+++ b/module/common/src/jsMain/kotlin/org/cru/godtools/shared/common/model/Uri.js.kt
@@ -2,5 +2,6 @@ package org.cru.godtools.shared.common.model
 
 // TODO: switch from String to URL
 actual typealias Uri = String
+actual val Uri.scheme get() = if (contains(":")) substringBefore(":") else null
 
 actual fun String?.toUriOrNull() = this

--- a/module/parser/src/androidMain/kotlin/org/cru/godtools/shared/tool/parser/util/Uri.android.kt
+++ b/module/parser/src/androidMain/kotlin/org/cru/godtools/shared/tool/parser/util/Uri.android.kt
@@ -1,5 +1,0 @@
-package org.cru.godtools.shared.tool.parser.util
-
-import android.net.Uri
-
-internal actual inline val Uri.scheme get() = scheme

--- a/module/parser/src/androidUnitTest/kotlin/org/cru/godtools/shared/tool/parser/model/TestConstants.android.kt
+++ b/module/parser/src/androidUnitTest/kotlin/org/cru/godtools/shared/tool/parser/model/TestConstants.android.kt
@@ -1,5 +1,3 @@
 package org.cru.godtools.shared.tool.parser.model
 
-import android.net.Uri
-
-actual val TEST_URL = Uri.parse("https://www.example.com")
+actual const val TEST_URL = "https://www.example.com"

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Manifest.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Manifest.kt
@@ -15,6 +15,7 @@ import org.ccci.gto.support.androidx.annotation.RestrictToScope
 import org.ccci.gto.support.androidx.annotation.VisibleForTesting
 import org.ccci.gto.support.fluidsonic.locale.PlatformLocale
 import org.cru.godtools.shared.common.model.Uri
+import org.cru.godtools.shared.common.model.isHttpUrl
 import org.cru.godtools.shared.common.model.toUriOrNull
 import org.cru.godtools.shared.tool.parser.ParserConfig
 import org.cru.godtools.shared.tool.parser.internal.AndroidColorInt
@@ -35,7 +36,6 @@ import org.cru.godtools.shared.tool.parser.model.shareable.Shareable
 import org.cru.godtools.shared.tool.parser.model.shareable.Shareable.Companion.parseShareableItems
 import org.cru.godtools.shared.tool.parser.model.shareable.XMLNS_SHAREABLE
 import org.cru.godtools.shared.tool.parser.model.tips.Tip
-import org.cru.godtools.shared.tool.parser.util.isHttpUrl
 import org.cru.godtools.shared.tool.parser.util.setOnce
 import org.cru.godtools.shared.tool.parser.xml.XmlPullParser
 import org.cru.godtools.shared.tool.parser.xml.parseChildren

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Manifest.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Manifest.kt
@@ -385,7 +385,7 @@ class Manifest : BaseModel, Styles {
                 }
 
                 XMLNS_ARTICLE -> when (name) {
-                    XML_PAGES_AEM_IMPORT -> getAttributeValue(XML_PAGES_AEM_IMPORT_SRC).toUriOrNull()
+                    XML_PAGES_AEM_IMPORT -> getAttributeValue(XML_PAGES_AEM_IMPORT_SRC)?.toUriOrNull()
                         ?.takeIf { it.isHttpUrl }
                         ?.let { result.aemImports += it }
                 }

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/util/Uri.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/util/Uri.kt
@@ -3,6 +3,6 @@ package org.cru.godtools.shared.tool.parser.util
 import org.cru.godtools.shared.common.model.toUriOrNull
 
 internal fun String?.toAbsoluteUriOrNull(defaultScheme: String = "http") =
-    this?.addSchemeIfNecessary(defaultScheme).toUriOrNull()
+    this?.addSchemeIfNecessary(defaultScheme)?.toUriOrNull()
 internal val String.hasUriScheme get() = contains(':')
 private fun String.addSchemeIfNecessary(defaultScheme: String) = if (hasUriScheme) this else "$defaultScheme://$this"

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/util/Uri.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/util/Uri.kt
@@ -1,10 +1,6 @@
 package org.cru.godtools.shared.tool.parser.util
 
-import org.cru.godtools.shared.common.model.Uri
 import org.cru.godtools.shared.common.model.toUriOrNull
-
-internal expect val Uri.scheme: String?
-internal val Uri.isHttpUrl: Boolean get() = scheme?.matches(Regex("https?", RegexOption.IGNORE_CASE)) == true
 
 internal fun String?.toAbsoluteUriOrNull(defaultScheme: String = "http") =
     this?.addSchemeIfNecessary(defaultScheme).toUriOrNull()

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/util/UriTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/util/UriTest.kt
@@ -2,12 +2,8 @@ package org.cru.godtools.shared.tool.parser.util
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
 import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
-import org.cru.godtools.shared.common.model.toUriOrNull
 
 @RunOnAndroidWith(AndroidJUnit4::class)
 class UriTest {
@@ -20,23 +16,5 @@ class UriTest {
             "godtools://org.cru.godtools/dashboard/lessons",
             "godtools://org.cru.godtools/dashboard/lessons".toAbsoluteUriOrNull().toString()
         )
-    }
-
-    @Test
-    fun testScheme() {
-        assertEquals("http", "http://example.com".toUriOrNull()!!.scheme)
-        assertEquals("https", "https://example.com".toUriOrNull()!!.scheme)
-        assertEquals("mailto", "mailto:user@example.com".toUriOrNull()!!.scheme)
-        assertEquals("godtools", "godtools://org.cru.godtools/dashboard/lessons".toUriOrNull()!!.scheme)
-        assertNull("invalid-uri".toUriOrNull()!!.scheme)
-    }
-
-    @Test
-    fun testIsHttpUrl() {
-        assertTrue("http://example.com".toUriOrNull()!!.isHttpUrl)
-        assertTrue("https://example.com".toUriOrNull()!!.isHttpUrl)
-        assertFalse("mailto:user@example.com".toUriOrNull()!!.isHttpUrl)
-        assertFalse("godtools://org.cru.godtools/dashboard/lessons".toUriOrNull()!!.isHttpUrl)
-        assertFalse("invalid-uri".toUriOrNull()!!.isHttpUrl)
     }
 }

--- a/module/parser/src/iosMain/kotlin/org/cru/godtools/shared/tool/parser/util/Uri.ios.kt
+++ b/module/parser/src/iosMain/kotlin/org/cru/godtools/shared/tool/parser/util/Uri.ios.kt
@@ -1,5 +1,0 @@
-package org.cru.godtools.shared.tool.parser.util
-
-import platform.Foundation.NSURL
-
-internal actual inline val NSURL.scheme get() = scheme

--- a/module/parser/src/jsMain/kotlin/org/cru/godtools/shared/tool/parser/util/Uri.js.kt
+++ b/module/parser/src/jsMain/kotlin/org/cru/godtools/shared/tool/parser/util/Uri.js.kt
@@ -1,5 +1,0 @@
-package org.cru.godtools.shared.tool.parser.util
-
-import org.cru.godtools.shared.common.model.Uri
-
-internal actual inline val Uri.scheme: String? get() = if (contains(":")) substringBefore(":") else null


### PR DESCRIPTION
- **relocate Uri.scheme property to the common module**
- **make toUriOrNull take a non-null receiver**
- **use a String for Uris on Android**
