### PR TITLE
add a UserCounterName for lesson completion counters

### DIFF
--- a/module/user-activity/src/commonMain/kotlin/org/cru/godtools/shared/user/activity/UserCounterNames.kt
+++ b/module/user-activity/src/commonMain/kotlin/org/cru/godtools/shared/user/activity/UserCounterNames.kt
@@ -23,6 +23,7 @@ object UserCounterNames {
     fun ARTICLE_OPEN(uri: Uri) =
         "$ARTICLE_OPENS_PREFIX${uri.toString().lowercase().encodeUtf8().md5().hex().lowercase()}"
     fun LESSON_OPEN(tool: String) = "$LESSON_OPENS_PREFIX$tool".lowercase()
+    fun LESSON_COMPLETION(tool: String) = "$LESSON_COMPLETIONS_PREFIX$tool".lowercase()
     fun TOOL_OPEN(tool: String) = "$TOOL_OPENS_PREFIX$tool".lowercase()
     fun SCREEN_SHARE(tool: String) = "$SCREEN_SHARES_PREFIX$tool".lowercase()
     fun LANGUAGE_USED(locale: PlatformLocale) = LANGUAGE_USED(locale.toCommon())

--- a/module/user-activity/src/commonTest/kotlin/org/cru/godtools/shared/user/activity/UserCounterNamesTest.kt
+++ b/module/user-activity/src/commonTest/kotlin/org/cru/godtools/shared/user/activity/UserCounterNamesTest.kt
@@ -14,6 +14,7 @@ class UserCounterNamesTest {
     fun verifyCounterNames() {
         assertEquals("tool_opens.kgp", UserCounterNames.TOOL_OPEN("kgp"))
         assertEquals("lesson_opens.lessonhs", UserCounterNames.LESSON_OPEN("lessonhs"))
+        assertEquals("lesson_completions.lessonhs", UserCounterNames.LESSON_COMPLETION("lessonhs"))
         assertEquals("screen_shares.kgp", UserCounterNames.SCREEN_SHARE("kgp"))
         assertEquals("language_used.en", UserCounterNames.LANGUAGE_USED(Locale.forLanguageTag("en").toPlatform()))
         assertEquals(


### PR DESCRIPTION
This will allow us to generate the name for lesson completion counters in a manner that will be consistent on all platforms
