### PR TITLE
GT-2450 Add support for PageCollectionPages in CYOA tools

### DIFF
--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/ParserConfig.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/ParserConfig.kt
@@ -31,6 +31,7 @@ data class ParserConfig private constructor(
         const val FEATURE_CONTENT_CARD = "content_card"
         const val FEATURE_FLOW = "flow"
         const val FEATURE_MULTISELECT = "multiselect"
+        const val FEATURE_PAGE_COLLECTION = "page-collection"
         internal const val FEATURE_REQUIRED_VERSIONS = "required-versions"
     }
 

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/HasPages.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/HasPages.kt
@@ -5,6 +5,9 @@ import kotlin.js.ExperimentalJsExport
 import kotlin.js.JsExport
 import kotlin.js.JsName
 import kotlin.native.HiddenFromObjC
+import kotlin.reflect.KClass
+import org.ccci.gto.support.androidx.annotation.RestrictTo
+import org.ccci.gto.support.androidx.annotation.RestrictToScope
 import org.cru.godtools.shared.tool.parser.model.page.Page
 
 @JsExport
@@ -14,6 +17,11 @@ interface HasPages : Base {
     val pages: List<Page>
 
     fun findPage(id: String?) = id?.let { pages.find { it.id == id } }
+
+    @HiddenFromObjC
+    @JsExport.Ignore
+    @RestrictTo(RestrictToScope.LIBRARY)
+    fun <T : Page> supportsPageType(type: KClass<T>): Boolean
 
     // region Kotlin/JS interop
     @HiddenFromObjC

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/HasPages.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/HasPages.kt
@@ -1,0 +1,23 @@
+package org.cru.godtools.shared.tool.parser.model
+
+import kotlin.experimental.ExperimentalObjCRefinement
+import kotlin.js.ExperimentalJsExport
+import kotlin.js.JsExport
+import kotlin.js.JsName
+import kotlin.native.HiddenFromObjC
+import org.cru.godtools.shared.tool.parser.model.page.Page
+
+@JsExport
+@OptIn(ExperimentalJsExport::class, ExperimentalObjCRefinement::class)
+interface HasPages : Base {
+    @JsName("_pages")
+    val pages: List<Page>
+
+    fun findPage(id: String?) = id?.let { pages.find { it.id == id } }
+
+    // region Kotlin/JS interop
+    @HiddenFromObjC
+    @JsName("pages")
+    val jsPages get() = pages.toTypedArray()
+    // endregion Kotlin/JS interop
+}

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Manifest.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Manifest.kt
@@ -67,7 +67,7 @@ private const val XML_TIPS_TIP_SRC = "src"
 
 @JsExport
 @OptIn(ExperimentalJsExport::class, ExperimentalObjCRefinement::class)
-class Manifest : BaseModel, Styles {
+class Manifest : BaseModel, Styles, HasPages {
     internal companion object {
         @AndroidColorInt
         internal val DEFAULT_PRIMARY_COLOR = color(59, 164, 219, 1.0)
@@ -182,8 +182,7 @@ class Manifest : BaseModel, Styles {
 
     val aemImports: List<Uri>
     val categories: List<Category>
-    @JsName("_pages")
-    var pages: List<Page> by setOnce()
+    override var pages: List<Page> by setOnce()
         private set
     @VisibleForTesting
     internal val resources: Map<String?, Resource>
@@ -348,7 +347,6 @@ class Manifest : BaseModel, Styles {
 
     @JsExport.Ignore
     fun findCategory(category: String?) = categories.firstOrNull { it.id == category }
-    fun findPage(id: String?) = id?.let { pages.firstOrNull { it.id == id } }
     @JsExport.Ignore
     fun findShareable(id: String?) = id?.let { shareables.firstOrNull { it.id == id } }
     @JsExport.Ignore
@@ -422,10 +420,6 @@ class Manifest : BaseModel, Styles {
     @HiddenFromObjC
     @JsName("dismissListeners")
     val jsDismissListeners get() = dismissListeners.toTypedArray()
-
-    @HiddenFromObjC
-    @JsName("pages")
-    val jsPages get() = pages.toTypedArray()
     // endregion Kotlin/JS interop
 
     enum class Type {

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Manifest.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Manifest.kt
@@ -102,7 +102,7 @@ class Manifest : BaseModel, Styles, HasPages {
                 if (config.parsePages) {
                     launch {
                         manifest.pages = manifest.pageXmlFiles
-                            .map { (name, src) -> async { Page.parse(manifest, name, parseFile(src)) } }
+                            .map { (name, src) -> async { Page.parse(manifest, name, parseFile(src), parseFile) } }
                             .awaitAll().filterNotNull()
                     }
                 } else {
@@ -198,7 +198,7 @@ class Manifest : BaseModel, Styles, HasPages {
     internal var tips: Map<String, Tip> by setOnce()
         private set
 
-    private val pageXmlFiles: List<XmlFile>
+    internal val pageXmlFiles: List<XmlFile>
     private val tipXmlFiles: List<XmlFile>
 
     val relatedFiles get() = buildSet {
@@ -304,7 +304,8 @@ class Manifest : BaseModel, Styles, HasPages {
         resources: ((Manifest) -> List<Resource>)? = null,
         shareables: ((Manifest) -> List<Shareable>)? = null,
         tips: ((Manifest) -> List<Tip>)? = null,
-        pages: ((Manifest) -> List<Page>)? = null
+        pages: ((Manifest) -> List<Page>)? = null,
+        pageXmlFiles: List<XmlFile> = emptyList(),
     ) {
         this.config = config
 
@@ -344,7 +345,7 @@ class Manifest : BaseModel, Styles, HasPages {
         this.shareables = shareables?.invoke(this).orEmpty()
         this.tips = tips?.invoke(this)?.associateBy { it.id }.orEmpty()
 
-        pageXmlFiles = emptyList()
+        this.pageXmlFiles = pageXmlFiles
         tipXmlFiles = emptyList()
     }
 

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/lesson/LessonPage.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/lesson/LessonPage.kt
@@ -7,6 +7,7 @@ import org.cru.godtools.shared.tool.parser.model.AnalyticsEvent
 import org.cru.godtools.shared.tool.parser.model.AnalyticsEvent.Companion.parseAnalyticsEvents
 import org.cru.godtools.shared.tool.parser.model.Content
 import org.cru.godtools.shared.tool.parser.model.Gravity
+import org.cru.godtools.shared.tool.parser.model.HasPages
 import org.cru.godtools.shared.tool.parser.model.ImageScaleType
 import org.cru.godtools.shared.tool.parser.model.Manifest
 import org.cru.godtools.shared.tool.parser.model.Parent
@@ -27,10 +28,10 @@ class LessonPage : Page, Parent {
     override val content: List<Content>
 
     internal constructor(
-        manifest: Manifest,
+        container: HasPages,
         fileName: String?,
         parser: XmlPullParser
-    ) : super(manifest, fileName, parser) {
+    ) : super(container, fileName, parser) {
         parser.require(XmlPullParser.START_TAG, XMLNS_LESSON, XML_PAGE)
 
         analyticsEvents = mutableListOf()

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/lesson/LessonPage.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/lesson/LessonPage.kt
@@ -72,6 +72,4 @@ class LessonPage : Page, Parent {
 
         content = emptyList()
     }
-
-    override fun supports(type: Manifest.Type) = type == Manifest.Type.LESSON
 }

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/page/CardCollectionPage.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/page/CardCollectionPage.kt
@@ -73,8 +73,6 @@ class CardCollectionPage : Page {
         cards = emptyList()
     }
 
-    override fun supports(type: Manifest.Type) = type == Manifest.Type.CYOA
-
     class Card : BaseModel, Parent, HasAnalyticsEvents {
         internal companion object {
             internal const val XML_CARD = "card"

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/page/CardCollectionPage.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/page/CardCollectionPage.kt
@@ -9,6 +9,7 @@ import org.cru.godtools.shared.tool.parser.model.AnalyticsEvent.Trigger
 import org.cru.godtools.shared.tool.parser.model.BaseModel
 import org.cru.godtools.shared.tool.parser.model.Content
 import org.cru.godtools.shared.tool.parser.model.HasAnalyticsEvents
+import org.cru.godtools.shared.tool.parser.model.HasPages
 import org.cru.godtools.shared.tool.parser.model.Manifest
 import org.cru.godtools.shared.tool.parser.model.Parent
 import org.cru.godtools.shared.tool.parser.model.PlatformColor
@@ -32,10 +33,10 @@ class CardCollectionPage : Page {
     val cards: List<Card>
 
     internal constructor(
-        manifest: Manifest,
+        container: HasPages,
         fileName: String?,
         parser: XmlPullParser
-    ) : super(manifest, fileName, parser) {
+    ) : super(container, fileName, parser) {
         parser.require(XmlPullParser.START_TAG, XMLNS_PAGE, XML_PAGE)
         parser.requirePageType(TYPE_CARD_COLLECTION)
 

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/page/ContentPage.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/page/ContentPage.kt
@@ -5,6 +5,7 @@ import org.ccci.gto.support.androidx.annotation.RestrictToScope
 import org.cru.godtools.shared.tool.parser.model.AnalyticsEvent
 import org.cru.godtools.shared.tool.parser.model.AnalyticsEvent.Companion.parseAnalyticsEvents
 import org.cru.godtools.shared.tool.parser.model.Content
+import org.cru.godtools.shared.tool.parser.model.HasPages
 import org.cru.godtools.shared.tool.parser.model.Manifest
 import org.cru.godtools.shared.tool.parser.model.Parent
 import org.cru.godtools.shared.tool.parser.model.XMLNS_ANALYTICS
@@ -23,10 +24,10 @@ class ContentPage : Page, Parent {
     override val content: List<Content>
 
     internal constructor(
-        manifest: Manifest,
+        container: HasPages,
         fileName: String?,
         parser: XmlPullParser
-    ) : super(manifest, fileName, parser) {
+    ) : super(container, fileName, parser) {
         parser.require(XmlPullParser.START_TAG, XMLNS_PAGE, XML_PAGE)
         parser.requirePageType(TYPE_CONTENT)
 
@@ -47,10 +48,10 @@ class ContentPage : Page, Parent {
 
     @RestrictTo(RestrictToScope.TESTS)
     internal constructor(
-        manifest: Manifest,
+        container: HasPages,
         id: String? = null,
         parentPage: String? = null
-    ) : super(manifest, id = id, parentPage = parentPage) {
+    ) : super(container, id = id, parentPage = parentPage) {
         analyticsEvents = emptyList()
         content = emptyList()
     }

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/page/ContentPage.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/page/ContentPage.kt
@@ -6,7 +6,6 @@ import org.cru.godtools.shared.tool.parser.model.AnalyticsEvent
 import org.cru.godtools.shared.tool.parser.model.AnalyticsEvent.Companion.parseAnalyticsEvents
 import org.cru.godtools.shared.tool.parser.model.Content
 import org.cru.godtools.shared.tool.parser.model.HasPages
-import org.cru.godtools.shared.tool.parser.model.Manifest
 import org.cru.godtools.shared.tool.parser.model.Parent
 import org.cru.godtools.shared.tool.parser.model.XMLNS_ANALYTICS
 import org.cru.godtools.shared.tool.parser.model.parseContent
@@ -55,6 +54,4 @@ class ContentPage : Page, Parent {
         analyticsEvents = emptyList()
         content = emptyList()
     }
-
-    override fun supports(type: Manifest.Type) = type == Manifest.Type.CYOA
 }

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/page/Page.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/page/Page.kt
@@ -181,7 +181,7 @@ abstract class Page : BaseModel, Styles, HasAnalyticsEvents {
     @AndroidColorInt
     private val _cardBackgroundColor: PlatformColor?
     @get:AndroidColorInt
-    override val cardBackgroundColor get() = _cardBackgroundColor ?: manifest.cardBackgroundColor
+    override val cardBackgroundColor get() = _cardBackgroundColor ?: super.cardBackgroundColor
 
     private val _multiselectOptionBackgroundColor: PlatformColor?
     override val multiselectOptionBackgroundColor

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/page/Page.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/page/Page.kt
@@ -142,9 +142,9 @@ abstract class Page : BaseModel, Styles, HasAnalyticsEvents {
     internal val fileName: String?
 
     private val _parentPage: String?
-    val parentPage get() = manifest.findPage(_parentPage)
-    val nextPage get() = manifest.pages.getOrNull(position + 1)
-    val previousPage get() = manifest.pages.getOrNull(position - 1)
+    val parentPage get() = hasPagesParent.findPage(_parentPage)
+    val nextPage get() = hasPagesParent.pages.getOrNull(position + 1)
+    val previousPage get() = hasPagesParent.pages.getOrNull(position - 1)
 
     val isHidden: Boolean
 

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/page/Page.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/page/Page.kt
@@ -9,6 +9,7 @@ import kotlin.native.HiddenFromObjC
 import org.ccci.gto.support.androidx.annotation.RestrictTo
 import org.ccci.gto.support.androidx.annotation.RestrictToScope
 import org.ccci.gto.support.androidx.annotation.VisibleForTesting
+import org.cru.godtools.shared.tool.parser.ParserConfig.Companion.FEATURE_PAGE_COLLECTION
 import org.cru.godtools.shared.tool.parser.internal.AndroidColorInt
 import org.cru.godtools.shared.tool.parser.model.AnalyticsEvent
 import org.cru.godtools.shared.tool.parser.model.AnalyticsEvent.Trigger
@@ -71,6 +72,8 @@ private const val XML_HIDDEN = "hidden"
 abstract class Page : BaseModel, Styles, HasAnalyticsEvents {
     internal companion object {
         internal const val XML_PAGE = "page"
+
+        private const val XML_PARENT_PAGE_COLLECTION_OVERRIDE = "parent_override_page-collection"
 
         @AndroidColorInt
         @VisibleForTesting
@@ -210,7 +213,10 @@ abstract class Page : BaseModel, Styles, HasAnalyticsEvents {
 
         _id = parser.getAttributeValue(XML_ID)
         this.fileName = fileName
-        _parentPage = parser.getAttributeValue(XMLNS_CYOA, XML_PARENT)
+        _parentPage =
+            parser.getAttributeValue(XMLNS_CYOA, XML_PARENT_PAGE_COLLECTION_OVERRIDE)
+                ?.takeIf { manifest.config.supportsFeature(FEATURE_PAGE_COLLECTION) }
+                ?: parser.getAttributeValue(XMLNS_CYOA, XML_PARENT)
 
         isHidden = parser.getAttributeValue(XML_HIDDEN)?.toBoolean() ?: false
 

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/page/Page.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/page/Page.kt
@@ -48,6 +48,7 @@ import org.cru.godtools.shared.tool.parser.model.page.ContentPage.Companion.TYPE
 import org.cru.godtools.shared.tool.parser.model.page.Page.Companion.DEFAULT_BACKGROUND_COLOR
 import org.cru.godtools.shared.tool.parser.model.page.Page.Companion.DEFAULT_BACKGROUND_IMAGE_GRAVITY
 import org.cru.godtools.shared.tool.parser.model.page.Page.Companion.DEFAULT_BACKGROUND_IMAGE_SCALE_TYPE
+import org.cru.godtools.shared.tool.parser.model.page.PageCollectionPage.Companion.TYPE_PAGE_COLLECTION
 import org.cru.godtools.shared.tool.parser.model.primaryColor
 import org.cru.godtools.shared.tool.parser.model.primaryTextColor
 import org.cru.godtools.shared.tool.parser.model.stylesParent
@@ -89,6 +90,7 @@ abstract class Page : BaseModel, Styles, HasAnalyticsEvents {
                 XMLNS_PAGE -> when (val type = parser.getAttributeValue(XMLNS_XSI, XML_TYPE)) {
                     TYPE_CARD_COLLECTION -> CardCollectionPage(container, fileName, parser)
                     TYPE_CONTENT -> ContentPage(container, fileName, parser)
+                    TYPE_PAGE_COLLECTION -> PageCollectionPage(container, fileName, parser)
                     else -> {
                         val message = "Unrecognized page type: <${parser.namespace}:${parser.name} type=$type>"
                         Logger.e(message, UnsupportedOperationException(message), "Page")

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/page/Page.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/page/Page.kt
@@ -135,7 +135,7 @@ abstract class Page : BaseModel, Styles, HasAnalyticsEvents {
         }
 
     val id by lazy { _id ?: fileName ?: "${manifest.code}-$position" }
-    val position by lazy { manifest.pages.indexOf(this) }
+    val position by lazy { hasPagesParent.pages.indexOf(this) }
 
     private val _id: String?
     @VisibleForTesting

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/page/Page.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/page/Page.kt
@@ -127,6 +127,13 @@ abstract class Page : BaseModel, Styles, HasAnalyticsEvents {
         }
     }
 
+    private val hasPagesParent: HasPages
+        get() {
+            var parent = parent
+            while (parent !is HasPages) parent = parent?.parent ?: return manifest
+            return parent
+        }
+
     val id by lazy { _id ?: fileName ?: "${manifest.code}-$position" }
     val position by lazy { manifest.pages.indexOf(this) }
 
@@ -168,7 +175,8 @@ abstract class Page : BaseModel, Styles, HasAnalyticsEvents {
     @Suppress("ktlint:standard:property-naming") // https://github.com/pinterest/ktlint/issues/2448
     private val _controlColor: PlatformColor?
     @get:AndroidColorInt
-    internal val controlColor get() = _controlColor ?: manifest.pageControlColor
+    internal val controlColor: PlatformColor
+        get() = _controlColor ?: (hasPagesParent as? Page)?.controlColor ?: manifest.pageControlColor
 
     @AndroidColorInt
     private val _cardBackgroundColor: PlatformColor?

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/page/Page.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/page/Page.kt
@@ -102,7 +102,7 @@ abstract class Page : BaseModel, Styles, HasAnalyticsEvents {
                     Logger.e(message, UnsupportedOperationException(message), "Page")
                     null
                 }
-            }?.takeIf { it.supports(container.manifest.type) }
+            }?.takeIf { container.supportsPageType(it::class) }
         }
 
         internal fun XmlPullParser.requirePageType(type: String) {
@@ -254,8 +254,6 @@ abstract class Page : BaseModel, Styles, HasAnalyticsEvents {
         _textColor = textColor
         _textScale = textScale
     }
-
-    internal abstract fun supports(type: Manifest.Type): Boolean
 
     // region HasAnalyticsEvents
     @VisibleForTesting

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/page/PageCollectionPage.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/page/PageCollectionPage.kt
@@ -1,0 +1,64 @@
+package org.cru.godtools.shared.tool.parser.model.page
+
+import org.cru.godtools.shared.tool.parser.ParserConfig.Companion.FEATURE_PAGE_COLLECTION
+import org.cru.godtools.shared.tool.parser.model.AnalyticsEvent
+import org.cru.godtools.shared.tool.parser.model.AnalyticsEvent.Companion.parseAnalyticsEvents
+import org.cru.godtools.shared.tool.parser.model.HasPages
+import org.cru.godtools.shared.tool.parser.model.Manifest
+import org.cru.godtools.shared.tool.parser.model.XMLNS_ANALYTICS
+import org.cru.godtools.shared.tool.parser.xml.XmlPullParser
+import org.cru.godtools.shared.tool.parser.xml.parseChildren
+
+class PageCollectionPage : Page, HasPages {
+    companion object {
+        internal const val TYPE_PAGE_COLLECTION = "page-collection"
+
+        private const val XML_PAGES = "pages"
+    }
+
+    override val analyticsEvents: List<AnalyticsEvent>
+    override val pages: List<Page>
+
+    internal constructor(
+        container: HasPages,
+        fileName: String?,
+        parser: XmlPullParser
+    ) : super(container, fileName, parser) {
+        parser.require(XmlPullParser.START_TAG, XMLNS_PAGE, XML_PAGE)
+        parser.requirePageType(TYPE_PAGE_COLLECTION)
+
+        analyticsEvents = mutableListOf()
+        pages = mutableListOf()
+        parser.parseChildren {
+            when (parser.namespace) {
+                XMLNS_ANALYTICS -> when (parser.name) {
+                    AnalyticsEvent.XML_EVENTS -> analyticsEvents += parser.parseAnalyticsEvents(this)
+                }
+
+                XMLNS_PAGE -> when (parser.name) {
+                    XML_PAGES -> pages += parser.parsePages()
+                }
+            }
+        }
+    }
+
+    private fun XmlPullParser.parsePages() = buildList {
+        require(XmlPullParser.START_TAG, XMLNS_PAGE, XML_PAGES)
+
+        // process any child elements
+        parseChildren {
+            when (namespace) {
+                XMLNS_PAGE -> when (name) {
+                    XML_PAGE -> {
+                        parse(this@PageCollectionPage, null, this@parsePages)
+                            ?.takeIf { it is ContentPage }
+                            ?.let { add(it) }
+                    }
+                }
+            }
+        }
+    }
+
+    override fun supports(type: Manifest.Type) =
+        type == Manifest.Type.CYOA && manifest.config.supportsFeature(FEATURE_PAGE_COLLECTION)
+}

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/page/PageCollectionPage.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/page/PageCollectionPage.kt
@@ -21,6 +21,8 @@ class PageCollectionPage : Page, HasPages {
         private const val XML_IMPORT = "import"
         private const val XML_IMPORT_FILENAME = "filename"
 
+        const val PARENT_PARAM_ACTIVE_PAGE = "active-page"
+
         internal suspend fun parse(
             container: HasPages,
             fileName: String?,

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/page/PageCollectionPage.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/page/PageCollectionPage.kt
@@ -1,10 +1,9 @@
 package org.cru.godtools.shared.tool.parser.model.page
 
-import org.cru.godtools.shared.tool.parser.ParserConfig.Companion.FEATURE_PAGE_COLLECTION
+import kotlin.reflect.KClass
 import org.cru.godtools.shared.tool.parser.model.AnalyticsEvent
 import org.cru.godtools.shared.tool.parser.model.AnalyticsEvent.Companion.parseAnalyticsEvents
 import org.cru.godtools.shared.tool.parser.model.HasPages
-import org.cru.godtools.shared.tool.parser.model.Manifest
 import org.cru.godtools.shared.tool.parser.model.XMLNS_ANALYTICS
 import org.cru.godtools.shared.tool.parser.xml.XmlPullParser
 import org.cru.godtools.shared.tool.parser.xml.parseChildren
@@ -51,7 +50,7 @@ class PageCollectionPage : Page, HasPages {
                 XMLNS_PAGE -> when (name) {
                     XML_PAGE -> {
                         parse(this@PageCollectionPage, null, this@parsePages)
-                            ?.takeIf { it is ContentPage }
+                            ?.takeIf { supportsPageType(it::class) }
                             ?.let { add(it) }
                     }
                 }
@@ -59,6 +58,5 @@ class PageCollectionPage : Page, HasPages {
         }
     }
 
-    override fun supports(type: Manifest.Type) =
-        type == Manifest.Type.CYOA && manifest.config.supportsFeature(FEATURE_PAGE_COLLECTION)
+    override fun <T : Page> supportsPageType(type: KClass<T>) = type == ContentPage::class
 }

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/tract/TractPage.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/tract/TractPage.kt
@@ -134,8 +134,6 @@ class TractPage : Page {
         this.callToAction = callToAction?.invoke(this) ?: CallToAction(this)
     }
 
-    override fun supports(type: Manifest.Type) = type == Manifest.Type.TRACT
-
     fun findModal(id: String?) = modals.firstOrNull { it.id.equals(id, ignoreCase = true) }
 
     // region Cards

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/tract/TractPage.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/tract/TractPage.kt
@@ -19,6 +19,7 @@ import org.cru.godtools.shared.tool.parser.model.EventId
 import org.cru.godtools.shared.tool.parser.model.Gravity
 import org.cru.godtools.shared.tool.parser.model.Gravity.Companion.toGravityOrNull
 import org.cru.godtools.shared.tool.parser.model.HasAnalyticsEvents
+import org.cru.godtools.shared.tool.parser.model.HasPages
 import org.cru.godtools.shared.tool.parser.model.ImageScaleType
 import org.cru.godtools.shared.tool.parser.model.ImageScaleType.Companion.toImageScaleTypeOrNull
 import org.cru.godtools.shared.tool.parser.model.Manifest
@@ -66,10 +67,10 @@ class TractPage : Page {
     val callToAction: CallToAction
 
     internal constructor(
-        manifest: Manifest,
+        container: HasPages,
         fileName: String?,
         parser: XmlPullParser
-    ) : super(manifest, fileName, parser) {
+    ) : super(container, fileName, parser) {
         parser.require(XmlPullParser.START_TAG, XMLNS_TRACT, XML_PAGE)
 
         _cardTextColor = parser.getAttributeValue(XML_CARD_TEXT_COLOR)?.toColorOrNull()

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/analytics/ToolAnalyticsScreenNamesTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/analytics/ToolAnalyticsScreenNamesTest.kt
@@ -14,7 +14,7 @@ class ToolAnalyticsScreenNamesTest {
     @Test
     fun testForCyoaPage() {
         val page = ContentPage(
-            manifest = Manifest(code = "cyoa"),
+            container = Manifest(code = "cyoa"),
             id = "page"
         )
 

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/internal/UsesResources.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/internal/UsesResources.kt
@@ -1,8 +1,11 @@
 package org.cru.godtools.shared.tool.parser.internal
 
+import org.cru.godtools.shared.tool.parser.xml.XmlPullParser
 import org.cru.godtools.shared.tool.parser.xml.XmlPullParserFactory
 
 abstract class UsesResources(internal val resourcesDir: String? = "model") {
+    internal val parseFile: suspend (String) -> XmlPullParser = { getTestXmlParser(it) }
+
     internal suspend fun getTestXmlParser(name: String) =
         TEST_XML_PULL_PARSER_FACTORY.getXmlParser(name)!!.apply { nextTag() }
 }

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/page/PageCollectionPageTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/page/PageCollectionPageTest.kt
@@ -1,0 +1,44 @@
+package org.cru.godtools.shared.tool.parser.model.page
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlinx.coroutines.test.runTest
+import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
+import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
+import org.cru.godtools.shared.tool.parser.ParserConfig
+import org.cru.godtools.shared.tool.parser.ParserConfig.Companion.FEATURE_PAGE_COLLECTION
+import org.cru.godtools.shared.tool.parser.internal.UsesResources
+import org.cru.godtools.shared.tool.parser.model.Manifest
+import org.cru.godtools.shared.tool.parser.xml.XmlPullParserException
+
+@RunOnAndroidWith(AndroidJUnit4::class)
+class PageCollectionPageTest : UsesResources("model/page") {
+    private val manifest = Manifest(
+        config = ParserConfig().withSupportedFeatures(FEATURE_PAGE_COLLECTION),
+        type = Manifest.Type.CYOA,
+    )
+
+    // region Parse XML
+    @Test
+    fun testParsePageCollectionPage() = runTest {
+        assertNotNull(PageCollectionPage(manifest, null, getTestXmlParser("page_page-collection.xml"))) {
+            assertEquals(1, it.analyticsEvents.size)
+            assertEquals(1, it.pages.size)
+            assertNotNull(it.pages[0]) { page ->
+                assertIs<ContentPage>(page)
+                assertEquals("content_page", page.id)
+            }
+        }
+    }
+
+    @Test
+    fun testParsePageCollectionPageInvalidType() = runTest {
+        assertFailsWith(XmlPullParserException::class) {
+            PageCollectionPage(manifest, null, getTestXmlParser("page_invalid_type.xml"))
+        }
+    }
+    // endregion Parse XML
+}

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/page/PageCollectionPageTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/page/PageCollectionPageTest.kt
@@ -19,12 +19,18 @@ class PageCollectionPageTest : UsesResources("model/page") {
     private val manifest = Manifest(
         config = ParserConfig().withSupportedFeatures(FEATURE_PAGE_COLLECTION),
         type = Manifest.Type.CYOA,
+        pageXmlFiles = listOf(
+            Manifest.XmlFile("ref_page_valid", "page_content.xml"),
+            Manifest.XmlFile("ref_page_invalid", "page_page-collection_imports.xml"),
+        ),
     )
 
     // region Parse XML
     @Test
     fun testParsePageCollectionPage() = runTest {
-        assertNotNull(PageCollectionPage(manifest, null, getTestXmlParser("page_page-collection.xml"))) {
+        assertNotNull(
+            PageCollectionPage.parse(manifest, null, getTestXmlParser("page_page-collection.xml"), parseFile)
+        ) {
             assertEquals(1, it.analyticsEvents.size)
             assertEquals(1, it.pages.size)
             assertNotNull(it.pages[0]) { page ->
@@ -35,9 +41,21 @@ class PageCollectionPageTest : UsesResources("model/page") {
     }
 
     @Test
+    fun testParsePageCollectionPage_PageImports() = runTest {
+        assertNotNull(
+            PageCollectionPage.parse(manifest, null, getTestXmlParser("page_page-collection_imports.xml"), parseFile)
+        ) {
+            assertEquals(1, it.analyticsEvents.size)
+            assertEquals(2, it.pages.size)
+            assertEquals("embedded_content_page", it.pages[0].id)
+            assertEquals("content_page", it.pages[1].id)
+        }
+    }
+
+    @Test
     fun testParsePageCollectionPageInvalidType() = runTest {
         assertFailsWith(XmlPullParserException::class) {
-            PageCollectionPage(manifest, null, getTestXmlParser("page_invalid_type.xml"))
+            PageCollectionPage.parse(manifest, null, getTestXmlParser("page_invalid_type.xml"), parseFile)
         }
     }
     // endregion Parse XML

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/page/PageTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/page/PageTest.kt
@@ -8,6 +8,8 @@ import kotlin.test.assertSame
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
 import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
+import org.cru.godtools.shared.tool.parser.ParserConfig
+import org.cru.godtools.shared.tool.parser.ParserConfig.Companion.FEATURE_PAGE_COLLECTION
 import org.cru.godtools.shared.tool.parser.internal.UsesResources
 import org.cru.godtools.shared.tool.parser.model.AnalyticsEvent
 import org.cru.godtools.shared.tool.parser.model.Manifest
@@ -41,6 +43,35 @@ class PageTest : UsesResources("model/page") {
             Page.parse(Manifest(type = Manifest.Type.LESSON), null, getTestXmlParser("../lesson/page.xml"))
         )
         assertNull(Page.parse(Manifest(type = Manifest.Type.TRACT), null, getTestXmlParser("../lesson/page.xml")))
+    }
+
+    @Test
+    fun testParsePageCollectionPage() = runTest {
+        val config = ParserConfig().withSupportedFeatures(FEATURE_PAGE_COLLECTION)
+        assertIs<PageCollectionPage>(
+            Page.parse(
+                Manifest(config = config, type = Manifest.Type.CYOA),
+                null,
+                getTestXmlParser("page_page-collection.xml"),
+                parseFile,
+            ),
+        )
+        assertNull(
+            Page.parse(
+                Manifest(type = Manifest.Type.CYOA),
+                null,
+                getTestXmlParser("page_page-collection.xml"),
+                parseFile,
+            ),
+        )
+        assertNull(
+            Page.parse(
+                Manifest(config = config, type = Manifest.Type.LESSON),
+                null,
+                getTestXmlParser("page_page-collection.xml"),
+                parseFile,
+            ),
+        )
     }
 
     @Test

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/page/PageTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/page/PageTest.kt
@@ -99,6 +99,32 @@ class PageTest : UsesResources("model/page") {
     }
     // endregion Page.parse()
 
+    // region Property: position
+    @Test
+    fun testPosition_manifest() {
+        val manifest = Manifest(
+            pages = { listOf(ContentPage(it, id = "page1"), ContentPage(it, id = "page2")) }
+        )
+
+        val page1 = manifest.findPage("page1")!!
+        val page2 = manifest.findPage("page2")!!
+        assertEquals(0, page1.position)
+        assertEquals(1, page2.position)
+    }
+
+    @Test
+    fun testPosition_hasPagesParent() {
+        val parent = TestPage(
+            pages = { listOf(ContentPage(it, id = "page1"), ContentPage(it, id = "page2")) }
+        )
+
+        val page1 = parent.findPage("page1")!!
+        val page2 = parent.findPage("page2")!!
+        assertEquals(0, page1.position)
+        assertEquals(1, page2.position)
+    }
+    // endregion Property: position
+
     // region Property: cardBackgroundColor
     @Test
     fun testPropertyCardBackgroundColor() {
@@ -215,7 +241,7 @@ class PageTest : UsesResources("model/page") {
         multiselectOptionBackgroundColor: PlatformColor? = null,
         multiselectOptionSelectedColor: PlatformColor? = null,
         override val analyticsEvents: List<AnalyticsEvent> = emptyList(),
-        override val pages: List<Page> = emptyList(),
+        pages: ((HasPages) -> List<Page>?)? = null,
     ) :
         Page(
             container = parent,
@@ -225,6 +251,7 @@ class PageTest : UsesResources("model/page") {
             multiselectOptionSelectedColor = multiselectOptionSelectedColor,
         ),
         HasPages {
+        override val pages: List<Page> = pages?.invoke(this).orEmpty()
         override fun <T : Page> supportsPageType(type: KClass<T>) = true
     }
 }

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/page/PageTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/page/PageTest.kt
@@ -195,7 +195,7 @@ class PageTest : UsesResources("model/page") {
 
     // region Property: parentPage
     @Test
-    fun testParentPage() {
+    fun testParentPage_manifest() {
         val manifest = Manifest(
             pages = { listOf(ContentPage(it, id = "page1"), ContentPage(it, id = "page2", parentPage = "page1")) }
         )
@@ -204,11 +204,22 @@ class PageTest : UsesResources("model/page") {
         val page2 = manifest.findPage("page2")!!
         assertSame(page1, page2.parentPage)
     }
+
+    @Test
+    fun testParentPage_hasPagesParent() {
+        val parent = TestPage(
+            pages = { listOf(ContentPage(it, id = "page1"), ContentPage(it, id = "page2", parentPage = "page1")) }
+        )
+
+        val page1 = parent.findPage("page1")!!
+        val page2 = parent.findPage("page2")!!
+        assertSame(page1, page2.parentPage)
+    }
     // endregion Property: parentPage
 
     // region Property: nextPage
     @Test
-    fun testNextPage() {
+    fun testNextPage_manifest() {
         val manifest = Manifest(
             pages = { listOf(ContentPage(it, id = "page1"), ContentPage(it, id = "page2")) }
         )
@@ -218,17 +229,41 @@ class PageTest : UsesResources("model/page") {
         assertSame(page2, page1.nextPage)
         assertNull(page2.nextPage)
     }
+
+    @Test
+    fun testNextPage_hasPagesParent() {
+        val parent = TestPage(
+            pages = { listOf(ContentPage(it, id = "page1"), ContentPage(it, id = "page2")) }
+        )
+
+        val page1 = parent.findPage("page1")!!
+        val page2 = parent.findPage("page2")!!
+        assertSame(page2, page1.nextPage)
+        assertNull(page2.nextPage)
+    }
     // endregion Property: nextPage
 
     // region Property: previousPage
     @Test
-    fun testPreviousPage() {
+    fun testPreviousPage_manifest() {
         val manifest = Manifest(
             pages = { listOf(ContentPage(it, id = "page1"), ContentPage(it, id = "page2")) }
         )
 
         val page1 = manifest.findPage("page1")!!
         val page2 = manifest.findPage("page2")!!
+        assertSame(page1, page2.previousPage)
+        assertNull(page1.previousPage)
+    }
+
+    @Test
+    fun testPreviousPage_hasPagesParent() {
+        val parent = TestPage(
+            pages = { listOf(ContentPage(it, id = "page1"), ContentPage(it, id = "page2")) }
+        )
+
+        val page1 = parent.findPage("page1")!!
+        val page2 = parent.findPage("page2")!!
         assertSame(page1, page2.previousPage)
         assertNull(page1.previousPage)
     }

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/page/PageTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/page/PageTest.kt
@@ -156,7 +156,5 @@ class PageTest : UsesResources("model/page") {
         container = manifest,
         multiselectOptionBackgroundColor = multiselectOptionBackgroundColor,
         multiselectOptionSelectedColor = multiselectOptionSelectedColor,
-    ) {
-        override fun supports(type: Manifest.Type) = true
-    }
+    )
 }

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/page/PageTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/page/PageTest.kt
@@ -153,7 +153,7 @@ class PageTest : UsesResources("model/page") {
         multiselectOptionSelectedColor: PlatformColor? = null,
         override val analyticsEvents: List<AnalyticsEvent> = emptyList(),
     ) : Page(
-        manifest = manifest,
+        container = manifest,
         multiselectOptionBackgroundColor = multiselectOptionBackgroundColor,
         multiselectOptionSelectedColor = multiselectOptionSelectedColor,
     ) {

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/page/PageTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/page/PageTest.kt
@@ -99,6 +99,20 @@ class PageTest : UsesResources("model/page") {
     }
     // endregion Page.parse()
 
+    // region Property: cardBackgroundColor
+    @Test
+    fun testPropertyCardBackgroundColor() {
+        val manifest = Manifest(cardBackgroundColor = TestColors.GREEN)
+        val hasPagesParent = TestPage(parent = manifest, cardBackgroundColor = TestColors.BLUE)
+
+        assertEquals(TestColors.RED, TestPage(manifest, cardBackgroundColor = TestColors.RED).cardBackgroundColor)
+        assertEquals(TestColors.RED, TestPage(hasPagesParent, cardBackgroundColor = TestColors.RED).cardBackgroundColor)
+        assertEquals(TestColors.GREEN, TestPage(manifest, cardBackgroundColor = null).cardBackgroundColor)
+        assertEquals(TestColors.GREEN, TestPage(TestPage(manifest, cardBackgroundColor = null)).cardBackgroundColor)
+        assertEquals(TestColors.BLUE, TestPage(hasPagesParent, cardBackgroundColor = null).cardBackgroundColor)
+    }
+    // endregion Property: cardBackgroundColor
+
     // region Property: controlColor
     @Test
     fun testPropertyControlColor() {
@@ -196,6 +210,7 @@ class PageTest : UsesResources("model/page") {
 
     private class TestPage(
         parent: HasPages = Manifest(),
+        cardBackgroundColor: PlatformColor? = null,
         controlColor: PlatformColor? = null,
         multiselectOptionBackgroundColor: PlatformColor? = null,
         multiselectOptionSelectedColor: PlatformColor? = null,
@@ -204,6 +219,7 @@ class PageTest : UsesResources("model/page") {
     ) :
         Page(
             container = parent,
+            cardBackgroundColor = cardBackgroundColor,
             controlColor = controlColor,
             multiselectOptionBackgroundColor = multiselectOptionBackgroundColor,
             multiselectOptionSelectedColor = multiselectOptionSelectedColor,

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/tract/TractPageTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/tract/TractPageTest.kt
@@ -105,13 +105,6 @@ class TractPageTest : UsesResources("model/tract") {
     }
 
     @Test
-    fun testCardBackgroundColorFallbackBehavior() {
-        val manifest = Manifest(cardBackgroundColor = TestColors.BLUE)
-        assertEquals(TestColors.GREEN, TractPage(manifest, cardBackgroundColor = TestColors.GREEN).cardBackgroundColor)
-        assertEquals(manifest.cardBackgroundColor, TractPage(manifest).cardBackgroundColor)
-    }
-
-    @Test
     fun testCardTextColorBehavior() {
         with(TractPage(textColor = TestColors.GREEN)) {
             assertEquals(TestColors.GREEN, cardTextColor)

--- a/module/parser/src/commonTest/resources/org/cru/godtools/shared/tool/parser/model/page/page_content.xml
+++ b/module/parser/src/commonTest/resources/org/cru/godtools/shared/tool/parser/model/page/page_content.xml
@@ -1,7 +1,7 @@
 <page xmlns="https://mobile-content-api.cru.org/xmlns/page"
     xmlns:analytics="https://mobile-content-api.cru.org/xmlns/analytics"
     xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="content">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="content" id="content_page">
     <analytics:events>
         <analytics:event action="test" system="firebase" />
     </analytics:events>

--- a/module/parser/src/commonTest/resources/org/cru/godtools/shared/tool/parser/model/page/page_content_parent.xml
+++ b/module/parser/src/commonTest/resources/org/cru/godtools/shared/tool/parser/model/page/page_content_parent.xml
@@ -1,0 +1,6 @@
+<page xmlns="https://mobile-content-api.cru.org/xmlns/page"
+    xmlns:cyoa="https://mobile-content-api.cru.org/xmlns/cyoa"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="content"
+    cyoa:parent="page1?param=value">
+    <content />
+</page>

--- a/module/parser/src/commonTest/resources/org/cru/godtools/shared/tool/parser/model/page/page_content_parent_override.xml
+++ b/module/parser/src/commonTest/resources/org/cru/godtools/shared/tool/parser/model/page/page_content_parent_override.xml
@@ -1,0 +1,6 @@
+<page xmlns="https://mobile-content-api.cru.org/xmlns/page"
+    xmlns:cyoa="https://mobile-content-api.cru.org/xmlns/cyoa"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="content"
+    cyoa:parent="page1?param=value" cyoa:parent_override_page-collection="page2?param=value2">
+    <content />
+</page>

--- a/module/parser/src/commonTest/resources/org/cru/godtools/shared/tool/parser/model/page/page_page-collection.xml
+++ b/module/parser/src/commonTest/resources/org/cru/godtools/shared/tool/parser/model/page/page_page-collection.xml
@@ -1,0 +1,30 @@
+<page xmlns="https://mobile-content-api.cru.org/xmlns/page"
+    xmlns:analytics="https://mobile-content-api.cru.org/xmlns/analytics"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="page-collection">
+    <analytics:events>
+        <analytics:event action="test" system="firebase" />
+    </analytics:events>
+
+    <pages>
+        <page id="content_page" xsi:type="content">
+            <analytics:events>
+                <analytics:event action="test2" system="firebase" />
+            </analytics:events>
+            <content>
+                <content:spacer />
+                <content:paragraph>
+                    <content:text>Text</content:text>
+                </content:paragraph>
+            </content>
+        </page>
+        <page id="card_collection_page" xsi:type="cardcollection">
+            <analytics:events>
+                <analytics:event action="test3" system="firebase" />
+            </analytics:events>
+            <cards>
+                <card />
+            </cards>
+        </page>
+    </pages>
+</page>

--- a/module/parser/src/commonTest/resources/org/cru/godtools/shared/tool/parser/model/page/page_page-collection_imports.xml
+++ b/module/parser/src/commonTest/resources/org/cru/godtools/shared/tool/parser/model/page/page_page-collection_imports.xml
@@ -1,0 +1,26 @@
+<page xmlns="https://mobile-content-api.cru.org/xmlns/page"
+    xmlns:analytics="https://mobile-content-api.cru.org/xmlns/analytics"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="page-collection">
+    <analytics:events>
+        <analytics:event action="test" system="firebase" />
+    </analytics:events>
+
+    <pages>
+        <page id="embedded_content_page" xsi:type="content">
+            <analytics:events>
+                <analytics:event action="test2" system="firebase" />
+            </analytics:events>
+            <content>
+                <content:spacer />
+                <content:paragraph>
+                    <content:text>Text</content:text>
+                </content:paragraph>
+            </content>
+        </page>
+        <import filename="ref_page_valid" />
+        <import filename="ref_page_invalid" />
+        <import filename="ref_page_missing" />
+        <import />
+    </pages>
+</page>


### PR DESCRIPTION
This adds support for parsing the new page collection page type for CYOA tools. This functionality is behind a new `FEATURE_PAGE_COLLECTION` feature flag that can be enabled when you are ready to use the functionality.

a `PageCollectionPage` contains a list of pages that should be rendered as a swipeable view pager.

TODO:
- [x] Figure out how to reference & handle `parentPage` when that parent is actually a page in a `PageCollectionPage`