### PR TITLE
TypeScript export updates

### DIFF
--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Accordion.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Accordion.kt
@@ -22,6 +22,7 @@ class Accordion : Content {
     }
 
     @JsName("_sections")
+    @JsExport.Ignore
     val sections: List<Section>
     override val tips get() = sections.flatMap { it.contentTips }
 

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Animation.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Animation.kt
@@ -32,8 +32,10 @@ class Animation : Content, Clickable {
     val loop: Boolean
     val autoPlay: Boolean
 
+    @JsExport.Ignore
     @JsName("_playListeners")
     val playListeners: Set<EventId>
+    @JsExport.Ignore
     @JsName("_stopListeners")
     val stopListeners: Set<EventId>
 

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Clickable.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Clickable.kt
@@ -24,6 +24,7 @@ private const val XML_URL = "url"
 interface Clickable : Base {
     val isClickable get() = url != null || events.isNotEmpty()
 
+    @JsExport.Ignore
     @JsName("_events")
     val events: List<EventId>
     val url: Uri?

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Flow.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Flow.kt
@@ -34,6 +34,7 @@ class Flow : Content {
 
     internal val rowGravity: Gravity.Horizontal
 
+    @JsExport.Ignore
     @JsName("_items")
     val items: List<Item>
 

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/HasAnalyticsEvents.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/HasAnalyticsEvents.kt
@@ -9,6 +9,7 @@ import kotlin.native.HiddenFromObjC
 @JsExport
 @OptIn(ExperimentalJsExport::class, ExperimentalObjCRefinement::class)
 interface HasAnalyticsEvents {
+    @JsExport.Ignore
     @JsName("_getAnalyticsEvents")
     fun getAnalyticsEvents(type: AnalyticsEvent.Trigger): List<AnalyticsEvent>
 

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/HasPages.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/HasPages.kt
@@ -12,6 +12,7 @@ import org.cru.godtools.shared.tool.parser.model.page.Page
 @JsExport
 @OptIn(ExperimentalJsExport::class, ExperimentalObjCRefinement::class)
 interface HasPages : Base {
+    @JsExport.Ignore
     @JsName("_pages")
     val pages: List<Page>
 

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Manifest.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Manifest.kt
@@ -130,6 +130,7 @@ class Manifest : BaseModel, Styles, HasPages {
     val locale: PlatformLocale?
     val type: Type
 
+    @JsExport.Ignore
     @JsName("_dismissListeners")
     val dismissListeners: Set<EventId>
 

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Multiselect.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Multiselect.kt
@@ -55,6 +55,7 @@ class Multiselect : Content {
     private val _optionSelectedColor: PlatformColor?
     private val optionSelectedColor get() = _optionSelectedColor ?: stylesParent?.multiselectOptionSelectedColor
 
+    @JsExport.Ignore
     @JsName("_options")
     val options: List<Option>
     override val tips get() = options.flatMap { it.contentTips }

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Parent.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Parent.kt
@@ -12,6 +12,7 @@ import org.cru.godtools.shared.tool.parser.xml.parseChildren
 @JsExport
 @OptIn(ExperimentalJsExport::class, ExperimentalObjCRefinement::class)
 interface Parent : Base {
+    @JsExport.Ignore
     @JsName("_content")
     val content: List<Content>
 

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Tabs.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Tabs.kt
@@ -22,6 +22,7 @@ class Tabs : Content {
         internal const val XML_TABS = "tabs"
     }
 
+    @JsExport.Ignore
     @JsName("_tabs")
     val tabs: List<Tab>
     override val tips get() = tabs.flatMap { it.contentTips }

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Text.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Text.kt
@@ -59,6 +59,7 @@ class Text : Content {
     val textColor get() = _textColor ?: stylesParent.textColor
     private val _textScale: Double
     val textScale get() = _textScale * stylesParent.textScale
+    @JsExport.Ignore
     @JsName("_textStyles")
     val textStyles: Set<Style>
 

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/page/Page.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/page/Page.kt
@@ -158,8 +158,10 @@ abstract class Page : BaseModel, Styles, HasAnalyticsEvents {
 
     val isHidden: Boolean
 
+    @JsExport.Ignore
     @JsName("_listeners")
     val listeners: Set<EventId>
+    @JsExport.Ignore
     @JsName("_dismissListeners")
     val dismissListeners: Set<EventId>
 

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/tract/Modal.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/tract/Modal.kt
@@ -38,8 +38,10 @@ class Modal : BaseModel, Parent, Styles {
     val title: Text?
     override val content: List<Content>
 
+    @JsExport.Ignore
     @JsName("_listeners")
     val listeners: Set<EventId>
+    @JsExport.Ignore
     @JsName("_dismissListeners")
     val dismissListeners: Set<EventId>
 

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/tract/TractPage.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/tract/TractPage.kt
@@ -61,6 +61,7 @@ class TractPage : Page {
 
     val header: Header?
     val hero: Hero?
+    @JsExport.Ignore
     @JsName("_modals")
     val modals: List<Modal>
     val callToAction: CallToAction
@@ -136,6 +137,7 @@ class TractPage : Page {
     fun findModal(id: String?) = modals.firstOrNull { it.id.equals(id, ignoreCase = true) }
 
     // region Cards
+    @JsExport.Ignore
     @JsName("_cards")
     val cards: List<Card>
     val visibleCards get() = cards.filter { !it.isHidden }

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/tract/TractPage.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/tract/TractPage.kt
@@ -163,8 +163,11 @@ class TractPage : Page {
         val isLastVisibleCard get() = this == page.visibleCards.lastOrNull()
 
         val isHidden: Boolean
+
+        @JsExport.Ignore
         @JsName("_listeners")
         val listeners: Set<EventId>
+        @JsExport.Ignore
         @JsName("_dismissListeners")
         val dismissListeners: Set<EventId>
 


### PR DESCRIPTION
This PR hides several properties that expose kotlin collections in favor of the already exposed JS Array variants