### PR TITLE
GT-2538 Fix Attribute parsing on Android

### DIFF
--- a/module/parser/src/androidMain/kotlin/org/cru/godtools/shared/tool/parser/xml/AndroidXmlPullParser.kt
+++ b/module/parser/src/androidMain/kotlin/org/cru/godtools/shared/tool/parser/xml/AndroidXmlPullParser.kt
@@ -12,6 +12,6 @@ internal class AndroidXmlPullParser(private val delegate: org.xmlpull.v1.XmlPull
     override fun nextText(): String = delegate.nextText()
 
     override fun getAttributeValue(name: String): String? = delegate.getAttributeValue("", name)
-    override fun getAttributeValue(namespace: String?, name: String): String? =
-        delegate.getAttributeValue(namespace.orEmpty(), name)
+    override fun getAttributeValue(namespace: String, name: String): String? =
+        delegate.getAttributeValue(namespace, name)
 }

--- a/module/parser/src/androidMain/kotlin/org/cru/godtools/shared/tool/parser/xml/AndroidXmlPullParser.kt
+++ b/module/parser/src/androidMain/kotlin/org/cru/godtools/shared/tool/parser/xml/AndroidXmlPullParser.kt
@@ -11,6 +11,7 @@ internal class AndroidXmlPullParser(private val delegate: org.xmlpull.v1.XmlPull
     override fun nextTag() = delegate.nextTag()
     override fun nextText(): String = delegate.nextText()
 
+    override fun getAttributeValue(name: String): String? = delegate.getAttributeValue("", name)
     override fun getAttributeValue(namespace: String?, name: String): String? =
-        delegate.getAttributeValue(namespace, name)
+        delegate.getAttributeValue(namespace.orEmpty(), name)
 }

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Animation.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Animation.kt
@@ -45,9 +45,9 @@ class Animation : Content, Clickable {
     internal constructor(parent: Base, parser: XmlPullParser) : super(parent, parser) {
         parser.require(XmlPullParser.START_TAG, XMLNS_CONTENT, XML_ANIMATION)
 
-        resourceName = parser.getAttributeValue(null, XML_RESOURCE)
-        loop = parser.getAttributeValue(null, XML_LOOP)?.toBoolean() ?: true
-        autoPlay = parser.getAttributeValue(null, XML_AUTOPLAY)?.toBoolean() ?: true
+        resourceName = parser.getAttributeValue(XML_RESOURCE)
+        loop = parser.getAttributeValue(XML_LOOP)?.toBoolean() ?: true
+        autoPlay = parser.getAttributeValue(XML_AUTOPLAY)?.toBoolean() ?: true
 
         playListeners = parser.getAttributeValue(XML_PLAY_LISTENERS).toEventIds().toSet()
         stopListeners = parser.getAttributeValue(XML_STOP_LISTENERS).toEventIds().toSet()

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Content.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Content.kt
@@ -39,7 +39,7 @@ abstract class Content : BaseModel, Visibility {
     final override val goneIf: Expression?
 
     internal constructor(parent: Base, parser: XmlPullParser) : super(parent) {
-        version = parser.getAttributeValue(null, XML_VERSION)?.toIntOrNull() ?: SCHEMA_VERSION
+        version = parser.getAttributeValue(XML_VERSION)?.toIntOrNull() ?: SCHEMA_VERSION
         requiredFeatures = parser.getAttributeValue(XML_REQUIRED_FEATURES)
             ?.split(REGEX_SEQUENCE_SEPARATOR)?.filterTo(mutableSetOf()) { it.isNotBlank() }.orEmpty()
         requiredDeviceType = parser.getAttributeValue(XML_REQUIRED_DEVICE_TYPE)?.toDeviceTypes()

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Manifest.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Manifest.kt
@@ -226,7 +226,7 @@ class Manifest : BaseModel, Styles, HasPages {
         _navBarControlColor = parser.getAttributeValue(XML_NAVBAR_CONTROL_COLOR)?.toColorOrNull()
 
         backgroundColor = parser.getAttributeValue(XML_BACKGROUND_COLOR)?.toColorOrNull() ?: DEFAULT_BACKGROUND_COLOR
-        _backgroundImage = parser.getAttributeValue(null, XML_BACKGROUND_IMAGE)
+        _backgroundImage = parser.getAttributeValue(XML_BACKGROUND_IMAGE)
         backgroundImageGravity = parser.getAttributeValue(XML_BACKGROUND_IMAGE_GRAVITY)?.toGravityOrNull()
             ?: DEFAULT_BACKGROUND_IMAGE_GRAVITY
         backgroundImageScaleType = parser.getAttributeValue(XML_BACKGROUND_IMAGE_SCALE_TYPE)?.toImageScaleTypeOrNull()

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Resource.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Resource.kt
@@ -21,8 +21,8 @@ class Resource : BaseModel {
     internal constructor(manifest: Manifest, parser: XmlPullParser) : super(manifest) {
         parser.require(XmlPullParser.START_TAG, XMLNS_MANIFEST, XML_RESOURCE)
 
-        name = parser.getAttributeValue(null, XML_FILENAME)
-        localName = parser.getAttributeValue(null, XML_SRC)
+        name = parser.getAttributeValue(XML_FILENAME)
+        localName = parser.getAttributeValue(XML_SRC)
 
         parser.skipTag()
     }

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/tips/InlineTip.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/tips/InlineTip.kt
@@ -26,7 +26,7 @@ class InlineTip : Content {
     internal constructor(parent: Base, parser: XmlPullParser) : super(parent, parser) {
         parser.require(XmlPullParser.START_TAG, XMLNS_TRAINING, XML_TIP)
 
-        id = parser.getAttributeValue(null, XML_ID)
+        id = parser.getAttributeValue(XML_ID)
 
         parser.skipTag()
     }

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/tips/Tip.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/tips/Tip.kt
@@ -31,7 +31,7 @@ class Tip : BaseModel, Styles {
         parser.require(XmlPullParser.START_TAG, XMLNS_TRAINING, XML_TIP)
 
         this.id = id
-        type = parser.getAttributeValue(null, XML_TYPE)?.toTypeOrNull() ?: Type.DEFAULT
+        type = parser.getAttributeValue(XML_TYPE)?.toTypeOrNull() ?: Type.DEFAULT
         pages = buildList {
             parser.parseChildren {
                 when (parser.namespace) {

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/tract/TractPage.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/tract/TractPage.kt
@@ -199,7 +199,7 @@ class TractPage : Page {
 
             parser.require(XmlPullParser.START_TAG, XMLNS_TRACT, XML_CARD)
 
-            isHidden = parser.getAttributeValue(null, XML_HIDDEN)?.toBoolean() ?: false
+            isHidden = parser.getAttributeValue(XML_HIDDEN)?.toBoolean() ?: false
             listeners = parser.getAttributeValue(XML_LISTENERS).toEventIds().toSet()
             dismissListeners = parser.getAttributeValue(XML_DISMISS_LISTENERS).toEventIds().toSet()
 

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/xml/SaxXmlPullParser.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/xml/SaxXmlPullParser.kt
@@ -39,7 +39,9 @@ abstract class SaxXmlPullParser : XmlPullParser {
         }
     }
 
-    override fun getAttributeValue(namespace: String?, name: String): String? {
+    override fun getAttributeValue(name: String) = getAttributeValueInt(null, name)
+    override fun getAttributeValue(namespace: String, name: String) = getAttributeValueInt(namespace, name)
+    private fun getAttributeValueInt(namespace: String?, name: String): String? {
         val event = currentEvent.takeIf { it.type == START_TAG } ?: throw IndexOutOfBoundsException()
         return event.attrs?.get(QName(namespace, name))
     }

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/xml/XmlPullParser.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/xml/XmlPullParser.kt
@@ -11,8 +11,8 @@ internal interface XmlPullParser {
     fun nextTag(): Int
     fun nextText(): String
 
-    fun getAttributeValue(name: String) = getAttributeValue(null, name)
-    fun getAttributeValue(namespace: String?, name: String): String?
+    fun getAttributeValue(name: String): String?
+    fun getAttributeValue(namespace: String, name: String): String?
 
     companion object {
         const val START_DOCUMENT = 0

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/xml/XmlPullParserTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/xml/XmlPullParserTest.kt
@@ -1,0 +1,19 @@
+package org.cru.godtools.shared.tool.parser.xml
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
+import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
+import org.cru.godtools.shared.tool.parser.internal.UsesResources
+
+@RunOnAndroidWith(AndroidJUnit4::class)
+class XmlPullParserTest : UsesResources("xml") {
+    @Test
+    fun `getAttributeValue - namespaces`() = runTest {
+        val parser = getTestXmlParser("parser_attributes_namespaces.xml")
+        assertEquals("none", parser.getAttributeValue("attr"))
+        assertEquals("ns1", parser.getAttributeValue("ns1:", "attr"))
+        assertEquals("ns2", parser.getAttributeValue("ns2:", "attr"))
+    }
+}

--- a/module/parser/src/commonTest/resources/org/cru/godtools/shared/tool/parser/xml/parser_attributes_namespaces.xml
+++ b/module/parser/src/commonTest/resources/org/cru/godtools/shared/tool/parser/xml/parser_attributes_namespaces.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<root xmlns:ns1="ns1:" xmlns:ns2="ns2:" attr="none" ns1:attr="ns1" ns2:attr="ns2" />


### PR DESCRIPTION
- **add a unit test for the broken Android attribute parsing**
- **update AndroidXmlPullParser to use "" for the namespace when the attribute doesn't have a namespace**
- **make the namespace for getAttributeValue non-null**
