### PR TITLE
remove ios background test task

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -187,7 +187,7 @@ jobs:
           key: ${{ runner.os }}-konan-${{ github.sha }}
           restore-keys: ${{ runner.os }}-konan-
       - name: Run iOS Unit Tests
-        run: ./gradlew iosX64Test iosX64BackgroundTest --scan
+        run: ./gradlew iosX64Test --scan
 
   js_tests:
     name: JS Unit Tests

--- a/build-logic/src/main/kotlin/TargetsConfig.kt
+++ b/build-logic/src/main/kotlin/TargetsConfig.kt
@@ -1,6 +1,5 @@
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
-import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTargetWithTests
 import org.jetbrains.kotlin.gradle.plugin.mpp.TestExecutable
 
 internal fun KotlinMultiplatformExtension.configureCommonSourceSets() {
@@ -28,20 +27,6 @@ fun KotlinMultiplatformExtension.configureIosTargets() {
     iosX64 { copyTestResources() }
     iosArm64 { copyTestResources() }
     iosSimulatorArm64 { copyTestResources() }
-
-    // enable running ios tests on a background thread as well
-    // configuration copied from: https://github.com/square/okio/pull/929
-    targets.withType(KotlinNativeTargetWithTests::class.java) {
-        binaries {
-            // Configure a separate test where code runs in background
-            test("background", setOf(DEBUG)) {
-                freeCompilerArgs += "-trw"
-            }
-        }
-        testRuns.create("background") {
-            setExecutionSourceFrom(binaries.getByName("backgroundDebugTest") as TestExecutable)
-        }
-    }
 }
 
 fun KotlinMultiplatformExtension.configureJsTargets() {


### PR DESCRIPTION
This is no longer relevant after switching to the new memory model for iOS
