### PR TITLE
GT-2683 Adding padding for Buttons with large text

### DIFF
--- a/module/renderer/src/androidUnitTest/kotlin/org/cru/godtools/shared/renderer/content/RenderButtonPaparazziTest.kt
+++ b/module/renderer/src/androidUnitTest/kotlin/org/cru/godtools/shared/renderer/content/RenderButtonPaparazziTest.kt
@@ -9,6 +9,7 @@ import org.cru.godtools.shared.renderer.state.State
 import org.cru.godtools.shared.tool.parser.model.Button
 import org.cru.godtools.shared.tool.parser.model.Dimension
 import org.cru.godtools.shared.tool.parser.model.Gravity
+import org.cru.godtools.shared.tool.parser.model.Manifest
 import org.cru.godtools.shared.tool.parser.model.Text
 
 class RenderButtonPaparazziTest : BasePaparazziTest() {
@@ -117,8 +118,40 @@ class RenderButtonPaparazziTest : BasePaparazziTest() {
     }
 
     @Test
+    fun `RenderButton() - Large Text`() {
+        val manifest = Manifest(textScale = 3.0)
+
+        contentSnapshot {
+            RenderContentStack(
+                listOf(
+                    Button(
+                        parent = manifest,
+                        style = Button.Style.CONTAINED,
+                        text = { Text(it, "Large Text") }
+                    ),
+                    Button(
+                        parent = manifest,
+                        style = Button.Style.CONTAINED,
+                        text = { Text(it, "Large Text") }
+                    ),
+                    Button(
+                        parent = manifest,
+                        style = Button.Style.OUTLINED,
+                        text = { Text(it, "Large Text") }
+                    ),
+                    Button(
+                        parent = manifest,
+                        style = Button.Style.OUTLINED,
+                        text = { Text(it, "Large Text") }
+                    ),
+                )
+            )
+        }
+    }
+
+    @Test
     fun `RenderButton() - IsInvisible`() {
-        val state: State = State()
+        val state = State()
         state.setVar("a", listOf("value"))
 
         contentSnapshot {

--- a/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/content/RenderButton.kt
+++ b/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/content/RenderButton.kt
@@ -5,7 +5,9 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.LocalMinimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -20,6 +22,8 @@ import org.cru.godtools.shared.renderer.content.extensions.width
 import org.cru.godtools.shared.renderer.state.State
 import org.cru.godtools.shared.tool.parser.model.Button
 
+private val Button_Vertical_Padding = 4.dp
+
 @Composable
 internal fun ColumnScope.RenderButton(button: Button, state: State) {
     val scope = rememberCoroutineScope()
@@ -28,31 +32,38 @@ internal fun ColumnScope.RenderButton(button: Button, state: State) {
         button.isInvisibleFlow(state)
     }.collectAsState(button.isInvisible(state))
 
-    Button(
-        onClick = { button.handleClickable(state, scope) },
-        enabled = !invisible,
-        colors = when (button.style) {
-            Button.Style.OUTLINED -> ButtonDefaults.outlinedButtonColors(
-                containerColor = button.backgroundColor.toComposeColor()
-            )
-            Button.Style.CONTAINED, Button.Style.UNKNOWN -> ButtonDefaults.buttonColors(
-                containerColor = button.buttonColor.toComposeColor()
-            )
-        },
-        elevation = when (button.style) {
-            Button.Style.OUTLINED -> null
-            Button.Style.CONTAINED, Button.Style.UNKNOWN -> ButtonDefaults.buttonElevation()
-        },
-        border = when (button.style) {
-            Button.Style.OUTLINED -> BorderStroke(1.dp, button.buttonColor.toComposeColor())
-            Button.Style.CONTAINED, Button.Style.UNKNOWN -> null
-        },
-        modifier = Modifier
-            .visibility(button, state)
-            .padding(horizontal = Horizontal_Padding)
-            .width(button.width)
-            .align(button.gravity.alignment)
+    val minSize = LocalMinimumInteractiveComponentSize.current
+    CompositionLocalProvider(
+        // We decrease the minimum size to account for the additional vertical padding
+        // we are adding before the minimum size modifier
+        LocalMinimumInteractiveComponentSize provides minSize - (Button_Vertical_Padding * 2)
     ) {
-        RenderTextNode(button.text)
+        Button(
+            onClick = { button.handleClickable(state, scope) },
+            enabled = !invisible,
+            colors = when (button.style) {
+                Button.Style.OUTLINED -> ButtonDefaults.outlinedButtonColors(
+                    containerColor = button.backgroundColor.toComposeColor()
+                )
+                Button.Style.CONTAINED, Button.Style.UNKNOWN -> ButtonDefaults.buttonColors(
+                    containerColor = button.buttonColor.toComposeColor()
+                )
+            },
+            elevation = when (button.style) {
+                Button.Style.OUTLINED -> null
+                Button.Style.CONTAINED, Button.Style.UNKNOWN -> ButtonDefaults.buttonElevation()
+            },
+            border = when (button.style) {
+                Button.Style.OUTLINED -> BorderStroke(1.dp, button.buttonColor.toComposeColor())
+                Button.Style.CONTAINED, Button.Style.UNKNOWN -> null
+            },
+            modifier = Modifier
+                .visibility(button, state)
+                .padding(horizontal = Horizontal_Padding, vertical = Button_Vertical_Padding)
+                .width(button.width)
+                .align(button.gravity.alignment)
+        ) {
+            RenderTextNode(button.text)
+        }
     }
 }

--- a/module/renderer/src/test/snapshots/images/org.cru.godtools.shared.renderer.content_RenderButtonPaparazziTest_RenderButton()_-_Large_Text.png
+++ b/module/renderer/src/test/snapshots/images/org.cru.godtools.shared.renderer.content_RenderButtonPaparazziTest_RenderButton()_-_Large_Text.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f970f362b0f16446e8764c89d2d3b8dd2da16e3b9687a7bcef8f302fe05fccd
+size 29793


### PR DESCRIPTION
This addresses a padding issue in the renderer test tool (it would also show up for users with increased accessibility settings)
<img width="897" height="1079" alt="Screenshot 2025-07-15 at 9 26 09 AM" src="https://github.com/user-attachments/assets/ea6bf266-74d1-4c67-810c-faae6765b6bc" />
