### PR TITLE
Fix the compose feature branch build

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ ktlintGradle = "13.1.0"
 napier = "2.6.1"
 npmPublish = "3.5.3"
 okio = "3.16.0"
-robolectric = "4.16"
+robolectric = "4.15.1"
 
 [libraries]
 android-gradle = "com.android.tools.build:gradle:8.12.1"


### PR DESCRIPTION
There is a bug between paparazzi & robolectric that is causing tests to fail. for now we will downgrade robolectric to avoid the bug.

see: https://github.com/cashapp/paparazzi/issues/1979
see: https://github.com/robolectric/robolectric/issues/10586