### PR TITLE
Remove iosX64 target

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -19,7 +19,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ./gradlew :module:parser:testDebugUnitTest --tests "org.cru.godtools.shared.parser.FooTest"
 
 # Run iOS unit tests
-./gradlew iosSimulatorArm64Test iosX64Test
+./gradlew iosSimulatorArm64Test
 
 # Run JavaScript unit tests
 ./gradlew jsTest
@@ -64,7 +64,7 @@ publishing/
 ## Architecture
 
 ### Platforms & Targets
-Each module supports `androidTarget`, `iosX64`, `iosArm64`, `iosSimulatorArm64`, and `js` via the `godtools-shared.module-conventions` convention plugin in `build-logic/`.
+Each module supports `androidTarget`, `iosArm64`, `iosSimulatorArm64`, and `js` via the `godtools-shared.module-conventions` convention plugin in `build-logic/`.
 
 ### Parsing Pipeline
 - `ManifestParser` uses a factory-injected `XmlPullParser` (Android/iOS/JS implementations differ)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,7 +194,7 @@ jobs:
           key: ${{ runner.os }}-konan-${{ github.sha }}
           restore-keys: ${{ runner.os }}-konan-
       - name: Run iOS Unit Tests
-        run: ./gradlew iosSimulatorArm64Test iosX64Test --scan
+        run: ./gradlew iosSimulatorArm64Test --scan
 
   js_tests:
     name: JS Unit Tests

--- a/build-logic/src/main/kotlin/TargetsConfig.kt
+++ b/build-logic/src/main/kotlin/TargetsConfig.kt
@@ -24,7 +24,6 @@ internal fun KotlinMultiplatformExtension.configureAndroidTargets() {
 }
 
 fun KotlinMultiplatformExtension.configureIosTargets() {
-    iosX64 { copyTestResources() }
     iosArm64 { copyTestResources() }
     iosSimulatorArm64 { copyTestResources() }
 }


### PR DESCRIPTION
## Summary
- Removes `iosX64` from `configureIosTargets()` in `TargetsConfig.kt`
- Drops `iosX64Test` from the iOS CI test step in `build.yml`
- Updates `CLAUDE.md` to reflect the reduced target list

## Test plan
- [ ] iOS CI job passes with only `iosSimulatorArm64Test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)