### PR TITLE
GT-3034 Parse resource checksums and sizes from manifest

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6,6 +6,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 `godtools-shared` is a **Kotlin Multiplatform (KMP)** library that parses and renders interactive GodTools content (lessons, tracts, etc.) across Android, iOS, and JavaScript/Web platforms.
 
+The XML content format is defined by XSD schemas in the [`mobile-content-api` repository](https://github.com/CruGlobal/mobile-content-api/tree/master/public/xmlns), covering manifest, tract, lesson, cyoa, article, and other content types.
+
 ## Build & Development Commands
 
 ```bash

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 rootProject.name=godtools-shared
-version=1.3.3
+version=1.4.0
 
 org.gradle.caching=true
 org.gradle.jvmargs=-Xmx4g

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Manifest.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Manifest.kt
@@ -206,9 +206,9 @@ class Manifest : BaseModel, Styles, HasPages {
     internal val tipXmlFiles: List<XmlFile>
 
     val relatedFiles get() = buildSet {
-        addAll(pageXmlFiles.map { it.src })
-        addAll(tipXmlFiles.map { it.src })
-        addAll(resources.values.mapNotNull { it.localName })
+        addAll(pageXmlFiles)
+        addAll(tipXmlFiles)
+        addAll(resources.values.filter { it.src != null })
     }
 
     private constructor(parser: XmlPullParser, config: ParserConfig) {
@@ -476,12 +476,18 @@ class Manifest : BaseModel, Styles, HasPages {
         }
     }
 
+    interface File {
+        val src: String?
+        val checksumSha256: String?
+        val size: Int?
+    }
+
     data class XmlFile(
-        internal val name: String?,
-        internal val src: String,
-        internal val checksumSha256: String? = null,
-        internal val size: Int? = null,
-    )
+        val name: String?,
+        override val src: String,
+        override val checksumSha256: String? = null,
+        override val size: Int? = null,
+    ) : File
 }
 
 val Manifest?.navBarColor get() = this?.navBarColor ?: primaryColor

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Manifest.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Manifest.kt
@@ -66,6 +66,8 @@ private const val XML_PAGES = "pages"
 private const val XML_PAGES_PAGE = "page"
 private const val XML_PAGES_PAGE_FILENAME = "filename"
 private const val XML_PAGES_PAGE_SRC = "src"
+private const val XML_PAGES_PAGE_CHECKSUM_SHA256 = "checksum-sha256"
+private const val XML_PAGES_PAGE_SIZE = "size"
 private const val XML_PAGES_AEM_IMPORT = "aem-import"
 private const val XML_PAGES_AEM_IMPORT_SRC = "src"
 private const val XML_RESOURCES = "resources"
@@ -73,6 +75,8 @@ private const val XML_TIPS = "tips"
 private const val XML_TIPS_TIP = "tip"
 private const val XML_TIPS_TIP_ID = "id"
 private const val XML_TIPS_TIP_SRC = "src"
+private const val XML_TIPS_TIP_CHECKSUM_SHA256 = "checksum-sha256"
+private const val XML_TIPS_TIP_SIZE = "size"
 
 @JsExport
 @OptIn(ExperimentalJsExport::class, ExperimentalObjCRefinement::class)
@@ -199,7 +203,7 @@ class Manifest : BaseModel, Styles, HasPages {
         private set
 
     internal val pageXmlFiles: List<XmlFile>
-    private val tipXmlFiles: List<XmlFile>
+    internal val tipXmlFiles: List<XmlFile>
 
     val relatedFiles get() = buildSet {
         addAll(pageXmlFiles.map { it.src })
@@ -403,7 +407,9 @@ class Manifest : BaseModel, Styles, HasPages {
                     XML_PAGES_PAGE -> {
                         val src = getAttributeValue(XML_PAGES_PAGE_SRC) ?: return@parseChildren
                         val fileName = getAttributeValue(XML_PAGES_PAGE_FILENAME)
-                        result.pages += XmlFile(fileName, src)
+                        val checksumSha256 = getAttributeValue(XML_PAGES_PAGE_CHECKSUM_SHA256)?.lowercase()
+                        val size = getAttributeValue(XML_PAGES_PAGE_SIZE)?.toIntOrNull()
+                        result.pages += XmlFile(fileName, src, checksumSha256, size)
                     }
                 }
 
@@ -434,7 +440,9 @@ class Manifest : BaseModel, Styles, HasPages {
                     XML_TIPS_TIP -> {
                         val id = getAttributeValue(XML_TIPS_TIP_ID) ?: return@parseChildren
                         val src = getAttributeValue(XML_TIPS_TIP_SRC) ?: return@parseChildren
-                        add(XmlFile(id, src))
+                        val checksumSha256 = getAttributeValue(XML_TIPS_TIP_CHECKSUM_SHA256)?.lowercase()
+                        val size = getAttributeValue(XML_TIPS_TIP_SIZE)?.toIntOrNull()
+                        add(XmlFile(id, src, checksumSha256, size))
                     }
                 }
             }
@@ -468,7 +476,12 @@ class Manifest : BaseModel, Styles, HasPages {
         }
     }
 
-    data class XmlFile(internal val name: String?, internal val src: String)
+    data class XmlFile(
+        internal val name: String?,
+        internal val src: String,
+        internal val checksumSha256: String? = null,
+        internal val size: Int? = null,
+    )
 }
 
 val Manifest?.navBarColor get() = this?.navBarColor ?: primaryColor

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Resource.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Resource.kt
@@ -14,21 +14,24 @@ private const val XML_SIZE = "size"
 
 @JsExport
 @OptIn(ExperimentalJsExport::class)
-class Resource : BaseModel {
+class Resource : BaseModel, Manifest.File {
     internal companion object {
         internal const val XML_RESOURCE = "resource"
     }
 
     val name: String?
-    val localName: String?
-    val checksumSha256: String?
-    val size: Int?
+    override val src: String?
+    override val checksumSha256: String?
+    override val size: Int?
+
+    @Deprecated("Since v1.4.0, use src instead")
+    val localName get() = src
 
     internal constructor(manifest: Manifest, parser: XmlPullParser) : super(manifest) {
         parser.require(XmlPullParser.START_TAG, XMLNS_MANIFEST, XML_RESOURCE)
 
         name = parser.getAttributeValue(XML_FILENAME)
-        localName = parser.getAttributeValue(XML_SRC)
+        src = parser.getAttributeValue(XML_SRC)
         checksumSha256 = parser.getAttributeValue(XML_CHECKSUM_SHA256)?.lowercase()
         size = parser.getAttributeValue(XML_SIZE)?.toIntOrNull()
 
@@ -40,12 +43,12 @@ class Resource : BaseModel {
     constructor(
         manifest: Manifest = Manifest(),
         name: String? = null,
-        localName: String? = null,
+        src: String? = null,
         checksumSha256: String? = null,
         size: Int? = null,
     ) : super(manifest) {
         this.name = name
-        this.localName = localName
+        this.src = src
         this.checksumSha256 = checksumSha256
         this.size = size
     }
@@ -55,7 +58,7 @@ class Resource : BaseModel {
         other == null -> false
         other !is Resource -> false
         name != other.name -> false
-        localName != other.localName -> false
+        src != other.src -> false
         checksumSha256 != other.checksumSha256 -> false
         size != other.size -> false
         else -> true
@@ -63,7 +66,7 @@ class Resource : BaseModel {
 
     override fun hashCode(): Int {
         var result = name?.hashCode() ?: 0
-        result = 31 * result + (localName?.hashCode() ?: 0)
+        result = 31 * result + (src?.hashCode() ?: 0)
         result = 31 * result + (checksumSha256?.hashCode() ?: 0)
         result = 31 * result + (size?.hashCode() ?: 0)
         return result

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Resource.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Resource.kt
@@ -9,6 +9,8 @@ import org.cru.godtools.shared.tool.parser.xml.skipTag
 
 private const val XML_FILENAME = "filename"
 private const val XML_SRC = "src"
+private const val XML_CHECKSUM_SHA256 = "checksum-sha256"
+private const val XML_SIZE = "size"
 
 @JsExport
 @OptIn(ExperimentalJsExport::class)
@@ -19,12 +21,16 @@ class Resource : BaseModel {
 
     val name: String?
     val localName: String?
+    val checksumSha256: String?
+    val size: Int?
 
     internal constructor(manifest: Manifest, parser: XmlPullParser) : super(manifest) {
         parser.require(XmlPullParser.START_TAG, XMLNS_MANIFEST, XML_RESOURCE)
 
         name = parser.getAttributeValue(XML_FILENAME)
         localName = parser.getAttributeValue(XML_SRC)
+        checksumSha256 = parser.getAttributeValue(XML_CHECKSUM_SHA256)?.lowercase()
+        size = parser.getAttributeValue(XML_SIZE)?.toIntOrNull()
 
         parser.skipTag()
     }
@@ -35,9 +41,13 @@ class Resource : BaseModel {
         manifest: Manifest = Manifest(),
         name: String? = null,
         localName: String? = null,
+        checksumSha256: String? = null,
+        size: Int? = null,
     ) : super(manifest) {
         this.name = name
         this.localName = localName
+        this.checksumSha256 = checksumSha256
+        this.size = size
     }
 
     override fun equals(other: Any?) = when {
@@ -46,12 +56,16 @@ class Resource : BaseModel {
         other !is Resource -> false
         name != other.name -> false
         localName != other.localName -> false
+        checksumSha256 != other.checksumSha256 -> false
+        size != other.size -> false
         else -> true
     }
 
     override fun hashCode(): Int {
         var result = name?.hashCode() ?: 0
         result = 31 * result + (localName?.hashCode() ?: 0)
+        result = 31 * result + (checksumSha256?.hashCode() ?: 0)
+        result = 31 * result + (size?.hashCode() ?: 0)
         return result
     }
 }

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/CategoryTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/CategoryTest.kt
@@ -18,11 +18,11 @@ class CategoryTest : UsesResources() {
         assertEquals("testParseCategory", category.id)
         assertNotNull(category.banner).also {
             assertEquals("banner.jpg", it.name)
-            assertEquals("bannersha1.jpg", it.localName)
+            assertEquals("bannersha1.jpg", it.src)
         }
         assertEquals(setOf("tag1", "tag2"), category.aemTags)
         assertEquals("Category", category.label!!.text)
-        assertEquals(TestColors.RED, category.label!!.textColor)
+        assertEquals(TestColors.RED, category.label.textColor)
     }
 
     @Test

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/ManifestTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/ManifestTest.kt
@@ -69,7 +69,7 @@ class ManifestTest : UsesResources() {
         assertEquals("testParseCategory", category.id)
         val banner = assertNotNull(category.banner)
         assertEquals("banner.jpg", banner.name)
-        assertEquals("bannersha1.jpg", banner.localName)
+        assertEquals("bannersha1.jpg", banner.src)
         assertEquals(setOf("tag1", "tag2"), category.aemTags)
         val label = assertNotNull(category.label)
         assertEquals("Category", label.text)
@@ -137,7 +137,7 @@ class ManifestTest : UsesResources() {
         assertTrue(manifest.backgroundImageGravity.isEnd)
         val backgroundImage = assertNotNull(manifest.backgroundImage)
         assertEquals("file.jpg", backgroundImage.name)
-        assertEquals("sha1.jpg", backgroundImage.localName)
+        assertEquals("sha1.jpg", backgroundImage.src)
     }
 
     @Test
@@ -203,7 +203,7 @@ class ManifestTest : UsesResources() {
 
     @Test
     fun testParseManifestWithoutParsingRelated() = runTest {
-        val expectedRelatedFiles = setOf(
+        val expectedRelatedFileSrcs = setOf(
             "page1_sha.xml",
             "page2_sha.xml",
             "tip1_sha.xml",
@@ -217,7 +217,7 @@ class ManifestTest : UsesResources() {
         assertTrue(manifest.pages.isEmpty())
         assertTrue(manifest.tips.isEmpty())
         assertTrue(manifest.hasTips)
-        assertEquals(expectedRelatedFiles, manifest.relatedFiles)
+        assertEquals(expectedRelatedFileSrcs, manifest.relatedFiles.map { it.src }.toSet())
     }
 
     @Test

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/ManifestTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/ManifestTest.kt
@@ -176,6 +176,32 @@ class ManifestTest : UsesResources() {
     }
 
     @Test
+    fun testParseManifestResourceChecksums() = runTest {
+        val manifest = parseManifest("manifest_checksums.xml", ParserConfig().withParseRelated(false))
+        val expectedChecksum = "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
+
+        val resource = assertNotNull(manifest.resources["file.jpg"])
+        assertEquals(expectedChecksum, resource.checksumSha256)
+        assertEquals(5678, resource.size)
+
+        val resourceNoChecksum = assertNotNull(manifest.resources["file2.jpg"])
+        assertNull(resourceNoChecksum.checksumSha256)
+        assertNull(resourceNoChecksum.size)
+
+        assertEquals(2, manifest.pageXmlFiles.size)
+        assertEquals(expectedChecksum, manifest.pageXmlFiles[0].checksumSha256)
+        assertEquals(1234, manifest.pageXmlFiles[0].size)
+        assertNull(manifest.pageXmlFiles[1].checksumSha256)
+        assertNull(manifest.pageXmlFiles[1].size)
+
+        assertEquals(2, manifest.tipXmlFiles.size)
+        assertEquals(expectedChecksum, manifest.tipXmlFiles[0].checksumSha256)
+        assertEquals(9012, manifest.tipXmlFiles[0].size)
+        assertNull(manifest.tipXmlFiles[1].checksumSha256)
+        assertNull(manifest.tipXmlFiles[1].size)
+    }
+
+    @Test
     fun testParseManifestWithoutParsingRelated() = runTest {
         val expectedRelatedFiles = setOf(
             "page1_sha.xml",

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/ResourceTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/ResourceTest.kt
@@ -13,6 +13,14 @@ class ResourceTest {
 
         assertNotEquals(Resource(name = "name", localName = "local"), Resource(name = "name2", localName = "local"))
         assertNotEquals(Resource(name = "name", localName = "local"), Resource(name = "name", localName = "local2"))
+        assertNotEquals(
+            Resource(name = "name", localName = "local"),
+            Resource(name = "name", localName = "local", checksumSha256 = "abc"),
+        )
+        assertNotEquals(
+            Resource(name = "name", localName = "local"),
+            Resource(name = "name", localName = "local", size = 123),
+        )
 
         assertFalse(Resource().equals(null))
         assertFalse(Resource().equals("resource"))
@@ -24,6 +32,10 @@ class ResourceTest {
         assertEquals(
             Resource(name = "name", localName = "local").hashCode(),
             Resource(name = "name", localName = "local").hashCode(),
+        )
+        assertEquals(
+            Resource(name = "name", localName = "local", checksumSha256 = "abc", size = 123).hashCode(),
+            Resource(name = "name", localName = "local", checksumSha256 = "abc", size = 123).hashCode(),
         )
     }
 }

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/ResourceTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/ResourceTest.kt
@@ -9,17 +9,17 @@ class ResourceTest {
     @Test
     fun testEquals() {
         assertEquals(Resource(), Resource())
-        assertEquals(Resource(name = "name", localName = "local"), Resource(name = "name", localName = "local"))
+        assertEquals(Resource(name = "name", src = "local"), Resource(name = "name", src = "local"))
 
-        assertNotEquals(Resource(name = "name", localName = "local"), Resource(name = "name2", localName = "local"))
-        assertNotEquals(Resource(name = "name", localName = "local"), Resource(name = "name", localName = "local2"))
+        assertNotEquals(Resource(name = "name", src = "local"), Resource(name = "name2", src = "local"))
+        assertNotEquals(Resource(name = "name", src = "local"), Resource(name = "name", src = "local2"))
         assertNotEquals(
-            Resource(name = "name", localName = "local"),
-            Resource(name = "name", localName = "local", checksumSha256 = "abc"),
+            Resource(name = "name", src = "local"),
+            Resource(name = "name", src = "local", checksumSha256 = "abc"),
         )
         assertNotEquals(
-            Resource(name = "name", localName = "local"),
-            Resource(name = "name", localName = "local", size = 123),
+            Resource(name = "name", src = "local"),
+            Resource(name = "name", src = "local", size = 123),
         )
 
         assertFalse(Resource().equals(null))
@@ -30,12 +30,12 @@ class ResourceTest {
     fun testHashCode() {
         assertEquals(Resource().hashCode(), Resource().hashCode())
         assertEquals(
-            Resource(name = "name", localName = "local").hashCode(),
-            Resource(name = "name", localName = "local").hashCode(),
+            Resource(name = "name", src = "local").hashCode(),
+            Resource(name = "name", src = "local").hashCode(),
         )
         assertEquals(
-            Resource(name = "name", localName = "local", checksumSha256 = "abc", size = 123).hashCode(),
-            Resource(name = "name", localName = "local", checksumSha256 = "abc", size = 123).hashCode(),
+            Resource(name = "name", src = "local", checksumSha256 = "abc", size = 123).hashCode(),
+            Resource(name = "name", src = "local", checksumSha256 = "abc", size = 123).hashCode(),
         )
     }
 }

--- a/module/parser/src/commonTest/resources/org/cru/godtools/shared/tool/parser/model/manifest_checksums.xml
+++ b/module/parser/src/commonTest/resources/org/cru/godtools/shared/tool/parser/model/manifest_checksums.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<manifest xmlns="https://mobile-content-api.cru.org/xmlns/manifest">
+    <pages>
+        <page filename="page0.xml" src="page0_sha.xml"
+            checksum-sha256="AABBCCDDEEFF00112233445566778899AABBCCDDEEFF00112233445566778899"
+            size="1234" />
+        <page src="page1_sha.xml" />
+    </pages>
+
+    <resources>
+        <resource filename="file.jpg" src="sha1.jpg"
+            checksum-sha256="AABBCCDDEEFF00112233445566778899AABBCCDDEEFF00112233445566778899"
+            size="5678" />
+        <resource filename="file2.jpg" src="sha2.jpg" />
+    </resources>
+</manifest>

--- a/module/parser/src/commonTest/resources/org/cru/godtools/shared/tool/parser/model/manifest_checksums.xml
+++ b/module/parser/src/commonTest/resources/org/cru/godtools/shared/tool/parser/model/manifest_checksums.xml
@@ -7,6 +7,13 @@
         <page src="page1_sha.xml" />
     </pages>
 
+    <tips>
+        <tip id="tip1" src="tip1_sha.xml"
+            checksum-sha256="AABBCCDDEEFF00112233445566778899AABBCCDDEEFF00112233445566778899"
+            size="9012" />
+        <tip id="tip2" src="tip2_sha.xml" />
+    </tips>
+
     <resources>
         <resource filename="file.jpg" src="sha1.jpg"
             checksum-sha256="AABBCCDDEEFF00112233445566778899AABBCCDDEEFF00112233445566778899"

--- a/module/renderer/src/androidUnitTest/kotlin/org/cru/godtools/shared/renderer/BasePaparazziTest.kt
+++ b/module/renderer/src/androidUnitTest/kotlin/org/cru/godtools/shared/renderer/BasePaparazziTest.kt
@@ -38,9 +38,9 @@ abstract class BasePaparazziTest(
     renderingMode: RenderingMode = RenderingMode.NORMAL
 ) {
     protected companion object {
-        val resourceBlackPanther = Resource(name = "black_panther", localName = "black_panther.png")
-        val resourceBruce = Resource(name = "bruce", localName = "bruce.jpg")
-        val resourceWaterfall = Resource(name = "waterfall", localName = "waterfall.jpg")
+        val resourceBlackPanther = Resource(name = "black_panther", src = "black_panther.png")
+        val resourceBruce = Resource(name = "bruce", src = "bruce.jpg")
+        val resourceWaterfall = Resource(name = "waterfall", src = "waterfall.jpg")
     }
     enum class AccessibilityMode { ACCESSIBILITY, NO_ACCESSIBILITY }
 

--- a/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/content/RenderAnimation.kt
+++ b/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/content/RenderAnimation.kt
@@ -49,7 +49,7 @@ internal val LocalCompottieCoroutineContext = staticCompositionLocalOf<Coroutine
 
 @Composable
 internal fun ColumnScope.RenderAnimation(animation: Animation, state: State) {
-    val resource = animation.resource?.takeUnless { it.localName == null } ?: return
+    val resource = animation.resource?.takeUnless { it.src == null } ?: return
 
     val fileSystem = LocalResourceFileSystem.current
 

--- a/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/content/extensions/Resource+Compottie.kt
+++ b/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/content/extensions/Resource+Compottie.kt
@@ -15,7 +15,7 @@ import org.cru.godtools.shared.tool.parser.model.Resource
 @OptIn(InternalCompottieApi::class)
 internal fun LottieCompositionSpec.Companion.Resource(fileSystem: FileSystem, resource: Resource) =
     object : LottieCompositionSpec {
-        override val key get() = "resource_${resource.localName}"
+        override val key get() = "resource_${resource.src}"
 
         override suspend fun load() = fileSystem.source(resource.toPath()!!).buffer().readByteArray()
             .decodeToLottieComposition(LottieAnimationFormat.Undefined)

--- a/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/extensions/Resource+Coil.kt
+++ b/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/extensions/Resource+Coil.kt
@@ -9,7 +9,7 @@ import okio.Path.Companion.toPath
 import org.cru.godtools.shared.renderer.util.LocalResourceFileSystem
 import org.cru.godtools.shared.tool.parser.model.Resource
 
-internal fun Resource.toPath() = localName?.toPath()
+internal fun Resource.toPath() = src?.toPath()
 
 @Composable
 internal fun Resource.toImageRequestBuilder() = ImageRequest.Builder(LocalPlatformContext.current)

--- a/module/renderer/src/commonTest/kotlin/org/cru/godtools/shared/renderer/TestResources.kt
+++ b/module/renderer/src/commonTest/kotlin/org/cru/godtools/shared/renderer/TestResources.kt
@@ -26,13 +26,13 @@ object TestResources {
         .build()
 
     val resources = listOf(
-        Resource(name = "black_square", localName = "black_square.png"),
-        Resource(name = "red_square", localName = "red_square.png"),
-        Resource(name = "green_square", localName = "green_square.png"),
-        Resource(name = "tall", localName = "tall.png"),
-        Resource(name = "wide", localName = "wide.png"),
-        Resource(name = "kotlin_anim", localName = "kotlin_anim.json"),
-        Resource(name = "nyan_cat", localName = "nyan_cat.lottie"),
+        Resource(name = "black_square", src = "black_square.png"),
+        Resource(name = "red_square", src = "red_square.png"),
+        Resource(name = "green_square", src = "green_square.png"),
+        Resource(name = "tall", src = "tall.png"),
+        Resource(name = "wide", src = "wide.png"),
+        Resource(name = "kotlin_anim", src = "kotlin_anim.json"),
+        Resource(name = "nyan_cat", src = "nyan_cat.lottie"),
     )
 }
 


### PR DESCRIPTION
## Summary

- Parses `checksum-sha256` (lowercased) and `size` attributes added by [mobile-content-api#1988](https://github.com/CruGlobal/mobile-content-api/pull/1988) on manifest `<page>`, `<resource>`, and `<tip>` entries
- Introduces `Manifest.File` interface exposing `src`, `checksumSha256`, and `size`; both `Resource` and the internal `XmlFile` implement it
- `relatedFiles` now returns `Set<Manifest.File>` instead of `Set<String>`, giving callers access to checksum and size alongside the file path
- Renames `Resource.localName` → `src` to align with the interface and the XML attribute name; `localName` is kept as a deprecated alias (v1.4.0)

## Test plan

- [x] New `testParseManifestResourceChecksums` test covers checksum/size parsing for resources, pages, and tips, including uppercase→lowercase normalization
- [x] `ResourceTest` updated for new `equals`/`hashCode` fields
- [x] ktlint, Android unit tests, and iOS simulator tests all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)