### PR TITLE
GT-3045: Upgrade to AGP 9.2.1 and Gradle 9.5.1

### DIFF
--- a/build-logic/src/main/kotlin/godtools-shared.module-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/godtools-shared.module-conventions.gradle.kts
@@ -1,5 +1,3 @@
-import com.android.build.api.dsl.androidLibrary
-
 plugins {
     kotlin("multiplatform")
     id("com.android.kotlin.multiplatform.library")
@@ -9,7 +7,7 @@ plugins {
 enablePublishing()
 
 kotlin {
-    androidLibrary {
+    android {
         compileSdk = 36
         minSdk = 24
     }

--- a/build-logic/src/main/kotlin/org/cru/godtools/shared/gradle/KotlinAntlrPlugin.kt
+++ b/build-logic/src/main/kotlin/org/cru/godtools/shared/gradle/KotlinAntlrPlugin.kt
@@ -6,6 +6,7 @@ import org.gradle.api.Project
 import org.gradle.api.plugins.antlr.AntlrPlugin.ANTLR_CONFIGURATION_NAME
 import org.gradle.api.plugins.antlr.internal.DefaultAntlrSourceDirectorySet
 import org.gradle.kotlin.dsl.create
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 
 /**
@@ -21,7 +22,6 @@ class KotlinAntlrPlugin : Plugin<Project> {
 
         // create antlr configuration
         val antlrConfiguration = target.configurations.create(ANTLR_CONFIGURATION_NAME)
-            .setVisible(false)
             .setDescription("The Antlr libraries to be used for this project.")
 
         // for each source set
@@ -48,10 +48,9 @@ class KotlinAntlrPlugin : Plugin<Project> {
                         .get().asFile
                 }
 
-            // 3) Set up the Antlr output directory (adding to javac inputs!)
-            // TODO: register as a generated source once it is supported in the gradle plugin
-            //       see: https://youtrack.jetbrains.com/issue/KT-45161#focus=Comments-27-8632322.0-0
-            kotlin.srcDir(generateTask)
+            // 3) Register the Antlr output as a generated Kotlin source directory
+            @OptIn(ExperimentalKotlinGradlePluginApi::class)
+            generatedKotlin.srcDir(generateTask)
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ okio = "3.17.0"
 robolectric = "4.15.1"
 
 [libraries]
-android-gradle = "com.android.tools.build:gradle:8.13.2"
+android-gradle = "com.android.tools.build:gradle:9.2.1"
 androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "androidx-annotation" }
 androidx-compose-ui-test-manifest = "androidx.compose.ui:ui-test-manifest:1.11.2"
 androidx-graphics-shapes = "androidx.graphics:graphics-shapes:1.1.0"

--- a/module/analytics/build.gradle.kts
+++ b/module/analytics/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "org.cru.godtools.shared.analytics"
 
         withHostTest { }

--- a/module/common/build.gradle.kts
+++ b/module/common/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "org.cru.godtools.shared.common"
 
         withHostTest { }

--- a/module/interop/build.gradle.kts
+++ b/module/interop/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "org.cru.godtools.shared.interop"
 
         withHostTest { }

--- a/module/parser-base/build.gradle.kts
+++ b/module/parser-base/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "org.cru.godtools.shared.tool.parser.base"
 
         withHostTest { }

--- a/module/parser-expressions/build.gradle.kts
+++ b/module/parser-expressions/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "org.cru.godtools.shared.tool.parser.expressions"
 
         withHostTest { }

--- a/module/parser/build.gradle.kts
+++ b/module/parser/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "org.cru.godtools.shared.tool.parser"
 
         withHostTest {}

--- a/module/renderer-state/build.gradle.kts
+++ b/module/renderer-state/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "org.cru.godtools.shared.renderer.state"
 
         withHostTest { }

--- a/module/renderer/build.gradle.kts
+++ b/module/renderer/build.gradle.kts
@@ -10,7 +10,7 @@ compose.resources {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "org.cru.godtools.shared.renderer"
 
         androidResources.enable = true

--- a/module/user-activity/build.gradle.kts
+++ b/module/user-activity/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "org.cru.godtools.shared.user.activity"
 
         withHostTest { }


### PR DESCRIPTION
## Summary
- Upgrade Android Gradle Plugin to 9.2.1 and Gradle to 9.5.1
- Rename `kotlin.androidLibrary` DSL block to `kotlin.android` (renamed in AGP 8.12, removed in AGP 9)
- Register the ANTLR output as a generated Kotlin source via `KotlinSourceSet.generatedKotlin` (KT-45161); tagging the directory as generated wires the AGP lint task dependency on ANTLR generation automatically

## Test plan
- [ ] `./gradlew assemble` succeeds across all modules
- [ ] `./gradlew lint` runs cleanly (verifies the ANTLR/lint wiring)
- [ ] `./gradlew testAndroidHostTest verifyPaparazzi` passes
- [ ] `./gradlew iosSimulatorArm64Test` passes
- [ ] `./gradlew jsTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)