### PR TITLE
Upgrade to Android SDK 37

### DIFF
--- a/build-logic/src/main/kotlin/godtools-shared.module-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/godtools-shared.module-conventions.gradle.kts
@@ -8,7 +8,7 @@ enablePublishing()
 
 kotlin {
     android {
-        compileSdk = 36
+        compileSdk = 37
         minSdk = 24
     }
     configureIosTargets()

--- a/module/renderer/src/androidHostTest/kotlin/org/cru/godtools/shared/renderer/BasePaparazziTest.kt
+++ b/module/renderer/src/androidHostTest/kotlin/org/cru/godtools/shared/renderer/BasePaparazziTest.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalInspectionMode
 import app.cash.paparazzi.Paparazzi
 import app.cash.paparazzi.accessibility.AccessibilityRenderExtension
-import app.cash.paparazzi.detectEnvironment
 import coil3.ImageLoader
 import coil3.SingletonImageLoader
 import coil3.annotation.DelicateCoilApi
@@ -46,11 +45,6 @@ abstract class BasePaparazziTest(
 
     @get:Rule
     val paparazzi = Paparazzi(
-        environment = detectEnvironment().copy(
-            // HACK: Override the compileSdkVersion to 35 to workaround Paparazzi not yet supporting SDK 36
-            //       https://github.com/cashapp/paparazzi/pull/2066 might solve the issue
-            compileSdkVersion = 35,
-        ),
         renderingMode = renderingMode,
         maxPercentDifference = 0.0,
         renderExtensions = buildSet {


### PR DESCRIPTION
## Summary
- Bump `compileSdk` from 36 to 37 in the module conventions plugin
- Drop the Paparazzi `compileSdkVersion = 35` HACK in `BasePaparazziTest` — Paparazzi 2.0.0-alpha05 (layoutlib 16.2.1) renders fine at the new SDK level

## Test plan
- [x] `./gradlew assemble`
- [x] `./gradlew testAndroidHostTest verifyPaparazzi`

🤖 Generated with [Claude Code](https://claude.com/claude-code)