### PR TITLE
Claude Code config updates: gitignore cleanup and pr-review skill refresh

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,0 +1,2 @@
+settings.local.json
+worktrees/

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -7,6 +7,27 @@ allowed-tools: Bash, Read, Grep, Glob, Write, Edit
 
 Review pull request $ARGUMENTS against the godtools-shared project conventions.
 
+**Every invocation is a fresh review.** Execute every step from scratch each time this skill
+is invoked — even when a review already ran earlier in this conversation, and even when the
+delta since then looks tiny. Re-read the dismissed issues, re-fetch the full diff, re-run all
+pre-flight commands, and re-evaluate the complete checklist against **every** changed file in
+the diff — not just the files changed since the last pass. A prior green pre-flight certified
+a tree that no longer exists; prior findings may have shifted lines or been invalidated. The
+only earlier-pass state that may inform this pass is what steps 7–9 explicitly consume:
+comments already posted on the PR (for dedup and thread resolution).
+
+None of these permit reusing an earlier pass:
+- "Only a small / typo / test-only commit landed since" — fix commits break checks as readily
+  as feature commits.
+- "lint can't see the changed file" — the pre-flight is unconditional; it validates the tree,
+  not the delta.
+- "The earlier categorization / findings are still in context" — re-derive them from the
+  fresh diff; carried-forward findings drift in line numbers and validity.
+- "The user is in a hurry / gradle is slow" — speed the pre-flight up by batching the tasks
+  into one gradle invocation or running it in the background while reviewing, never by
+  skipping commands.
+- "I'm near the context limit" — a fresh review beats a stale reused one.
+
 ## Steps
 
 1. Check for dismissed issues by reading `.claude/skills/pr-review/dismissed-issues.md` if it exists.
@@ -26,12 +47,18 @@ Use the branch name and commit log as the "title" in the review header.
 
 3. Identify all changed files and categorize them (module, source set, tests, build config, etc.).
 
-4. Pre-flight checks — run ktlint and lint, recording results for the review:
+4. Pre-flight checks — run ktlint, lint, and the iOS and JS test suites, recording results for the review:
 ```
 ./gradlew :build-logic:ktlintCheck ktlintCheck
 ./gradlew lint
+./gradlew iosSimulatorArm64Test
+./gradlew jsTest
 ```
 Any failures are reported as **❌ Must Fix** items in the review output. They do not stop the rest of the review.
+Run the iOS and JS suites even when the diff looks Android-only: Kotlin/Native and Kotlin/JS compile
+differently from the Android host, and code has compiled on Android while failing on iOS/JS (ktlint and
+lint never exercise those targets). `iosSimulatorArm64Test` requires a macOS host — if the review runs
+elsewhere, note that the iOS suite was skipped.
 
 5. Review each category using the checklist below. Before outputting, cross-reference every finding against dismissed patterns — a finding matches when it describes the same class of issue (not necessarily the exact file/line). Move matched findings to a separate suppressed list.
 
@@ -66,13 +93,76 @@ gh api repos/$REPO/pulls/$ARGUMENTS/reviews \
 
 Use the exact file path from the diff (e.g. `module/parser/src/.../Foo.kt`) and the line number in the current version of the file (RIGHT side). Each comment body should contain the full finding description. Always append the attribution footer `\n\n🤖 Posted by [Claude Code](https://claude.ai/code)` to each comment. If no new actionable findings exist (only ✅ items or all already commented), skip this step.
 
-8. If the review has **no ❌ or ⚠️ findings** (only ✅ and/or ⏭️ items), ask the user whether to post the full review. **Skip this step entirely when reviewing a branch with no PR — branch review mode is local-only.** Otherwise, if they say yes:
+8. **Resolve inline comment threads that have been addressed.** On a re-review, close out threads whose findings are now fixed. **Skip this step entirely when reviewing a branch with no PR — there are no threads to resolve.** A previously-posted thread counts as *addressed* when all of the following hold:
+   - it is still **unresolved**, and
+   - its first comment was posted by **this reviewer** — the body contains the `🤖 Posted by [Claude Code]` (or `🤖 [Claude Code]`) attribution footer — never touch a human reviewer's thread, and
+   - the thread has **no other comments** — only the reviewer's original comment, with no replies (`comments.totalCount == 1`). If anyone has replied, there is an active discussion; leave the thread open even if the code looks fixed, and
+   - **no finding in the current pass matches it** (the issue it described is no longer present in the code at that path). If the current review still raises the same finding, leave the thread open.
+
+   Fetch unresolved threads (reuse the GraphQL shape from the dismissal section) — `totalCount` reveals whether anyone replied:
+   ```bash
+   REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+   OWNER=${REPO%%/*}; REPONAME=${REPO##*/}
+   gh api graphql -f query="
+   {
+     repository(owner: \"$OWNER\", name: \"$REPONAME\") {
+       pullRequest(number: $ARGUMENTS) {
+         reviewThreads(first: 100) {
+           nodes {
+             id
+             isResolved
+             comments(first: 1) { totalCount nodes { id author { login } body path line } }
+           }
+         }
+       }
+     }
+   }"
+   ```
+
+   For each addressed thread, reply noting it was fixed, then resolve it:
+   ```bash
+   gh api repos/$REPO/pulls/$ARGUMENTS/comments \
+     --method POST \
+     --field in_reply_to=<comment_id> \
+     --field body="✅ Addressed in <short SHA> — resolving.
+
+   🤖 [Claude Code](https://claude.ai/code)"
+
+   gh api graphql -f query="
+   mutation {
+     resolveReviewThread(input: { threadId: \"<thread_node_id>\" }) {
+       thread { id isResolved }
+     }
+   }"
+   ```
+
+   Only resolve findings you can confirm are fixed by reading the current code — when in doubt, leave the thread open. List the threads you resolved in the review output.
+
+9. If the review has **no ❌ or ⚠️ findings** (only ✅ and/or ⏭️ items), ask the user whether to post the full review. **Skip this step entirely when reviewing a branch with no PR — branch review mode is local-only.** Otherwise, if they say yes:
    - Check whether the PR author matches the current git user (`gh pr view $ARGUMENTS --json author -q .author.login` vs `gh api user -q .login`)
    - If it is a **self-review**, post with `--comment` (GitHub does not allow self-approval)
    - If it is **someone else's PR**, ask whether to approve or just comment, then post with `--approve` or `--comment` accordingly
    - Always append `\n\n🤖 Posted by [Claude Code](https://claude.ai/code)` to the body
+   - After posting, offer to mark the superseded full reviews as outdated. List the PR's
+     earlier reviews whose body contains the `🤖 Posted by [Claude Code]` attribution footer
+     (never a human's review, and skip empty-body reviews — those are inline-comment
+     carriers, and skip the review just posted). If any exist, **ask the user per review**
+     (identify each by its date and verdict) whether to mark it outdated, then minimize only
+     the ones they approve:
 
-9. After the review output, print:
+     ```bash
+     gh api repos/$REPO/pulls/$ARGUMENTS/reviews \
+       --jq '.[] | select(.body | contains("Posted by [Claude Code]")) | {node_id, submitted_at, body: .body[0:100]}'
+     # For each review the user approved marking outdated:
+     gh api graphql -f query='
+     mutation {
+       minimizeComment(input: { subjectId: "<review node_id>", classifier: OUTDATED }) {
+         minimizedComment { isMinimized }
+       }
+     }'
+     ```
+
+10. After the review output, print:
 
 ```
 ---
@@ -96,7 +186,7 @@ To dismiss a finding so it won't appear in future reviews, say:
 - [ ] New model types are `data class` or `sealed class` where appropriate
 - [ ] Parser results use the sealed `ParserResult` hierarchy: `ParserResult.Data` or `ParserResult.Error` (never throw)
 - [ ] Parsing is done via `XmlPullParser` (the multiplatform abstraction) — never Android's or platform XML APIs directly
-- [ ] New public API surface uses `internal` where exposure is not intentional
+- [ ] Public API surface is intentional — `internal` where exposure isn't needed, and any change widening an existing `internal`/`private` declaration to public is called out as ⚠️ so the author can confirm it's deliberate
 
 ### Renderer Module (`module/renderer`)
 
@@ -136,11 +226,20 @@ For any new module, check `build.gradle.kts`:
 - [ ] Parser tests use in-memory XML strings or test fixture files — never real network
 - [ ] Tests are in the correct source set (`commonTest`, `androidHostTest`, etc.)
 
+**Test redundancy**
+
+Scan new/changed test classes for redundant tests and flag each as a **Minor Issue** (⚠️) suggesting consolidation:
+
+- [ ] No two tests cover the same behavior — flag a test whose assertions are a strict subset of another test's, or that exercises the same branch/path with no distinct assertion
+- [ ] When one test is a superset of another (same setup, additional assertions), suggest folding the unique assertion of the smaller test into the larger and deleting the duplicate
+- [ ] Do not flag tests that share setup but assert genuinely different behavior — overlapping setup is not redundancy
+
 ### Code Style
 
 Ktlint and `.editorconfig` enforce most style rules (line length, formatter rules, constant naming) — step 4's pre-flight already covers those. Manual checks:
 
 - [ ] Package prefix: `org.cru.godtools.shared`
+- [ ] No trailing comma on single-line function/constructor signatures or calls — e.g. `fun foo(a: String, b: Int,)` is wrong; trailing commas are only valid when parameters are on separate lines (ktlint's `trailing-comma-on-*` rules are disabled in `.editorconfig`, so the pre-flight does NOT catch this). Only touch a trailing comma on a line already being modified — don't churn otherwise-unchanged lines
 
 ### General Quality
 
@@ -156,13 +255,11 @@ Ktlint and `.editorconfig` enforce most style rules (line length, formatter rule
 
 ### Deprecated API Usage
 
-Scan changed files for deprecated API calls. Flag each one as a **Minor Issue** (⚠️) with a suggested replacement.
+Scan changed files for deprecated API calls. Flag each one as a **Minor Issue** (⚠️) with a suggested replacement. The step-4 pre-flight `./gradlew lint` already surfaces deprecation warnings — read its output rather than running a separate test compile.
 
-To surface deprecated usages introduced or touched in the diff:
-```bash
-# Compiler warnings will flag @Deprecated-annotated symbols
-./gradlew testAndroidHostTest 2>&1 | grep -i "deprecat"
-```
+### CI Workflows
+
+- [ ] When reviewing `.github/workflows/`, do not flag a deploy job for omitting a `needs` gate that other deploy jobs have — gates are per-artifact. In particular `lint` is Android Lint and only gates Android artifacts (e.g. `deploy_spm` intentionally omits it)
 
 ### PR Hygiene
 

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,3 @@ build/
 captures/
 out/
 local.properties
-
-# Claude Code
-.claude/settings.local.json


### PR DESCRIPTION
## Summary
- Move Claude Code gitignore rules into `.claude/.gitignore` (and ignore `.claude/worktrees/`)
- Refresh the `pr-review` skill based on an analysis of recent PR review activity and peer projects' pr-review skills:
  - Add a fresh-review preamble, re-review thread resolution, and superseded-review minimization steps
  - Extend the pre-flight to run the iOS and JS test suites (the only checks exercising Kotlin/Native and Kotlin/JS)
  - Add trailing-comma, test-redundancy, and CI-workflow `needs`-gate checks
  - Flag visibility widening of existing `internal`/`private` declarations
  - Read deprecation warnings from the existing lint pre-flight instead of a separate test compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)