### PR TITLE
[GT-3061] Add RenderTip and RenderTipBottomSheet composables

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,6 +67,7 @@ materialColorUtilities = "org.cru.mobile.fork.material-color-utilities:material-
 okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 testparameterinjector = "com.google.testparameterinjector:test-parameter-injector:1.22"
+touchrobot-paparazzi = "me.saket.touchrobot:touchrobot-paparazzi:0.2.0"
 turbine = "app.cash.turbine:turbine:1.2.1"
 
 # HACK: dependencies used to trigger renovate upgrades

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/tips/TipPage.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/tips/TipPage.kt
@@ -25,7 +25,7 @@ class TipPage : BaseModel, Parent {
     }
 
     @RestrictTo(RestrictTo.Scope.TESTS)
-    internal constructor(
+    constructor(
         tip: Tip = Tip(),
         position: Int = 0,
         content: ((TipPage) -> List<Content>)? = null,

--- a/module/renderer/build.gradle.kts
+++ b/module/renderer/build.gradle.kts
@@ -60,6 +60,7 @@ kotlin {
                 implementation(libs.androidx.compose.ui.test.manifest)
 
                 implementation(libs.testparameterinjector)
+                implementation(libs.touchrobot.paparazzi)
             }
         }
     }

--- a/module/renderer/src/androidHostTest/kotlin/org/cru/godtools/shared/renderer/BasePaparazziTest.kt
+++ b/module/renderer/src/androidHostTest/kotlin/org/cru/godtools/shared/renderer/BasePaparazziTest.kt
@@ -55,28 +55,39 @@ abstract class BasePaparazziTest(
 
     protected val tipsRepository = InMemoryTipsRepository()
 
+    // region Test Manifests
     protected val manifest by lazy {
         Manifest(
             code = "tool",
             locale = Locale.forLanguage("en"),
-            resources = {
-                listOf(
-                    resourceBlackPanther,
-                    resourceBruce,
-                    resourceWaterfall,
-                ) + TestResources.resources
-            },
-            tips = {
-                listOf(
-                    Tip(it, id = "ask", type = Tip.Type.ASK),
-                    Tip(it, id = "consider", type = Tip.Type.CONSIDER),
-                    Tip(it, id = "prepare", type = Tip.Type.PREPARE),
-                    Tip(it, id = "quote", type = Tip.Type.QUOTE),
-                    Tip(it, id = "tip", type = Tip.Type.TIP),
-                )
-            },
+            resources = { buildResources() },
+            tips = { it.buildTips() },
         )
     }
+
+    protected val rtlManifest by lazy {
+        Manifest(
+            code = "tool",
+            locale = Locale.forLanguage("ar"),
+            resources = { buildResources() },
+            tips = { it.buildTips() },
+        )
+    }
+
+    private fun buildResources() = listOf(
+        resourceBlackPanther,
+        resourceBruce,
+        resourceWaterfall,
+    ) + TestResources.resources
+
+    private fun Manifest.buildTips() = listOf(
+        Tip(this, id = "ask", type = Tip.Type.ASK),
+        Tip(this, id = "consider", type = Tip.Type.CONSIDER),
+        Tip(this, id = "prepare", type = Tip.Type.PREPARE),
+        Tip(this, id = "quote", type = Tip.Type.QUOTE),
+        Tip(this, id = "tip", type = Tip.Type.TIP),
+    )
+    // endregion Test Manifests
 
     @BeforeTest
     @OptIn(DelicateCoilApi::class)

--- a/module/renderer/src/androidHostTest/kotlin/org/cru/godtools/shared/renderer/tips/RenderTipBottomSheetPaparazziTest.kt
+++ b/module/renderer/src/androidHostTest/kotlin/org/cru/godtools/shared/renderer/tips/RenderTipBottomSheetPaparazziTest.kt
@@ -1,0 +1,59 @@
+package org.cru.godtools.shared.renderer.tips
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.SheetValue
+import kotlin.test.Test
+import kotlinx.coroutines.runBlocking
+import org.cru.godtools.shared.renderer.BasePaparazziTest
+import org.cru.godtools.shared.tool.parser.model.Text
+import org.cru.godtools.shared.tool.parser.model.tips.Tip
+import org.cru.godtools.shared.tool.parser.model.tips.TipPage
+
+@OptIn(ExperimentalMaterial3Api::class)
+class RenderTipBottomSheetPaparazziTest : BasePaparazziTest() {
+    // start the sheet already expanded so the static snapshot captures the fully presented sheet
+    private val expandedSheetState = SheetState(
+        skipPartiallyExpanded = true,
+        positionalThreshold = { 0f },
+        velocityThreshold = { 0f },
+        initialValue = SheetValue.Expanded,
+    )
+
+    private fun tip(pageCount: Int = 3) = Tip(manifest, id = "training", type = Tip.Type.ASK) {
+        List(pageCount) { i ->
+            TipPage(it, position = i) { page -> listOf(Text(page, text = "Tip page ${i + 1} content")) }
+        }
+    }
+
+    @Test
+    fun `RenderTipBottomSheet()`() = contentSnapshot {
+        RenderTipBottomSheet(tip(), onDismiss = {}, sheetState = expandedSheetState)
+    }
+
+    @Test
+    fun `RenderTipBottomSheet() - Last Page`() = contentSnapshot {
+        RenderTipBottomSheet(tip(pageCount = 1), onDismiss = {}, sheetState = expandedSheetState)
+    }
+
+    @Test
+    fun `RenderTipBottomSheet() - Completed Tip`() {
+        runBlocking { tipsRepository.markTipComplete(manifest.code!!, manifest.locale!!, "training") }
+        contentSnapshot {
+            RenderTipBottomSheet(tip(), onDismiss = {}, sheetState = expandedSheetState)
+        }
+    }
+
+    @Test
+    fun `RenderTipBottomSheet() - RTL`() = contentSnapshot {
+        RenderTipBottomSheet(
+            Tip(rtlManifest, id = "training", type = Tip.Type.ASK) {
+                List(3) { i ->
+                    TipPage(it, position = i) { page -> listOf(Text(page, text = "محتوى الصفحة ${i + 1}")) }
+                }
+            },
+            onDismiss = {},
+            sheetState = expandedSheetState
+        )
+    }
+}

--- a/module/renderer/src/androidHostTest/kotlin/org/cru/godtools/shared/renderer/tips/RenderTipPaparazziTest.kt
+++ b/module/renderer/src/androidHostTest/kotlin/org/cru/godtools/shared/renderer/tips/RenderTipPaparazziTest.kt
@@ -1,0 +1,61 @@
+package org.cru.godtools.shared.renderer.tips
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.SemanticsMatcher
+import kotlin.test.Test
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.delay
+import me.saket.touchrobot.onNode
+import me.saket.touchrobot.rememberTouchRobot
+import org.cru.godtools.shared.renderer.BasePaparazziTest
+import org.cru.godtools.shared.tool.parser.model.Text
+import org.cru.godtools.shared.tool.parser.model.tips.Tip
+import org.cru.godtools.shared.tool.parser.model.tips.TipPage
+
+// These tests exercise RenderTip directly instead of RenderTipBottomSheet because simulated touch events are unable to
+// reach the ModalBottomSheet popup window when rendered within Paparazzi.
+class RenderTipPaparazziTest : BasePaparazziTest() {
+    @Test
+    fun `RenderTip() - Page Swipe`() {
+        val tip = Tip(manifest, id = "training", type = Tip.Type.ASK) {
+            List(3) { i ->
+                TipPage(it, position = i) { page -> listOf(Text(page, text = "Tip page ${i + 1} content")) }
+            }
+        }
+
+        animatedContentSnapshot(end = 1_000) {
+            RenderTip(tip, modifier = Modifier.fillMaxSize())
+
+            val touchRobot = rememberTouchRobot()
+            LaunchedEffect(Unit) {
+                delay(200.milliseconds)
+                touchRobot.onNode(SemanticsMatcher.expectValue(TipPagePosition, 0)).performGesture {
+                    swipe(start = centerRight, stop = centerLeft, duration = 600.milliseconds)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `RenderTip() - Page Swipe - RTL`() {
+        val tip = Tip(rtlManifest, id = "training", type = Tip.Type.ASK) {
+            List(3) { i ->
+                TipPage(it, position = i) { page -> listOf(Text(page, text = "محتوى الصفحة ${i + 1}")) }
+            }
+        }
+
+        animatedContentSnapshot(end = 1_000) {
+            RenderTip(tip, modifier = Modifier.fillMaxSize())
+
+            val touchRobot = rememberTouchRobot()
+            LaunchedEffect(Unit) {
+                delay(200.milliseconds)
+                touchRobot.onNode(SemanticsMatcher.expectValue(TipPagePosition, 0)).performGesture {
+                    swipe(start = centerLeft, stop = centerRight, duration = 600.milliseconds)
+                }
+            }
+        }
+    }
+}

--- a/module/renderer/src/androidHostTest/snapshots/images/org.cru.godtools.shared.renderer.tips_RenderTipBottomSheetPaparazziTest_RenderTipBottomSheet().png
+++ b/module/renderer/src/androidHostTest/snapshots/images/org.cru.godtools.shared.renderer.tips_RenderTipBottomSheetPaparazziTest_RenderTipBottomSheet().png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c2cddeab8913183c3eea58b6026c77978b0b10a70090db651eb6acf60489bdb
+size 14059

--- a/module/renderer/src/androidHostTest/snapshots/images/org.cru.godtools.shared.renderer.tips_RenderTipBottomSheetPaparazziTest_RenderTipBottomSheet()_-_Completed_Tip.png
+++ b/module/renderer/src/androidHostTest/snapshots/images/org.cru.godtools.shared.renderer.tips_RenderTipBottomSheetPaparazziTest_RenderTipBottomSheet()_-_Completed_Tip.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e955f68ace7d8d4763e99978efae5b5f9c87ecedb86922eee6d661e1645cd10
+size 15673

--- a/module/renderer/src/androidHostTest/snapshots/images/org.cru.godtools.shared.renderer.tips_RenderTipBottomSheetPaparazziTest_RenderTipBottomSheet()_-_Last_Page.png
+++ b/module/renderer/src/androidHostTest/snapshots/images/org.cru.godtools.shared.renderer.tips_RenderTipBottomSheetPaparazziTest_RenderTipBottomSheet()_-_Last_Page.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2cc2f56ce0f4432bc646b88add8fec798702511c4520e575f04f2556d7570490
+size 14156

--- a/module/renderer/src/androidHostTest/snapshots/images/org.cru.godtools.shared.renderer.tips_RenderTipBottomSheetPaparazziTest_RenderTipBottomSheet()_-_RTL.png
+++ b/module/renderer/src/androidHostTest/snapshots/images/org.cru.godtools.shared.renderer.tips_RenderTipBottomSheetPaparazziTest_RenderTipBottomSheet()_-_RTL.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b1bec74e85d25a8e520cc141b6552a787ddbbb8c5d949da835651461d7029b7
+size 13569

--- a/module/renderer/src/androidHostTest/snapshots/videos/org.cru.godtools.shared.renderer.tips_RenderTipPaparazziTest_RenderTip()_-_Page_Swipe.png
+++ b/module/renderer/src/androidHostTest/snapshots/videos/org.cru.godtools.shared.renderer.tips_RenderTipPaparazziTest_RenderTip()_-_Page_Swipe.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:466657066be15e426160e67d4204153c842d96405fc20f53afa4728a61cf63b7
+size 312419

--- a/module/renderer/src/androidHostTest/snapshots/videos/org.cru.godtools.shared.renderer.tips_RenderTipPaparazziTest_RenderTip()_-_Page_Swipe_-_RTL.png
+++ b/module/renderer/src/androidHostTest/snapshots/videos/org.cru.godtools.shared.renderer.tips_RenderTipPaparazziTest_RenderTip()_-_Page_Swipe_-_RTL.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f5782859e0750da20b0c496213b3d94a9bb3a6d978466de7422b833bcf82cb8
+size 302718

--- a/module/renderer/src/commonMain/composeResources/values/strings_renderer.xml
+++ b/module/renderer/src/commonMain/composeResources/values/strings_renderer.xml
@@ -12,6 +12,17 @@
     <string name="lesson_accessibility_action_page_previous">Previous Page</string>
     <string name="lesson_accessibility_action_page_next">Next Page</string>
 
+    <!-- Tip Strings -->
+    <eat-comment />
+    <string name="tool_renderer_tip_accessibility_action_close">Close Tip</string>
+    <string name="tool_renderer_tip_action_next">Next</string>
+    <string name="tool_renderer_tip_action_close">Close</string>
+    <string name="tool_renderer_tip_type_ask">Ask</string>
+    <string name="tool_renderer_tip_type_consider">Consider</string>
+    <string name="tool_renderer_tip_type_prepare">Prepare</string>
+    <string name="tool_renderer_tip_type_quote">Quote</string>
+    <string name="tool_renderer_tip_type_tip">Tip</string>
+
     <!-- Tool Content Strings -->
     <eat-comment />
     <string name="tool_renderer_accordion_section_action_collapse">Collapse</string>

--- a/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/content/extensions/Tip+Compose.kt
+++ b/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/content/extensions/Tip+Compose.kt
@@ -18,8 +18,14 @@ import org.cru.godtools.shared.renderer.generated.resources.ic_tips_quote
 import org.cru.godtools.shared.renderer.generated.resources.ic_tips_quote_done
 import org.cru.godtools.shared.renderer.generated.resources.ic_tips_tip
 import org.cru.godtools.shared.renderer.generated.resources.ic_tips_tip_done
+import org.cru.godtools.shared.renderer.generated.resources.tool_renderer_tip_type_ask
+import org.cru.godtools.shared.renderer.generated.resources.tool_renderer_tip_type_consider
+import org.cru.godtools.shared.renderer.generated.resources.tool_renderer_tip_type_prepare
+import org.cru.godtools.shared.renderer.generated.resources.tool_renderer_tip_type_quote
+import org.cru.godtools.shared.renderer.generated.resources.tool_renderer_tip_type_tip
 import org.cru.godtools.shared.tool.parser.model.tips.Tip
 import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
 
 @Composable
 internal fun painterTip(tip: Tip, isComplete: Boolean) = painterResource(
@@ -29,6 +35,17 @@ internal fun painterTip(tip: Tip, isComplete: Boolean) = painterResource(
         Tip.Type.QUOTE -> if (isComplete) Res.drawable.ic_tips_quote_done else Res.drawable.ic_tips_quote
         Tip.Type.PREPARE -> if (isComplete) Res.drawable.ic_tips_prepare_done else Res.drawable.ic_tips_prepare
         Tip.Type.TIP -> if (isComplete) Res.drawable.ic_tips_tip_done else Res.drawable.ic_tips_tip
+    }
+)
+
+@Composable
+internal fun stringTipType(type: Tip.Type) = stringResource(
+    when (type) {
+        Tip.Type.ASK -> Res.string.tool_renderer_tip_type_ask
+        Tip.Type.CONSIDER -> Res.string.tool_renderer_tip_type_consider
+        Tip.Type.PREPARE -> Res.string.tool_renderer_tip_type_prepare
+        Tip.Type.QUOTE -> Res.string.tool_renderer_tip_type_quote
+        Tip.Type.TIP -> Res.string.tool_renderer_tip_type_tip
     }
 )
 

--- a/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/lesson/RenderLesson.kt
+++ b/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/lesson/RenderLesson.kt
@@ -22,20 +22,14 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.compose.LocalLifecycleOwner
-import androidx.lifecycle.compose.rememberLifecycleOwner
 import com.github.ajalt.colormath.extensions.android.composecolor.toComposeColor
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.launch
@@ -50,6 +44,7 @@ import org.cru.godtools.shared.renderer.generated.resources.lesson_accessibility
 import org.cru.godtools.shared.renderer.generated.resources.lesson_accessibility_action_share
 import org.cru.godtools.shared.renderer.state.State
 import org.cru.godtools.shared.renderer.util.ContentEventListener
+import org.cru.godtools.shared.renderer.util.ProvideCurrentPageLifecycleOwner
 import org.cru.godtools.shared.renderer.util.ProvideLayoutDirectionFromLocale
 import org.cru.godtools.shared.tool.parser.model.backgroundColor
 import org.cru.godtools.shared.tool.parser.model.lessonNavBarColor
@@ -190,12 +185,7 @@ private fun RenderLessonPager(
         key = { lessonPagerState.pages[it].id },
         modifier = modifier.testTag(TestTagLessonPager),
     ) { i ->
-        val isCurrentPage by remember { derivedStateOf { i == pagerState.currentPage } }
-        val lifecycleOwner = rememberLifecycleOwner(
-            maxLifecycle = if (isCurrentPage) Lifecycle.State.RESUMED else Lifecycle.State.STARTED
-        )
-
-        CompositionLocalProvider(LocalLifecycleOwner provides lifecycleOwner) {
+        ProvideCurrentPageLifecycleOwner(pagerState, page = i) {
             RenderLessonPage(lessonPagerState.pages[i], state = state, contentInsets = contentInsets) { event ->
                 when (event) {
                     LessonPageEvent.NextPage -> coroutineScope.launch { pagerState.animateScrollToPage(i + 1) }

--- a/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/lesson/RenderLessonPage.kt
+++ b/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/lesson/RenderLessonPage.kt
@@ -39,6 +39,7 @@ import org.cru.godtools.shared.renderer.generated.resources.Res
 import org.cru.godtools.shared.renderer.generated.resources.lesson_accessibility_action_page_next
 import org.cru.godtools.shared.renderer.generated.resources.lesson_accessibility_action_page_previous
 import org.cru.godtools.shared.renderer.state.State
+import org.cru.godtools.shared.renderer.util.triggerScreenView
 import org.cru.godtools.shared.tool.analytics.ToolAnalyticsScreenNames
 import org.cru.godtools.shared.tool.parser.model.AnalyticsEvent
 import org.cru.godtools.shared.tool.parser.model.lesson.LessonPage
@@ -64,13 +65,7 @@ fun RenderLessonPage(
 ) {
     val coroutineScope = rememberCoroutineScope()
     LifecycleResumeEffect(page, state) {
-        state.triggerEvent(
-            State.Event.AnalyticsEvent.ScreenView(
-                tool = page.manifest.code,
-                locale = page.manifest.locale,
-                screenName = ToolAnalyticsScreenNames.forLessonPage(page)
-            )
-        )
+        state.triggerScreenView(page.manifest, ToolAnalyticsScreenNames.forLessonPage(page))
 
         val delayedEvents = page.triggerAnalyticsEvents(AnalyticsEvent.Trigger.VISIBLE, state, coroutineScope)
         onPauseOrDispose { delayedEvents.forEach { it.cancel() } }

--- a/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/tips/RenderTip.kt
+++ b/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/tips/RenderTip.kt
@@ -1,0 +1,160 @@
+package org.cru.godtools.shared.renderer.tips
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.rememberLifecycleOwner
+import com.github.ajalt.colormath.extensions.android.composecolor.toComposeColor
+import kotlinx.coroutines.launch
+import org.cru.godtools.shared.renderer.content.extensions.stringTipType
+import org.cru.godtools.shared.renderer.generated.resources.Res
+import org.cru.godtools.shared.renderer.generated.resources.tool_renderer_tip_accessibility_action_close
+import org.cru.godtools.shared.renderer.state.State
+import org.cru.godtools.shared.renderer.util.ProvideLayoutDirectionFromLocale
+import org.cru.godtools.shared.tool.parser.model.tips.Tip
+import org.jetbrains.compose.resources.stringResource
+
+internal const val TestTagTipPager = "TipPager"
+
+private val TipAppBarHeight = 64.dp
+private val TipProgressBarHeight = 12.dp
+private val TipProgressBarGapSize = 0.dp - TipProgressBarHeight
+private val TipHeaderHorizontalPadding = 32.dp
+
+/**
+ * Render the full content of a training [tip]: close button, page progress, tip type header, and a pager of the tip's
+ * pages, each page ending with a pinned Next/Close button.
+ *
+ * This composable fills the height it is given, so it should be sized by the caller (e.g. `Modifier.fillMaxSize()` or
+ * a bounded container such as [RenderTipBottomSheet]).
+ *
+ * @param onDismiss triggered when the user closes the tip, either via the close button or by completing the last page.
+ */
+@Composable
+fun RenderTip(
+    tip: Tip,
+    modifier: Modifier = Modifier,
+    state: State = remember { State() },
+    onDismiss: () -> Unit = {},
+) {
+    val coroutineScope = rememberCoroutineScope()
+    val pagerState = rememberPagerState { tip.pages.size }
+
+    ProvideLayoutDirectionFromLocale(tip.manifest.locale) {
+        Column(modifier) {
+            TipAppBar(pagerState, onDismiss = onDismiss)
+            TipHeader(tip, modifier = Modifier.padding(top = 8.dp))
+
+            HorizontalPager(
+                pagerState,
+                beyondViewportPageCount = 1,
+                verticalAlignment = Alignment.Top,
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(top = 16.dp)
+                    .testTag(TestTagTipPager)
+            ) { i ->
+                val page = tip.pages[i]
+                val isCurrentPage by remember { derivedStateOf { i == pagerState.currentPage } }
+                val lifecycleOwner = rememberLifecycleOwner(
+                    maxLifecycle = if (isCurrentPage) Lifecycle.State.RESUMED else Lifecycle.State.STARTED,
+                )
+
+                CompositionLocalProvider(LocalLifecycleOwner provides lifecycleOwner) {
+                    RenderTipPage(
+                        page,
+                        state = state,
+                        onNextPage = { coroutineScope.launch { pagerState.animateScrollToPage(i + 1) } },
+                        onCloseTip = onDismiss,
+                        modifier = Modifier.fillMaxSize()
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TipAppBar(pagerState: PagerState, onDismiss: () -> Unit, modifier: Modifier = Modifier) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+            .fillMaxWidth()
+            .height(TipAppBarHeight)
+    ) {
+        IconButton(
+            onClick = onDismiss,
+            modifier = Modifier.padding(horizontal = 8.dp)
+        ) {
+            Icon(
+                Icons.Filled.Close,
+                contentDescription = stringResource(Res.string.tool_renderer_tip_accessibility_action_close),
+                tint = MaterialTheme.colorScheme.primary,
+            )
+        }
+        LinearProgressIndicator(
+            progress = {
+                when (val pageCount = pagerState.pageCount) {
+                    0 -> 0f
+                    else -> (pagerState.currentPage + 1 + pagerState.currentPageOffsetFraction) / pageCount
+                }
+            },
+            gapSize = TipProgressBarGapSize,
+            drawStopIndicator = {},
+            modifier = Modifier
+                .height(TipProgressBarHeight)
+                .weight(1f)
+        )
+
+        // Match the width of the Close IconButton w/ padding
+        Spacer(Modifier.width(64.dp))
+    }
+}
+
+@Composable
+private fun TipHeader(tip: Tip, modifier: Modifier = Modifier) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = TipHeaderHorizontalPadding)
+    ) {
+        TipIcon(tip)
+        Text(
+            stringTipType(tip.type),
+            fontWeight = FontWeight.Bold,
+            fontSize = 16.sp,
+            color = tip.textColor.toComposeColor(),
+            modifier = Modifier.padding(start = 12.dp)
+        )
+    }
+}

--- a/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/tips/RenderTip.kt
+++ b/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/tips/RenderTip.kt
@@ -16,7 +16,6 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -26,7 +25,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -45,8 +43,6 @@ import org.cru.godtools.shared.renderer.state.State
 import org.cru.godtools.shared.renderer.util.ProvideLayoutDirectionFromLocale
 import org.cru.godtools.shared.tool.parser.model.tips.Tip
 import org.jetbrains.compose.resources.stringResource
-
-internal const val TestTagTipPager = "TipPager"
 
 private val TipAppBarHeight = 64.dp
 private val TipProgressBarHeight = 12.dp
@@ -75,7 +71,7 @@ fun RenderTip(
 
     ProvideLayoutDirectionFromLocale(tip.manifest.locale) {
         Column(modifier) {
-            TipAppBar(pagerState, onDismiss = onDismiss)
+            TipAppBar(tip, pagerState, onDismiss = onDismiss)
             TipHeader(tip, modifier = Modifier.padding(top = 8.dp))
 
             HorizontalPager(
@@ -85,7 +81,6 @@ fun RenderTip(
                 modifier = Modifier
                     .weight(1f)
                     .padding(top = 16.dp)
-                    .testTag(TestTagTipPager)
             ) { i ->
                 val page = tip.pages[i]
                 val isCurrentPage by remember { derivedStateOf { i == pagerState.currentPage } }
@@ -119,7 +114,9 @@ fun RenderTip(
 }
 
 @Composable
-private fun TipAppBar(pagerState: PagerState, onDismiss: () -> Unit, modifier: Modifier = Modifier) {
+private fun TipAppBar(tip: Tip, pagerState: PagerState, onDismiss: () -> Unit, modifier: Modifier = Modifier) {
+    val primaryColor = tip.primaryColor.toComposeColor()
+
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = modifier
@@ -133,9 +130,10 @@ private fun TipAppBar(pagerState: PagerState, onDismiss: () -> Unit, modifier: M
             Icon(
                 Icons.Filled.Close,
                 contentDescription = stringResource(Res.string.tool_renderer_tip_accessibility_action_close),
-                tint = MaterialTheme.colorScheme.primary,
+                tint = primaryColor,
             )
         }
+
         LinearProgressIndicator(
             progress = {
                 when (val pageCount = pagerState.pageCount) {
@@ -143,6 +141,8 @@ private fun TipAppBar(pagerState: PagerState, onDismiss: () -> Unit, modifier: M
                     else -> (pagerState.currentPage + 1 + pagerState.currentPageOffsetFraction) / pageCount
                 }
             },
+            color = primaryColor,
+            trackColor = primaryColor.copy(alpha = primaryColor.alpha * 0.24f),
             gapSize = TipProgressBarGapSize,
             drawStopIndicator = {},
             modifier = Modifier

--- a/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/tips/RenderTip.kt
+++ b/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/tips/RenderTip.kt
@@ -34,7 +34,10 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.rememberLifecycleOwner
 import com.github.ajalt.colormath.extensions.android.composecolor.toComposeColor
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.cru.godtools.shared.renderer.content.extensions.stringTipType
 import org.cru.godtools.shared.renderer.generated.resources.Res
 import org.cru.godtools.shared.renderer.generated.resources.tool_renderer_tip_accessibility_action_close
@@ -67,6 +70,7 @@ fun RenderTip(
     onDismiss: () -> Unit = {},
 ) {
     val coroutineScope = rememberCoroutineScope()
+    val tipsRepository = LocalTipsRepository.current
     val pagerState = rememberPagerState { tip.pages.size }
 
     ProvideLayoutDirectionFromLocale(tip.manifest.locale) {
@@ -94,7 +98,18 @@ fun RenderTip(
                         page,
                         state = state,
                         onNextPage = { coroutineScope.launch { pagerState.animateScrollToPage(i + 1) } },
-                        onCloseTip = onDismiss,
+                        onCloseTip = {
+                            val tool = tip.manifest.code
+                            val locale = tip.manifest.locale
+                            if (tool != null && locale != null) {
+                                coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
+                                    withContext(NonCancellable) {
+                                        tipsRepository.markTipComplete(tool, locale, tip.id)
+                                    }
+                                }
+                            }
+                            onDismiss()
+                        },
                         modifier = Modifier.fillMaxSize()
                     )
                 }

--- a/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/tips/RenderTip.kt
+++ b/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/tips/RenderTip.kt
@@ -18,9 +18,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
@@ -28,9 +25,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.compose.LocalLifecycleOwner
-import androidx.lifecycle.compose.rememberLifecycleOwner
 import com.github.ajalt.colormath.extensions.android.composecolor.toComposeColor
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.NonCancellable
@@ -40,6 +34,7 @@ import org.cru.godtools.shared.renderer.content.extensions.stringTipType
 import org.cru.godtools.shared.renderer.generated.resources.Res
 import org.cru.godtools.shared.renderer.generated.resources.tool_renderer_tip_accessibility_action_close
 import org.cru.godtools.shared.renderer.state.State
+import org.cru.godtools.shared.renderer.util.ProvideCurrentPageLifecycleOwner
 import org.cru.godtools.shared.renderer.util.ProvideLayoutDirectionFromLocale
 import org.cru.godtools.shared.tool.parser.model.tips.Tip
 import org.jetbrains.compose.resources.stringResource
@@ -83,12 +78,8 @@ fun RenderTip(
                     .padding(top = 16.dp)
             ) { i ->
                 val page = tip.pages[i]
-                val isCurrentPage by remember { derivedStateOf { i == pagerState.currentPage } }
-                val lifecycleOwner = rememberLifecycleOwner(
-                    maxLifecycle = if (isCurrentPage) Lifecycle.State.RESUMED else Lifecycle.State.STARTED,
-                )
 
-                CompositionLocalProvider(LocalLifecycleOwner provides lifecycleOwner) {
+                ProvideCurrentPageLifecycleOwner(pagerState, page = i) {
                     RenderTipPage(
                         page,
                         state = state,

--- a/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/tips/RenderTipBottomSheet.kt
+++ b/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/tips/RenderTipBottomSheet.kt
@@ -1,0 +1,61 @@
+package org.cru.godtools.shared.renderer.tips
+
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import org.cru.godtools.shared.renderer.state.State
+import org.cru.godtools.shared.tool.parser.model.tips.Tip
+
+private val TipSheetMaxHeight = 450.dp
+private val TipSheetFullHeightThreshold = 500.dp
+
+/**
+ * Render a training [tip] within a modal bottom sheet.
+ *
+ * The sheet is capped at a max height of 450dp, unless there is less than 500dp of height available, in which case the
+ * sheet expands to the full available height.
+ *
+ * @param onDismiss triggered when the user dismisses the sheet, either by swiping it away, tapping the scrim, using
+ * the close button, or completing the last page of the tip. The caller is responsible for removing this composable
+ * from the composition.
+ */
+@Composable
+@OptIn(ExperimentalMaterial3Api::class)
+fun RenderTipBottomSheet(
+    tip: Tip,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+    sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+    state: State = remember { State() },
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        modifier = modifier
+    ) {
+        BoxWithConstraints {
+            RenderTip(
+                tip,
+                state = state,
+                onDismiss = onDismiss,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .then(
+                        when {
+                            maxHeight < TipSheetFullHeightThreshold -> Modifier.fillMaxHeight()
+                            else -> Modifier.heightIn(max = TipSheetMaxHeight)
+                        }
+                    )
+            )
+        }
+    }
+}

--- a/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/tips/RenderTipIcons.kt
+++ b/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/tips/RenderTipIcons.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.CornerSize
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -32,6 +33,27 @@ internal val TipElevation = 4.dp
 internal val TipArrowHeight = 48.dp
 private val TipArrowSize = 12.dp
 internal val TipCornerSize = CornerSize(6.dp)
+
+@Composable
+internal fun TipIcon(tip: Tip, modifier: Modifier = Modifier) {
+    val isComplete by tip.produceIsComplete()
+
+    Surface(
+        shape = RoundedCornerShape(TipCornerSize),
+        shadowElevation = TipElevation,
+        modifier = modifier.size(TipSize)
+    ) {
+        Image(
+            painterTip(tip, isComplete = isComplete),
+            contentDescription = null,
+            modifier = Modifier
+                .fillMaxSize()
+                .tipBackground(isComplete = isComplete)
+                .wrapContentSize()
+                .size(TipIconSize)
+        )
+    }
+}
 
 @Composable
 internal fun TipUpArrow(tip: Tip, state: State, modifier: Modifier = Modifier) {

--- a/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/tips/RenderTipPage.kt
+++ b/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/tips/RenderTipPage.kt
@@ -1,0 +1,88 @@
+package org.cru.godtools.shared.renderer.tips
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ProvideTextStyle
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.SemanticsPropertyKey
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import com.github.ajalt.colormath.extensions.android.composecolor.toComposeColor
+import org.ccci.gto.android.common.compose.foundation.verticalFadingEdgeEffect
+import org.cru.godtools.shared.renderer.ToolTheme
+import org.cru.godtools.shared.renderer.content.RenderContent
+import org.cru.godtools.shared.renderer.generated.resources.Res
+import org.cru.godtools.shared.renderer.generated.resources.tool_renderer_tip_action_close
+import org.cru.godtools.shared.renderer.generated.resources.tool_renderer_tip_action_next
+import org.cru.godtools.shared.renderer.state.State
+import org.cru.godtools.shared.tool.parser.model.primaryColor
+import org.cru.godtools.shared.tool.parser.model.primaryTextColor
+import org.cru.godtools.shared.tool.parser.model.stylesParent
+import org.cru.godtools.shared.tool.parser.model.tips.TipPage
+import org.jetbrains.compose.resources.stringResource
+
+internal const val TestTagTipPageButton = "TipPageButton"
+
+internal val TipPagePosition = SemanticsPropertyKey<Int>(
+    name = "TipPagePosition",
+    mergePolicy = { parentValue, _ ->
+        // Never merge TipPagePosition, to avoid leaking internal semantics to parents.
+        parentValue
+    },
+)
+
+@Composable
+internal fun RenderTipPage(
+    page: TipPage,
+    state: State,
+    onNextPage: () -> Unit,
+    onCloseTip: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.semantics { this[TipPagePosition] = page.position }
+    ) {
+        val scrollState = rememberScrollState()
+
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .verticalScroll(scrollState)
+                .verticalFadingEdgeEffect(scrollState)
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 8.dp)
+        ) {
+            ProvideTextStyle(ToolTheme.ContentTextStyle) {
+                RenderContent(page.content, state = state)
+            }
+        }
+
+        Button(
+            onClick = { if (page.isLastPage) onCloseTip() else onNextPage() },
+            colors = ButtonDefaults.buttonColors(
+                containerColor = page.stylesParent.primaryColor.toComposeColor(),
+                contentColor = page.stylesParent.primaryTextColor.toComposeColor(),
+            ),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 64.dp)
+                .padding(bottom = 16.dp)
+                .testTag(TestTagTipPageButton)
+        ) {
+            Text(
+                when {
+                    page.isLastPage -> stringResource(Res.string.tool_renderer_tip_action_close)
+                    else -> stringResource(Res.string.tool_renderer_tip_action_next)
+                }
+            )
+        }
+    }
+}

--- a/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/tips/RenderTipPage.kt
+++ b/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/tips/RenderTipPage.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.SemanticsPropertyKey
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.LifecycleResumeEffect
 import com.github.ajalt.colormath.extensions.android.composecolor.toComposeColor
 import org.ccci.gto.android.common.compose.foundation.verticalFadingEdgeEffect
 import org.cru.godtools.shared.renderer.ToolTheme
@@ -23,6 +24,7 @@ import org.cru.godtools.shared.renderer.generated.resources.Res
 import org.cru.godtools.shared.renderer.generated.resources.tool_renderer_tip_action_close
 import org.cru.godtools.shared.renderer.generated.resources.tool_renderer_tip_action_next
 import org.cru.godtools.shared.renderer.state.State
+import org.cru.godtools.shared.tool.analytics.ToolAnalyticsScreenNames
 import org.cru.godtools.shared.tool.parser.model.primaryColor
 import org.cru.godtools.shared.tool.parser.model.primaryTextColor
 import org.cru.godtools.shared.tool.parser.model.stylesParent
@@ -47,6 +49,17 @@ internal fun RenderTipPage(
     onCloseTip: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    LifecycleResumeEffect(page, state) {
+        state.triggerEvent(
+            State.Event.AnalyticsEvent.ScreenView(
+                tool = page.manifest.code,
+                locale = page.manifest.locale,
+                screenName = ToolAnalyticsScreenNames.forTipPage(page),
+            ),
+        )
+        onPauseOrDispose { }
+    }
+
     Column(
         modifier = modifier.semantics { this[TipPagePosition] = page.position }
     ) {

--- a/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/tips/RenderTipPage.kt
+++ b/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/tips/RenderTipPage.kt
@@ -24,6 +24,7 @@ import org.cru.godtools.shared.renderer.generated.resources.Res
 import org.cru.godtools.shared.renderer.generated.resources.tool_renderer_tip_action_close
 import org.cru.godtools.shared.renderer.generated.resources.tool_renderer_tip_action_next
 import org.cru.godtools.shared.renderer.state.State
+import org.cru.godtools.shared.renderer.util.triggerScreenView
 import org.cru.godtools.shared.tool.analytics.ToolAnalyticsScreenNames
 import org.cru.godtools.shared.tool.parser.model.primaryColor
 import org.cru.godtools.shared.tool.parser.model.primaryTextColor
@@ -50,13 +51,7 @@ internal fun RenderTipPage(
     modifier: Modifier = Modifier,
 ) {
     LifecycleResumeEffect(page, state) {
-        state.triggerEvent(
-            State.Event.AnalyticsEvent.ScreenView(
-                tool = page.manifest.code,
-                locale = page.manifest.locale,
-                screenName = ToolAnalyticsScreenNames.forTipPage(page),
-            ),
-        )
+        state.triggerScreenView(page.manifest, ToolAnalyticsScreenNames.forTipPage(page))
         onPauseOrDispose { }
     }
 

--- a/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/util/ProvideCurrentPageLifecycleOwner.kt
+++ b/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/util/ProvideCurrentPageLifecycleOwner.kt
@@ -1,0 +1,26 @@
+package org.cru.godtools.shared.renderer.util
+
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.rememberLifecycleOwner
+
+/**
+ * Provide a [LocalLifecycleOwner] to [content] that is only resumed while [page] is the settled page of [pagerState].
+ * Pages that are composed but not settled (e.g. pre-composed via beyondViewportPageCount, or crossed transiently
+ * mid-swipe) are capped at STARTED, so lifecycle-aware effects within a page only run once the pager settles on it.
+ */
+@Composable
+internal fun ProvideCurrentPageLifecycleOwner(pagerState: PagerState, page: Int, content: @Composable () -> Unit) {
+    val isSettledPage by remember(pagerState, page) { derivedStateOf { page == pagerState.settledPage } }
+    val lifecycleOwner = rememberLifecycleOwner(
+        maxLifecycle = if (isSettledPage) Lifecycle.State.RESUMED else Lifecycle.State.STARTED
+    )
+
+    CompositionLocalProvider(LocalLifecycleOwner provides lifecycleOwner, content = content)
+}

--- a/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/util/State+Analytics.kt
+++ b/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/util/State+Analytics.kt
@@ -1,0 +1,14 @@
+@file:Suppress("ktlint:standard:filename")
+
+package org.cru.godtools.shared.renderer.util
+
+import org.cru.godtools.shared.renderer.state.State
+import org.cru.godtools.shared.tool.parser.model.Manifest
+
+internal fun State.triggerScreenView(manifest: Manifest, screenName: String) = triggerEvent(
+    State.Event.AnalyticsEvent.ScreenView(
+        tool = manifest.code,
+        locale = manifest.locale,
+        screenName = screenName,
+    )
+)

--- a/module/renderer/src/commonTest/kotlin/org/cru/godtools/shared/renderer/BaseRendererTest.kt
+++ b/module/renderer/src/commonTest/kotlin/org/cru/godtools/shared/renderer/BaseRendererTest.kt
@@ -10,10 +10,12 @@ import kotlin.test.BeforeTest
 import kotlinx.coroutines.test.TestScope
 import org.cru.godtools.shared.renderer.internal.compose.resources.PreviewContextConfigurationEffect
 import org.cru.godtools.shared.renderer.state.State
+import org.cru.godtools.shared.renderer.tips.InMemoryTipsRepository
 import org.cru.godtools.shared.renderer.util.ProvideRendererServices
 
 abstract class BaseRendererTest {
     protected val state = State()
+    protected val tipsRepository = InMemoryTipsRepository()
 
     protected val lifecycleOwner = TestLifecycleOwner(Lifecycle.State.RESUMED)
     protected val testScope = TestScope()
@@ -23,7 +25,7 @@ abstract class BaseRendererTest {
         CompositionLocalProvider(LocalInspectionMode provides true) {
             PreviewContextConfigurationEffect()
         }
-        ProvideRendererServices(TestResources.fileSystem) {
+        ProvideRendererServices(TestResources.fileSystem, tipsRepository = tipsRepository) {
             CompositionLocalProvider(LocalLifecycleOwner provides lifecycleOwner, content = content)
         }
     }

--- a/module/renderer/src/commonTest/kotlin/org/cru/godtools/shared/renderer/tips/RenderTipBottomSheetTest.kt
+++ b/module/renderer/src/commonTest/kotlin/org/cru/godtools/shared/renderer/tips/RenderTipBottomSheetTest.kt
@@ -1,0 +1,60 @@
+package org.cru.godtools.shared.renderer.tips
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.v2.runComposeUiTest
+import io.fluidsonic.locale.Locale
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.runBlocking
+import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
+import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
+import org.cru.godtools.shared.renderer.BaseRendererTest
+import org.cru.godtools.shared.renderer.generated.resources.Res
+import org.cru.godtools.shared.renderer.generated.resources.tool_renderer_tip_accessibility_action_close
+import org.cru.godtools.shared.tool.parser.model.Manifest
+import org.cru.godtools.shared.tool.parser.model.Text
+import org.cru.godtools.shared.tool.parser.model.tips.Tip
+import org.cru.godtools.shared.tool.parser.model.tips.TipPage
+import org.jetbrains.compose.resources.getString
+
+@RunOnAndroidWith(AndroidJUnit4::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalTestApi::class)
+class RenderTipBottomSheetTest : BaseRendererTest() {
+    private val manifest = Manifest(code = "tool", locale = Locale.forLanguageTag("en"))
+    private val tip = Tip(manifest, id = "tip1", type = Tip.Type.ASK) { tip ->
+        listOf(TipPage(tip, position = 0) { page -> listOf(Text(page, text = "Tip Page 1")) })
+    }
+
+    private var dismissed = 0
+
+    private val closeTip by lazy { runBlocking { getString(Res.string.tool_renderer_tip_accessibility_action_close) } }
+
+    @Composable
+    private fun TestRenderTipBottomSheet() {
+        ProvideTestCompositionLocals {
+            RenderTipBottomSheet(tip, onDismiss = { dismissed++ }, state = state)
+        }
+    }
+
+    @Test
+    fun `UI - Renders the tip content in the sheet`() = runComposeUiTest {
+        setContent { TestRenderTipBottomSheet() }
+
+        onNodeWithText("Tip Page 1").assertIsDisplayed()
+        onNodeWithText("Ask").assertIsDisplayed()
+    }
+
+    @Test
+    fun `Action - X button triggers onDismiss`() = runComposeUiTest {
+        setContent { TestRenderTipBottomSheet() }
+
+        onNodeWithContentDescription(closeTip).performClick()
+        assertEquals(1, dismissed)
+    }
+}

--- a/module/renderer/src/commonTest/kotlin/org/cru/godtools/shared/renderer/tips/RenderTipTest.kt
+++ b/module/renderer/src/commonTest/kotlin/org/cru/godtools/shared/renderer/tips/RenderTipTest.kt
@@ -17,6 +17,9 @@ import androidx.compose.ui.test.v2.runComposeUiTest
 import io.fluidsonic.locale.Locale
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
 import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
@@ -107,5 +110,43 @@ class RenderTipTest : BaseRendererTest() {
 
         onNodeWithContentDescription(closeTip).assertIsDisplayed().performClick()
         assertEquals(1, dismissed)
+    }
+
+    @Test
+    fun `Action - Close button on last page marks the tip complete`() = runComposeUiTest {
+        setContent { TestRenderTip() }
+
+        onPageButton(0).performClick()
+        onPageButton(1).performClick()
+        onPageButton(2).performClick()
+        waitForIdle()
+
+        assertEquals(1, dismissed)
+        assertTrue(tipsRepository.isTipCompleteFlow(tip.manifest.code!!, Locale.forLanguageTag("en"), tip.id).first())
+    }
+
+    @Test
+    fun `Action - X button does not mark the tip complete`() = runComposeUiTest {
+        setContent { TestRenderTip() }
+
+        onNodeWithContentDescription(closeTip).performClick()
+        waitForIdle()
+
+        assertEquals(1, dismissed)
+        assertFalse(tipsRepository.isTipCompleteFlow(tip.manifest.code!!, Locale.forLanguageTag("en"), tip.id).first())
+    }
+
+    @Test
+    fun `Action - Close button skips marking complete when manifest has no code or locale`() = runComposeUiTest {
+        val tip = Tip(id = "tip1", type = Tip.Type.ASK) { tip ->
+            listOf(TipPage(tip, position = 0) { page -> listOf(Text(page, text = "Only Page")) })
+        }
+        setContent { TestRenderTip(tip) }
+
+        onPageButton(0).performClick()
+        waitForIdle()
+
+        assertEquals(1, dismissed)
+        assertFalse(tipsRepository.isTipCompleteFlow("tool", Locale.forLanguageTag("en"), tip.id).first())
     }
 }

--- a/module/renderer/src/commonTest/kotlin/org/cru/godtools/shared/renderer/tips/RenderTipTest.kt
+++ b/module/renderer/src/commonTest/kotlin/org/cru/godtools/shared/renderer/tips/RenderTipTest.kt
@@ -14,11 +14,13 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.v2.runComposeUiTest
+import app.cash.turbine.test
 import io.fluidsonic.locale.Locale
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
@@ -28,6 +30,7 @@ import org.cru.godtools.shared.renderer.generated.resources.Res
 import org.cru.godtools.shared.renderer.generated.resources.tool_renderer_tip_accessibility_action_close
 import org.cru.godtools.shared.renderer.generated.resources.tool_renderer_tip_action_close
 import org.cru.godtools.shared.renderer.generated.resources.tool_renderer_tip_action_next
+import org.cru.godtools.shared.renderer.state.State
 import org.cru.godtools.shared.tool.parser.model.Manifest
 import org.cru.godtools.shared.tool.parser.model.Text
 import org.cru.godtools.shared.tool.parser.model.tips.Tip
@@ -148,5 +151,26 @@ class RenderTipTest : BaseRendererTest() {
 
         assertEquals(1, dismissed)
         assertFalse(tipsRepository.isTipCompleteFlow("tool", Locale.forLanguageTag("en"), tip.id).first())
+    }
+
+    @Test
+    fun `Analytics - ScreenView event for each settled page`() = runComposeUiTest {
+        state.events.filterIsInstance<State.Event.AnalyticsEvent.ScreenView>().test {
+            setContent { TestRenderTip() }
+            assertEquals(
+                State.Event.AnalyticsEvent.ScreenView("tool", Locale.forLanguageTag("en"), "tool-tip-tip1-0"),
+                awaitItem(),
+            )
+
+            // the pre-composed (but not current) page 1 must not fire its ScreenView eagerly
+            expectNoEvents()
+
+            onPageButton(0).performClick()
+            waitForIdle()
+            assertEquals(
+                State.Event.AnalyticsEvent.ScreenView("tool", Locale.forLanguageTag("en"), "tool-tip-tip1-1"),
+                awaitItem(),
+            )
+        }
     }
 }

--- a/module/renderer/src/commonTest/kotlin/org/cru/godtools/shared/renderer/tips/RenderTipTest.kt
+++ b/module/renderer/src/commonTest/kotlin/org/cru/godtools/shared/renderer/tips/RenderTipTest.kt
@@ -1,0 +1,111 @@
+package org.cru.godtools.shared.renderer.tips
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.hasAnyAncestor
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.v2.runComposeUiTest
+import io.fluidsonic.locale.Locale
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.runBlocking
+import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
+import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
+import org.cru.godtools.shared.renderer.BaseRendererTest
+import org.cru.godtools.shared.renderer.generated.resources.Res
+import org.cru.godtools.shared.renderer.generated.resources.tool_renderer_tip_accessibility_action_close
+import org.cru.godtools.shared.renderer.generated.resources.tool_renderer_tip_action_close
+import org.cru.godtools.shared.renderer.generated.resources.tool_renderer_tip_action_next
+import org.cru.godtools.shared.tool.parser.model.Manifest
+import org.cru.godtools.shared.tool.parser.model.Text
+import org.cru.godtools.shared.tool.parser.model.tips.Tip
+import org.cru.godtools.shared.tool.parser.model.tips.TipPage
+import org.jetbrains.compose.resources.getString
+
+@RunOnAndroidWith(AndroidJUnit4::class)
+@OptIn(ExperimentalTestApi::class)
+class RenderTipTest : BaseRendererTest() {
+    private val tip = Tip(
+        manifest = Manifest(code = "tool", locale = Locale.forLanguageTag("en")),
+        id = "tip1",
+        type = Tip.Type.ASK,
+    ) { tip ->
+        List(3) { i -> TipPage(tip, position = i) { page -> listOf(Text(page, text = "Tip Page ${i + 1}")) } }
+    }
+
+    private var dismissed = 0
+
+    private val next by lazy { runBlocking { getString(Res.string.tool_renderer_tip_action_next) } }
+    private val close by lazy { runBlocking { getString(Res.string.tool_renderer_tip_action_close) } }
+    private val closeTip by lazy { runBlocking { getString(Res.string.tool_renderer_tip_accessibility_action_close) } }
+
+    @Composable
+    private fun TestRenderTip(tip: Tip = this.tip) {
+        ProvideTestCompositionLocals {
+            RenderTip(tip, state = state, onDismiss = { dismissed++ }, modifier = Modifier.fillMaxSize())
+        }
+    }
+
+    private fun SemanticsNodeInteractionsProvider.onPageButton(position: Int) = onNode(
+        hasTestTag(TestTagTipPageButton) and hasAnyAncestor(SemanticsMatcher.expectValue(TipPagePosition, position)),
+    )
+
+    @Test
+    fun `UI - Header - Tip type label`() = runComposeUiTest {
+        setContent { TestRenderTip() }
+        onNodeWithText("Ask").assertIsDisplayed()
+    }
+
+    @Test
+    fun `UI - Page content is rendered`() = runComposeUiTest {
+        setContent { TestRenderTip() }
+        onNodeWithText("Tip Page 1").assertIsDisplayed()
+    }
+
+    @Test
+    fun `UI - Button - Next on non-last pages and Close on last page`() = runComposeUiTest {
+        setContent { TestRenderTip() }
+
+        onPageButton(0).assertTextEquals(next)
+        onPageButton(0).performClick()
+        onPageButton(1).assertTextEquals(next)
+        onPageButton(1).performClick()
+        onPageButton(2).assertTextEquals(close)
+    }
+
+    @Test
+    fun `Action - Next button advances to the next page`() = runComposeUiTest {
+        setContent { TestRenderTip() }
+
+        onPageButton(0).performClick()
+        onNodeWithText("Tip Page 2").assertIsDisplayed()
+        assertEquals(0, dismissed)
+    }
+
+    @Test
+    fun `Action - Close button on last page dismisses the tip`() = runComposeUiTest {
+        setContent { TestRenderTip() }
+
+        onPageButton(0).performClick()
+        onPageButton(1).performClick()
+        onPageButton(2).performClick()
+        assertEquals(1, dismissed)
+    }
+
+    @Test
+    fun `Action - X button dismisses the tip`() = runComposeUiTest {
+        setContent { TestRenderTip() }
+
+        onNodeWithContentDescription(closeTip).assertIsDisplayed().performClick()
+        assertEquals(1, dismissed)
+    }
+}


### PR DESCRIPTION
Adds shared Compose support for rendering training Tips to `module/renderer`, matching the godtools-android `ui/tips-renderer` UI.

## New public API
- `RenderTip(tip, modifier, state, onDismiss)` — renders the full tip content: app-bar strip (X close button + Material3 `LinearProgressIndicator` page progress, tinted with the tip's `primaryColor`), tip-type badge + localized label header, and a `HorizontalPager` of tip pages, each with independently scrollable content (with a vertical fading edge) and a Next/Close button pinned to the page bottom.
- `RenderTipBottomSheet(tip, onDismiss, modifier, sheetState, state)` — Material3 `ModalBottomSheet` wrapper (forced expanded) hosting `RenderTip`, capped at 450dp tall (full height when less than 500dp is available), intended for presentation via Circuit overlays in host apps.
- `internal fun RenderTipPage(...)` (own file) renders a single tip page for finer-grained reuse within the module.

## Behavior
- Close on the last page marks the tip complete via `TipsRepository` (undispatched + `NonCancellable` so completion survives dismissal) and dismisses; the X button dismisses without completing. Completion state reactively drives the badge's done styling.
- Per-page `ScreenView` analytics events via the existing `State` event system (`ToolAnalyticsScreenNames.forTipPage`), gated per-page by lifecycle so only the current page fires.

## Supporting changes
- `TipPage`'s test constructor is now public `@RestrictTo(TESTS)` (mirroring `LessonPage`) so renderer tests can build tip pages.
- New English `tool_renderer_tip_*` strings (other locales via Crowdin).
- Compose UI behavior tests (Android + iOS), static Paparazzi snapshots of `RenderTipBottomSheet` (first/last page, completed, RTL), and animated page-swipe Paparazzi tests (LTR + RTL) driven by [touch-robot](https://github.com/saket/touch-robot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)