### PR TITLE
Make IosXmlPullParserFactory.openFile a suspend function

### DIFF
--- a/module/parser/src/iosMain/kotlin/org/cru/godtools/shared/tool/parser/xml/IosXmlPullParserFactory.kt
+++ b/module/parser/src/iosMain/kotlin/org/cru/godtools/shared/tool/parser/xml/IosXmlPullParserFactory.kt
@@ -4,7 +4,7 @@ import platform.Foundation.NSData
 import platform.Foundation.NSXMLParser
 
 abstract class IosXmlPullParserFactory : XmlPullParserFactory() {
-    abstract fun openFile(fileName: String): NSData?
+    abstract suspend fun openFile(fileName: String): NSData?
 
     override suspend fun getXmlParser(fileName: String) = openFile(fileName)?.let { IosXmlPullParser(NSXMLParser(it)) }
 }

--- a/module/parser/src/iosTest/kotlin/org/cru/godtools/shared/tool/parser/internal/UsesResources.ios.kt
+++ b/module/parser/src/iosTest/kotlin/org/cru/godtools/shared/tool/parser/internal/UsesResources.ios.kt
@@ -8,7 +8,7 @@ import platform.Foundation.dataWithContentsOfFile
 
 internal actual val UsesResources.TEST_XML_PULL_PARSER_FACTORY: XmlPullParserFactory
     get() = object : IosXmlPullParserFactory() {
-        override fun openFile(fileName: String) = this@TEST_XML_PULL_PARSER_FACTORY::class.qualifiedName
+        override suspend fun openFile(fileName: String) = this@TEST_XML_PULL_PARSER_FACTORY::class.qualifiedName
             ?.replace('.', '/')?.substringBeforeLast('/')
             ?.let { NSBundle.mainBundle.pathForResource(fileName, null, it) }
             ?.let { NSData.dataWithContentsOfFile(it) }


### PR DESCRIPTION
Makes `IosXmlPullParserFactory.openFile` a `suspend` function so iOS implementations can load files asynchronously (e.g. from suspending download/IO code) instead of blocking. `getXmlParser` was already suspendable, so this just propagates suspension to the open hook. The iOS test factory override was updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)