### PR TITLE
LessonPagerState tweaks: simplify pages and add settledPage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,15 @@
+# Android Studio
+captures/
+.idea/
+*.iml
+local.properties
+out/
+
 # Gradle
-.gradle/
 build/
+.gradle/
+gradle/gradle-daemon-jvm.properties
 *.podspec
 
 # Kotlin
 .kotlin/
-
-# Android Studio
-.idea/
-*.iml
-captures/
-out/
-local.properties

--- a/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/lesson/LessonPagerState.kt
+++ b/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/lesson/LessonPagerState.kt
@@ -36,6 +36,7 @@ class LessonPagerState private constructor(visiblePages: Collection<String>, pag
 
     private val _pagerState = pagerState ?: SaveablePagerState(0, 0f) { pages.size }
     val pagerState: PagerState get() = _pagerState
+    val settledPage by derivedStateOf { pages.getOrNull(_pagerState.settledPage) }
 
     fun updateManifest(manifest: Manifest) = updatePages(manifest.pages.filterIsInstance<LessonPage>())
     fun updatePages(pages: List<LessonPage>) {

--- a/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/lesson/LessonPagerState.kt
+++ b/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/lesson/LessonPagerState.kt
@@ -32,11 +32,8 @@ class LessonPagerState private constructor(visiblePages: Collection<String>, pag
 
     internal var allPages: ImmutableList<LessonPage> by mutableStateOf(persistentListOf())
     internal val visiblePages = mutableStateSetOf(*visiblePages.toTypedArray())
-    private val pagesState = derivedStateOf {
-        allPages.filter { it.id in this.visiblePages || !it.isHidden }.toImmutableList()
-    }
+    val pages by derivedStateOf { allPages.filter { it.id in this.visiblePages || !it.isHidden }.toImmutableList() }
 
-    val pages by pagesState
     private val _pagerState = pagerState ?: SaveablePagerState(0, 0f) { pages.size }
     val pagerState: PagerState get() = _pagerState
 

--- a/module/renderer/src/commonTest/kotlin/org/cru/godtools/shared/renderer/lesson/LessonPagerStateTest.kt
+++ b/module/renderer/src/commonTest/kotlin/org/cru/godtools/shared/renderer/lesson/LessonPagerStateTest.kt
@@ -14,6 +14,8 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
@@ -47,6 +49,58 @@ class LessonPagerStateTest : BaseRendererTest() {
 
         onNodeWithText("Page: 1").assertExists()
     }
+
+    // region settledPage
+    @Test
+    fun `settledPage - returns the page the pager is settled on`() {
+        val manifest = Manifest(type = Type.LESSON) {
+            listOf(
+                LessonPage(it, id = "page1"),
+                LessonPage(it, id = "page2"),
+            )
+        }
+
+        val state = LessonPagerState(manifest, currentPage = 1)
+        assertEquals("page2", state.settledPage?.id, "settledPage should be the page at the pager's settled index")
+    }
+
+    @Test
+    fun `settledPage - indexes into visible pages only`() {
+        val manifest = Manifest(type = Type.LESSON) {
+            listOf(
+                LessonPage(it, id = "page1"),
+                LessonPage(it, id = "page2", isHidden = true),
+                LessonPage(it, id = "page3"),
+            )
+        }
+
+        val state = LessonPagerState(manifest, currentPage = 1)
+        assertEquals("page3", state.settledPage?.id, "hidden pages are excluded from pages, shifting the index")
+
+        state.visiblePages += "page2"
+        assertEquals("page2", state.settledPage?.id, "settledPage should update when a hidden page becomes visible")
+    }
+
+    @Test
+    fun `settledPage - null when there are no pages`() {
+        val state = LessonPagerState()
+        assertNull(state.settledPage, "settledPage should be null when the pager has no pages")
+    }
+
+    @Test
+    fun `settledPage - null when the settled index is beyond the available pages`() {
+        val manifest = Manifest(type = Type.LESSON) {
+            listOf(
+                LessonPage(it, id = "page1"),
+                LessonPage(it, id = "page2"),
+            )
+        }
+
+        val state = LessonPagerState(manifest, currentPage = 1)
+        state.updatePages(emptyList())
+        assertNull(state.settledPage, "settledPage should be null when pages shrink below the settled index")
+    }
+    // endregion settledPage
 
     @Test
     @IgnoreOnIos // TODO: https://youtrack.jetbrains.com/issue/CMP-6836


### PR DESCRIPTION
## Summary
- Simplify the `pages` property on `LessonPagerState` by inlining the private `pagesState` backing property into a single `derivedStateOf` delegate
- Add a `settledPage: LessonPage?` property derived from the pager's settled index and the visible pages
- Add commonTest coverage for `settledPage` (settled index resolution, hidden page filtering, empty/out-of-range null cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)