### PR TITLE
Run Paparazzi tests independently from other unit tests

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -14,8 +14,8 @@ The XML content format is defined by XSD schemas in the [`mobile-content-api` re
 # Build all targets
 ./gradlew assemble
 
-# Run Android unit tests with snapshot verification and code coverage
-./gradlew testAndroidHostTest verifyPaparazzi koverXmlReportAndroid
+# Run Android unit tests with code coverage (Paparazzi tests are excluded by default)
+./gradlew testAndroidHostTest koverXmlReportAndroid
 
 # Run a single test class (Android)
 ./gradlew :module:parser:testAndroidHostTest --tests "org.cru.godtools.shared.parser.FooTest"
@@ -34,7 +34,8 @@ The XML content format is defined by XSD schemas in the [`mobile-content-api` re
 ./gradlew lint
 
 # Snapshot testing (Android) — recording only happens in CI
-./gradlew verifyPaparazzi                # Verify snapshots
+# Paparazzi tests are excluded from testAndroidHostTest by default; pass -Ppaparazzi to include them
+./gradlew verifyPaparazzi -Ppaparazzi    # Verify snapshots
 # To record new/updated snapshots: trigger the "Record Snapshots" workflow_dispatch
 # in GitHub Actions on the target branch — it commits the updated snapshot images back to the branch
 

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,4 +1,7 @@
 codecov:
+  max_report_age: off
+  notify:
+    after_n_builds: 2
   require_ci_to_pass: no
 
 coverage:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,13 +163,9 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: android-unit-test-results
-          path: "**/build/reports/tests/"
-      - name: Archive kover results
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: kover-results
-          path: "**/build/reports/kover/"
+          path: |
+            **/build/reports/tests/
+            **/build/reports/kover/
 
   paparazzi_tests:
     name: Paparazzi Screenshot Tests
@@ -213,6 +209,7 @@ jobs:
         with:
           name: paparazzi-results
           path: |
+            **/build/reports/tests/
             **/build/paparazzi/failures/
             **/build/reports/kover/
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,6 +155,7 @@ jobs:
         uses: codecov/codecov-action@v7
         with:
           fail_ci_if_error: true
+          flags: android
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
       - name: Archive test results
@@ -203,6 +204,7 @@ jobs:
         uses: codecov/codecov-action@v7
         with:
           fail_ci_if_error: true
+          flags: paparazzi
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
       - name: Archive Paparazzi results

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,6 +130,52 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+      - name: Setup Java JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: "temurin"
+          java-version-file: ".tool-versions"
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+      - name: Cache Konan
+        uses: actions/cache@v6
+        with:
+          path: ~/.konan
+          key: ${{ runner.os }}-konan-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-konan-
+      - name: Cache Maven
+        uses: actions/cache@v6
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-maven-
+      - name: Run Android Unit Tests
+        run: ./gradlew testAndroidHostTest koverXmlReportAndroid --scan --no-build-cache
+      - name: Codecov
+        uses: codecov/codecov-action@v7
+        with:
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
+      - name: Archive test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: android-unit-test-results
+          path: "**/build/reports/tests/"
+      - name: Archive kover results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: kover-results
+          path: "**/build/reports/kover/"
+
+  paparazzi_tests:
+    name: Paparazzi Screenshot Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
         with:
           lfs: 'true'
       - name: Setup Java JDK
@@ -151,28 +197,22 @@ jobs:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ github.sha }}
           restore-keys: ${{ runner.os }}-maven-
-      - name: Run Android Unit Tests
-        run: ./gradlew testAndroidHostTest verifyPaparazzi koverXmlReportAndroid --scan --no-build-cache
+      - name: Run Paparazzi Screenshot Tests
+        run: ./gradlew verifyPaparazzi koverXmlReportPaparazzi -Ppaparazzi --scan --no-build-cache
       - name: Codecov
         uses: codecov/codecov-action@v7
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
-      - name: Archive test results
+      - name: Archive Paparazzi results
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: android-unit-test-results
+          name: paparazzi-results
           path: |
             **/build/paparazzi/failures/
-            **/build/reports/tests/
-      - name: Archive kover results
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: kover-results
-          path: "**/build/reports/kover/"
+            **/build/reports/kover/
 
   ios_tests:
     name: iOS Unit Tests
@@ -250,7 +290,7 @@ jobs:
     name: Tag Release & Bump Version
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch' && inputs.triggerRelease && github.ref == 'refs/heads/main'
-    needs: [ build, check_metadata, ktlint, lint, android_tests, ios_tests, js_tests, check_version ]
+    needs: [ build, check_metadata, ktlint, lint, android_tests, paparazzi_tests, ios_tests, js_tests, check_version ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -282,7 +322,7 @@ jobs:
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Publish PR SNAPSHOT: Maven')) ||
       (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
-    needs: [ build, check_metadata, ktlint, lint, android_tests, ios_tests, js_tests, check_version ]
+    needs: [ build, check_metadata, ktlint, lint, android_tests, paparazzi_tests, ios_tests, js_tests, check_version ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v7

--- a/.github/workflows/record-snapshots.yml
+++ b/.github/workflows/record-snapshots.yml
@@ -38,7 +38,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Record snapshots
-        run: ./gradlew cleanRecordPaparazzi --scan
+        run: ./gradlew cleanRecordPaparazzi -Ppaparazzi --scan
       - name: Commit snapshots
         run: |
           git config --global user.name '${{ github.actor }}'

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     implementation(libs.kotlin.gradle)
     implementation(libs.kotlin.kover.gradle)
     implementation(libs.ktlint.gradle)
+    implementation(libs.paparazzi.gradle)
 }
 
 ktlint {

--- a/build-logic/src/main/kotlin/paparazzi-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/paparazzi-conventions.gradle.kts
@@ -1,0 +1,23 @@
+plugins {
+    id("app.cash.paparazzi")
+}
+
+// This task only exists in modules that apply paparazzi, so running it unqualified generates kover coverage
+// reports for paparazzi test runs without triggering unit tests in other modules.
+tasks.register("koverXmlReportPaparazzi") {
+    group = "verification"
+    dependsOn("koverXmlReport")
+}
+
+// HACK: Paparazzi tests are excluded from testAndroidHostTest by default because layoutlib and Robolectric
+//       conflict when run in the same JVM process. Pass -Ppaparazzi to include them. Remove this once
+//       resolved: https://github.com/cashapp/paparazzi/issues/1979
+val paparazziEnabled = project.hasProperty("paparazzi")
+val paparazziCategory = "org.cru.godtools.shared.renderer.BasePaparazziTest"
+
+tasks.withType<Test> {
+    if (name != "testAndroidHostTest") return@withType
+    useJUnit {
+        if (paparazziEnabled) includeCategories(paparazziCategory) else excludeCategories(paparazziCategory)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -65,6 +65,7 @@ kustomExport-compiler = { module = "deezer.kustomexport:compiler", version.ref =
 kustomExport-coroutines = { module = "deezer.kustomexport:lib-coroutines", version.ref = "kustomExport" }
 materialColorUtilities = "org.cru.mobile.fork.material-color-utilities:material-color-utilities:0.2.0_75"
 okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
+paparazzi-gradle = "app.cash.paparazzi:paparazzi-gradle-plugin:2.0.0-alpha05"
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 testparameterinjector = "com.google.testparameterinjector:test-parameter-injector:1.22"
 touchrobot-paparazzi = "me.saket.touchrobot:touchrobot-paparazzi:0.2.0"
@@ -86,4 +87,3 @@ grgit = { id = "org.ajoberstar.grgit", version = "5.3.3" }
 ksp = { id = "com.google.devtools.ksp", version = "2.3.11" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlintGradle" }
 npm-publish = { id = "org.jetbrains.kotlin.npm-publish", version = "3.7.0" }
-paparazzi = { id = "app.cash.paparazzi", version = "2.0.0-alpha05" }

--- a/module/renderer/build.gradle.kts
+++ b/module/renderer/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
     id("godtools-shared.module-conventions")
+    id("paparazzi-conventions")
     alias(libs.plugins.compose)
     alias(libs.plugins.compose.compiler)
-    alias(libs.plugins.paparazzi)
 }
 
 compose.resources {

--- a/module/renderer/src/androidHostTest/kotlin/org/cru/godtools/shared/renderer/BasePaparazziTest.kt
+++ b/module/renderer/src/androidHostTest/kotlin/org/cru/godtools/shared/renderer/BasePaparazziTest.kt
@@ -31,7 +31,9 @@ import org.cru.godtools.shared.tool.parser.model.Resource
 import org.cru.godtools.shared.tool.parser.model.tips.Tip
 import org.jetbrains.compose.resources.PreviewContextConfigurationEffect
 import org.junit.Rule
+import org.junit.experimental.categories.Category
 
+@Category(BasePaparazziTest::class)
 @OptIn(ExperimentalUuidApi::class)
 abstract class BasePaparazziTest(
     protected val accessibilityMode: AccessibilityMode = AccessibilityMode.NO_ACCESSIBILITY,


### PR DESCRIPTION
## Summary
- Add a `paparazzi-conventions` convention plugin (modeled on mpdx-kmp) that excludes Paparazzi tests from `testAndroidHostTest` by default using JUnit categories — `BasePaparazziTest` doubles as the `@Category` marker — and includes only them when `-Ppaparazzi` is passed. This works around layoutlib and Robolectric conflicting when run in the same JVM process (https://github.com/cashapp/paparazzi/issues/1979).
- The plugin registers a `koverXmlReportPaparazzi` task that only exists in modules applying Paparazzi, so CI can generate coverage for Paparazzi runs without triggering unit tests in other modules.
- Split CI into separate `android_tests` and `paparazzi_tests` jobs, tagging their codecov uploads with `android`/`paparazzi` flags and configuring codecov to wait for both uploads before reporting. Test and kover results are archived in a single artifact per job.
- The Record Snapshots workflow now passes `-Ppaparazzi` so recording still executes the snapshot tests.

## Test plan
- [x] `testAndroidHostTest` runs the 23 non-Paparazzi test classes and zero Paparazzi classes
- [x] `testAndroidHostTest -Ppaparazzi` runs exactly the 26 Paparazzi test classes
- [x] `verifyPaparazzi koverXmlReportPaparazzi -Ppaparazzi` schedules only `:module:renderer:` tasks (no other module's unit tests) and produces the kover report
- [x] `:module:renderer:assemble` and ktlint pass
- [ ] CI: `paparazzi_tests` job verifies snapshots against CI-recorded goldens

🤖 Generated with [Claude Code](https://claude.com/claude-code)