### PR TITLE
Assorted codebase cleanup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,6 @@ jobs:
       - name: Setup Java JDK
         uses: actions/setup-java@v5
         with:
-          distribution: "temurin"
           java-version-file: ".tool-versions"
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
@@ -61,7 +60,6 @@ jobs:
       - name: Setup Java JDK
         uses: actions/setup-java@v5
         with:
-          distribution: "temurin"
           java-version-file: ".tool-versions"
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
@@ -83,7 +81,6 @@ jobs:
       - name: Setup Java JDK
         uses: actions/setup-java@v5
         with:
-          distribution: "temurin"
           java-version-file: ".tool-versions"
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
@@ -111,7 +108,6 @@ jobs:
       - name: Setup Java JDK
         uses: actions/setup-java@v5
         with:
-          distribution: "temurin"
           java-version-file: ".tool-versions"
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
@@ -133,7 +129,6 @@ jobs:
       - name: Setup Java JDK
         uses: actions/setup-java@v5
         with:
-          distribution: "temurin"
           java-version-file: ".tool-versions"
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
@@ -178,7 +173,6 @@ jobs:
       - name: Setup Java JDK
         uses: actions/setup-java@v5
         with:
-          distribution: "temurin"
           java-version-file: ".tool-versions"
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
@@ -222,7 +216,6 @@ jobs:
       - name: Setup Java JDK
         uses: actions/setup-java@v5
         with:
-          distribution: "temurin"
           java-version-file: ".tool-versions"
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
@@ -244,7 +237,6 @@ jobs:
       - name: Setup Java JDK
         uses: actions/setup-java@v5
         with:
-          distribution: "temurin"
           java-version-file: ".tool-versions"
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
@@ -328,7 +320,6 @@ jobs:
       - name: Setup Java JDK
         uses: actions/setup-java@v5
         with:
-          distribution: "temurin"
           java-version-file: ".tool-versions"
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
@@ -354,7 +345,6 @@ jobs:
       - name: Setup Java JDK
         uses: actions/setup-java@v5
         with:
-          distribution: "temurin"
           java-version-file: ".tool-versions"
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
@@ -377,7 +367,6 @@ jobs:
       - name: Setup Java JDK
         uses: actions/setup-java@v5
         with:
-          distribution: "temurin"
           java-version-file: ".tool-versions"
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6

--- a/.github/workflows/ios-headers-diff.yml
+++ b/.github/workflows/ios-headers-diff.yml
@@ -19,7 +19,6 @@ jobs:
       - name: Setup Java JDK
         uses: actions/setup-java@v5
         with:
-          distribution: "temurin"
           java-version-file: ".tool-versions"
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6

--- a/.github/workflows/record-snapshots.yml
+++ b/.github/workflows/record-snapshots.yml
@@ -20,7 +20,6 @@ jobs:
       - name: Setup Java JDK
         uses: actions/setup-java@v5
         with:
-          distribution: "temurin"
           java-version-file: ".tool-versions"
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6

--- a/.github/workflows/typescript-headers-diff.yml
+++ b/.github/workflows/typescript-headers-diff.yml
@@ -19,7 +19,6 @@ jobs:
       - name: Setup Java JDK
         uses: actions/setup-java@v5
         with:
-          distribution: "temurin"
           java-version-file: ".tool-versions"
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6

--- a/build-logic/src/main/kotlin/godtools-shared.module-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/godtools-shared.module-conventions.gradle.kts
@@ -13,6 +13,10 @@ kotlin {
     }
     configureIosTargets()
 
+    compilerOptions {
+        freeCompilerArgs.add("-Xexpect-actual-classes")
+    }
+
     jvmToolchain {
         languageVersion.set(JavaLanguageVersion.of(versionCatalog.findVersion("jvm").get().requiredVersion))
     }

--- a/build-logic/src/main/kotlin/org/cru/godtools/shared/gradle/KotlinAntlrPlugin.kt
+++ b/build-logic/src/main/kotlin/org/cru/godtools/shared/gradle/KotlinAntlrPlugin.kt
@@ -37,7 +37,10 @@ class KotlinAntlrPlugin : Plugin<Project> {
 
             // 2) Create Antlr generate parser task
             val generateTask =
-                target.tasks.register("generate${name.capitalize()}GrammarSource", AntlrKotlinTask::class.java) {
+                target.tasks.register(
+                    "generate${name.replaceFirstChar { it.uppercase() }}GrammarSource",
+                    AntlrKotlinTask::class.java,
+                ) {
                     antlrClasspath = antlrConfiguration
                     maxHeapSize = "64m"
                     arguments = listOf("-visitor")

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,6 @@ org.gradle.parallel=true
 org.gradle.tooling.parallel=true
 
 kotlin.code.style=official
-kotlin.mpp.androidSourceSetLayoutVersion=2
 
 android.useAndroidX=true
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,6 @@ kustomExport = "0.8.2"
 goncalossilvaResources = "0.15.0"
 ktlint = "1.8.0"
 ktlintGradle = "14.2.0"
-napier = "2.6.1"
 okio = "3.18.1"
 robolectric = "4.16.1"
 

--- a/module/common/src/iosMain/kotlin/org/cru/godtools/shared/common/model/Uri.ios.kt
+++ b/module/common/src/iosMain/kotlin/org/cru/godtools/shared/common/model/Uri.ios.kt
@@ -3,7 +3,6 @@ package org.cru.godtools.shared.common.model
 import co.touchlab.kermit.Logger
 import platform.Foundation.NSURL
 
-@Suppress("CONFLICTING_OVERLOADS")
 actual typealias Uri = NSURL
 actual val Uri.scheme get() = scheme
 

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Gravity.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Gravity.kt
@@ -59,7 +59,7 @@ class Gravity @VisibleForTesting constructor(val horizontal: Horizontal, val ver
 
                 Gravity(horizontal ?: Horizontal.CENTER, vertical ?: Vertical.CENTER)
             } catch (e: IllegalArgumentException) {
-                Logger.e("Gravity", e) { "error parsing Gravity: $this" }
+                Logger.e(e, tag = "Gravity") { "error parsing Gravity: $this" }
                 null
             }
         }

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Text.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Text.kt
@@ -93,6 +93,7 @@ class Text : Content {
 
         textStyles = parser.getDeviceAttributeValue(manifest.config, XML_TEXT_STYLE)?.toTextStyles().orEmpty()
 
+        @Suppress("DEPRECATION")
         fontWeight = parser.getDeviceAttributeValue(manifest.config, XML_FONT_WEIGHT)?.toIntOrNull()
             ?.coerceIn(1..1000)
             ?: FONT_WEIGHT_BOLD.takeIf { Style.BOLD in textStyles }
@@ -213,6 +214,7 @@ class Text : Content {
         UNDERLINE;
 
         internal companion object {
+            @Suppress("DEPRECATION")
             private fun String.toTextStyleOrNull() = when (this) {
                 XML_TEXT_STYLE_BOLD -> BOLD
                 XML_TEXT_STYLE_ITALIC -> ITALIC

--- a/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Version.kt
+++ b/module/parser/src/commonMain/kotlin/org/cru/godtools/shared/tool/parser/model/Version.kt
@@ -18,7 +18,7 @@ internal value class Version private constructor(val version: List<UInt>) : Comp
         internal fun String.toVersionOrNull() = try {
             toVersion()
         } catch (e: IllegalArgumentException) {
-            Logger.e("Version", e) { "Invalid Version: $this" }
+            Logger.e(e, tag = "Version") { "Invalid Version: $this" }
             null
         }
     }

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/ButtonTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/ButtonTest.kt
@@ -11,6 +11,7 @@ import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
 import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
+import org.cru.godtools.shared.common.model.toUriOrNull
 import org.cru.godtools.shared.tool.parser.ParserConfig
 import org.cru.godtools.shared.tool.parser.ParserConfig.Companion.FEATURE_MULTISELECT
 import org.cru.godtools.shared.tool.parser.expressions.SimpleExpressionContext
@@ -57,7 +58,7 @@ class ButtonTest : UsesResources() {
         assertFalse(button.isIgnored)
         assertEquals(Button.Style.OUTLINED, button.style)
         assertEquals(TestColors.GREEN, button.backgroundColor)
-        assertEquals("https://www.google.com/", button.url!!.toString())
+        assertEquals("https://www.google.com/".toUriOrNull(), button.url)
         assertEquals("url button", button.text.text)
         assertEquals(1, button.analyticsEvents.size)
         assertEquals("firebase action", button.analyticsEvents.single().action)

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/ImageTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/ImageTest.kt
@@ -98,6 +98,7 @@ class ImageTest : UsesResources() {
     }
 
     @Test
+    @Suppress("DEPRECATION")
     fun testPropertyResourceLegacyWebImages() {
         val config = ParserConfig().withLegacyWebImageResources(true)
         val manifest = Manifest(config = config, resources = { listOf(Resource(it, name = resourceName)) })

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/ManifestTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/ManifestTest.kt
@@ -12,6 +12,7 @@ import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
 import org.ccci.gto.support.androidx.test.junit.runners.RunOnAndroidWith
+import org.cru.godtools.shared.common.model.toUriOrNull
 import org.cru.godtools.shared.tool.parser.ParserConfig
 import org.cru.godtools.shared.tool.parser.ParserConfig.Companion.FEATURE_PAGE_COLLECTION
 import org.cru.godtools.shared.tool.parser.internal.UsesResources
@@ -74,7 +75,7 @@ class ManifestTest : UsesResources() {
         val label = assertNotNull(category.label)
         assertEquals("Category", label.text)
         assertEquals(1, manifest.aemImports.size)
-        assertEquals("https://www.example.com", manifest.aemImports.single().toString())
+        assertEquals("https://www.example.com".toUriOrNull(), manifest.aemImports.single())
     }
 
     @Test

--- a/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/tract/TractPageCardTest.kt
+++ b/module/parser/src/commonTest/kotlin/org/cru/godtools/shared/tool/parser/model/tract/TractPageCardTest.kt
@@ -6,6 +6,7 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.support.androidx.test.junit.runners.AndroidJUnit4
@@ -30,9 +31,11 @@ class TractPageCardTest : UsesResources("model/tract") {
     fun verifyParseCard() = runTest {
         val card = TractPage(Manifest(code = "test"), "page.xml", getTestXmlParser("card.xml")).cards.single()
         assertEquals("page.xml-card-0", card.id)
-        assertEquals("Card 1", card.label!!.text)
-        assertEquals(card.primaryColor, card.label!!.textColor)
-        assertNotEquals(card.textColor, card.label!!.textColor)
+        assertNotNull(card.label) {
+            assertEquals("Card 1", it.text)
+            assertEquals(card.primaryColor, it.textColor)
+            assertNotEquals(card.textColor, it.textColor)
+        }
         assertEquals(TestColors.RED, card.backgroundColor)
         assertEquals("listener1 listener2".toEventIds().toSet(), card.listeners)
         assertEquals("dismiss-listener1 dismiss-listener2".toEventIds().toSet(), card.dismissListeners)
@@ -123,14 +126,18 @@ class TractPageCardTest : UsesResources("model/tract") {
     @Test
     fun testLabelTextColor() {
         with(Card(label = { Text(it) })) {
-            assertEquals(primaryColor, label!!.textColor)
-            assertNotEquals(textColor, label!!.textColor)
+            assertNotNull(label) {
+                assertEquals(primaryColor, it.textColor)
+                assertNotEquals(textColor, it.textColor)
+            }
         }
 
         with(Card(label = { Text(it, textColor = TestColors.GREEN) })) {
-            assertEquals(TestColors.GREEN, label!!.textColor)
-            assertNotEquals(primaryColor, label!!.textColor)
-            assertNotEquals(textColor, label!!.textColor)
+            assertNotNull(label) {
+                assertEquals(TestColors.GREEN, it.textColor)
+                assertNotEquals(primaryColor, it.textColor)
+                assertNotEquals(textColor, it.textColor)
+            }
         }
     }
 }

--- a/module/parser/src/iosMain/kotlin/org/cru/godtools/shared/tool/parser/model/PlatformColor.ios.kt
+++ b/module/parser/src/iosMain/kotlin/org/cru/godtools/shared/tool/parser/model/PlatformColor.ios.kt
@@ -5,7 +5,6 @@ import org.cru.godtools.shared.common.internal.colormath.toColormathSRGB
 import org.cru.godtools.shared.common.internal.colormath.toUIColor
 import platform.UIKit.UIColor
 
-@Suppress("CONFLICTING_OVERLOADS")
 actual typealias PlatformColor = UIColor
 
 internal actual fun Color.toPlatformColor() = toUIColor()

--- a/module/parser/src/iosMain/kotlin/org/cru/godtools/shared/tool/parser/xml/IosXmlPullParser.kt
+++ b/module/parser/src/iosMain/kotlin/org/cru/godtools/shared/tool/parser/xml/IosXmlPullParser.kt
@@ -8,7 +8,6 @@ import platform.darwin.NSObject
 class IosXmlPullParser(parser: NSXMLParser) : SaxXmlPullParser() {
     private val internalParser = InternalXMLParser(parser)
 
-    @Suppress("CONFLICTING_OVERLOADS")
     private inner class InternalXMLParser(parser: NSXMLParser) : NSObject(), NSXMLParserDelegateProtocol {
         // region Active Namespaces
         private val namespaces = mutableMapOf<String, MutableList<String>>()

--- a/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/content/extensions/Resource+Compottie.kt
+++ b/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/content/extensions/Resource+Compottie.kt
@@ -3,7 +3,6 @@
 package org.cru.godtools.shared.renderer.content.extensions
 
 import io.github.alexzhirkevich.compottie.InternalCompottieApi
-import io.github.alexzhirkevich.compottie.LottieAnimationFormat
 import io.github.alexzhirkevich.compottie.LottieCompositionSpec
 import io.github.alexzhirkevich.compottie.decodeToLottieComposition
 import okio.FileSystem
@@ -18,5 +17,5 @@ internal fun LottieCompositionSpec.Companion.Resource(fileSystem: FileSystem, re
         override val key get() = "resource_${resource.src}"
 
         override suspend fun load() = fileSystem.source(resource.toPath()!!).buffer().readByteArray()
-            .decodeToLottieComposition(LottieAnimationFormat.Unknown)
+            .decodeToLottieComposition()
     }

--- a/module/renderer/src/commonTest/kotlin/org/cru/godtools/shared/renderer/content/RenderAccordionTest.kt
+++ b/module/renderer/src/commonTest/kotlin/org/cru/godtools/shared/renderer/content/RenderAccordionTest.kt
@@ -12,7 +12,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performSemanticsAction
-import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.lifecycle.Lifecycle
 import app.cash.turbine.test
 import kotlin.test.Test

--- a/module/user-activity/src/commonMain/kotlin/org/cru/godtools/shared/user/activity/model/Badge.kt
+++ b/module/user-activity/src/commonMain/kotlin/org/cru/godtools/shared/user/activity/model/Badge.kt
@@ -15,7 +15,7 @@ data class Badge internal constructor(
     }
 
     enum class BadgeType(
-        @VisibleForTesting internal vararg val variantProgressTargets: Int,
+        @property:VisibleForTesting internal vararg val variantProgressTargets: Int,
         internal val colors: IconColors
     ) {
         TOOLS_OPENED(1, 5, 10, colors = IconColors(base = RGB("#62CCF3"))),

--- a/module/user-activity/src/commonMain/kotlin/org/cru/godtools/shared/user/activity/model/IconColors.kt
+++ b/module/user-activity/src/commonMain/kotlin/org/cru/godtools/shared/user/activity/model/IconColors.kt
@@ -6,13 +6,13 @@ import org.cru.godtools.shared.common.model.ThemeType
 
 @ConsistentCopyVisibility
 data class IconColors internal constructor(
-    @VisibleForTesting
+    @property:VisibleForTesting
     internal val light: Color,
-    @VisibleForTesting
+    @property:VisibleForTesting
     internal val dark: Color,
-    @VisibleForTesting
+    @property:VisibleForTesting
     internal val containerLight: Color,
-    @VisibleForTesting
+    @property:VisibleForTesting
     internal val containerDark: Color,
 ) {
     @Suppress("FunctionName")


### PR DESCRIPTION
A batch of small cleanup changes:

## CI / build configuration
- Remove the no longer needed `distribution` input from all `actions/setup-java` steps in the GitHub workflows
- Remove the deprecated `kotlin.mpp.androidSourceSetLayoutVersion` property
- Opt in to `-Xexpect-actual-classes` to silence expect/actual Beta warnings
- Remove unused napier version from `libs.versions.toml`
- Replace deprecated `String.capitalize()` with `replaceFirstChar` in `KotlinAntlrPlugin`

## Deprecation cleanup
- Switch deprecated `Logger.e` calls to the throwable-first overload with a named tag
- Drop the deprecated `LottieAnimationFormat` argument from `decodeToLottieComposition`
- Suppress deprecation warnings on `Text.Style.BOLD` legacy bridge code and the `withLegacyWebImageResources` regression test
- Drop unnecessary `CONFLICTING_OVERLOADS` suppressions in iOS sources
- Pin `@VisibleForTesting` to the property use-site target in `Badge` and `IconColors`

## Test cleanup
- Migrate `RenderAccordionTest` to `androidx.compose.ui.test.v2.runComposeUiTest`
- Compare `Uri` values directly in `ButtonTest` and `ManifestTest` assertions
- Replace redundant `!!` chains with `assertNotNull` blocks in `TractPageCardTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)