### PR TITLE
[GT-3014] Support starting a LessonPagerState on a specific LessonPage

### DIFF
--- a/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/lesson/LessonPagerState.kt
+++ b/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/lesson/LessonPagerState.kt
@@ -21,6 +21,11 @@ fun rememberLessonPagerState(manifest: Manifest, initialPage: Int = 0) =
     rememberSaveable(saver = LessonPagerState.Saver) { LessonPagerState(manifest, initialPage) }
         .apply { updateManifest(manifest) }
 
+@Composable
+fun rememberLessonPagerState(manifest: Manifest, initialPage: LessonPage?) =
+    rememberSaveable(saver = LessonPagerState.Saver) { LessonPagerState(manifest, initialPage) }
+        .apply { updateManifest(manifest) }
+
 @Stable
 class LessonPagerState private constructor(visiblePages: Collection<String>, pagerState: SaveablePagerState?) {
     constructor(manifest: Manifest? = null, currentPage: Int = 0) : this(
@@ -28,6 +33,17 @@ class LessonPagerState private constructor(visiblePages: Collection<String>, pag
         pagerState = SaveablePagerState(currentPage, 0f) { currentPage + 1 },
     ) {
         if (manifest != null) updateManifest(manifest) else updatePages(emptyList())
+    }
+
+    /**
+     * Create a LessonPagerState that starts on [initialPage], making [initialPage] initially visible when it's a
+     * hidden page. A `null` or unrecognized [initialPage] starts on the first page.
+     */
+    constructor(manifest: Manifest, initialPage: LessonPage?) : this(
+        visiblePages = setOfNotNull(initialPage?.id),
+        pagerState = initialPagerState(manifest, initialPage),
+    ) {
+        updateManifest(manifest)
     }
 
     internal var allPages: ImmutableList<LessonPage> by mutableStateOf(persistentListOf())
@@ -45,6 +61,18 @@ class LessonPagerState private constructor(visiblePages: Collection<String>, pag
     }
 
     companion object {
+        private fun initialPagerState(manifest: Manifest, initialPage: LessonPage?): SaveablePagerState {
+            val index = when (initialPage) {
+                null -> 0
+
+                else -> manifest.pages.filterIsInstance<LessonPage>()
+                    .filter { it.id == initialPage.id || !it.isHidden }
+                    .indexOfFirst { it.id == initialPage.id }
+                    .coerceAtLeast(0)
+            }
+            return SaveablePagerState(index, 0f) { index + 1 }
+        }
+
         val Saver = listSaver(
             save = {
                 listOf(

--- a/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/lesson/LessonPagerState.kt
+++ b/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/lesson/LessonPagerState.kt
@@ -48,7 +48,7 @@ class LessonPagerState private constructor(visiblePages: Collection<String>, pag
 
     internal var allPages: ImmutableList<LessonPage> by mutableStateOf(persistentListOf())
     internal val visiblePages = mutableStateSetOf(*visiblePages.toTypedArray())
-    val pages by derivedStateOf { allPages.filter { it.id in this.visiblePages || !it.isHidden }.toImmutableList() }
+    val pages by derivedStateOf { allPages.filterVisiblePages(this.visiblePages).toImmutableList() }
 
     private val _pagerState = pagerState ?: SaveablePagerState(0, 0f) { pages.size }
     val pagerState: PagerState get() = _pagerState
@@ -66,7 +66,7 @@ class LessonPagerState private constructor(visiblePages: Collection<String>, pag
                 null -> 0
 
                 else -> manifest.pages.filterIsInstance<LessonPage>()
-                    .filter { it.id == initialPage.id || !it.isHidden }
+                    .filterVisiblePages(setOf(initialPage.id))
                     .indexOfFirst { it.id == initialPage.id }
                     .coerceAtLeast(0)
             }
@@ -90,6 +90,9 @@ class LessonPagerState private constructor(visiblePages: Collection<String>, pag
         )
     }
 }
+
+private fun List<LessonPage>.filterVisiblePages(revealedHiddenPages: Set<String>) =
+    filter { !it.isHidden || it.id in revealedHiddenPages }
 
 private class SaveablePagerState(
     currentPage: Int,

--- a/module/renderer/src/commonTest/kotlin/org/cru/godtools/shared/renderer/lesson/LessonPagerStateTest.kt
+++ b/module/renderer/src/commonTest/kotlin/org/cru/godtools/shared/renderer/lesson/LessonPagerStateTest.kt
@@ -72,7 +72,7 @@ class LessonPagerStateTest : BaseRendererTest() {
 
     // region constructor(manifest, initialPage)
     @Test
-    fun `constructor(initialPage) - starts on the initial page`() {
+    fun `LessonPagerState - initialPage - starts on the initial page`() {
         val manifest = Manifest(type = Type.LESSON) {
             listOf(
                 LessonPage(it, id = "page1"),
@@ -85,7 +85,7 @@ class LessonPagerStateTest : BaseRendererTest() {
     }
 
     @Test
-    fun `constructor(initialPage) - hidden initial page should be visible`() {
+    fun `LessonPagerState - initialPage - hidden initial page should be visible`() {
         val manifest = Manifest(type = Type.LESSON) {
             listOf(
                 LessonPage(it, id = "page1"),
@@ -104,7 +104,7 @@ class LessonPagerStateTest : BaseRendererTest() {
     }
 
     @Test
-    fun `constructor(initialPage) - null initial page starts on the first page`() {
+    fun `LessonPagerState - initialPage - null initial page starts on the first page`() {
         val manifest = Manifest(type = Type.LESSON) {
             listOf(
                 LessonPage(it, id = "page1"),
@@ -117,7 +117,7 @@ class LessonPagerStateTest : BaseRendererTest() {
     }
 
     @Test
-    fun `constructor(initialPage) - initial page missing from the manifest starts on the first page`() {
+    fun `LessonPagerState - initialPage - initial page missing from the manifest starts on the first page`() {
         val manifest = Manifest(type = Type.LESSON) {
             listOf(
                 LessonPage(it, id = "page1"),

--- a/module/renderer/src/commonTest/kotlin/org/cru/godtools/shared/renderer/lesson/LessonPagerStateTest.kt
+++ b/module/renderer/src/commonTest/kotlin/org/cru/godtools/shared/renderer/lesson/LessonPagerStateTest.kt
@@ -70,7 +70,7 @@ class LessonPagerStateTest : BaseRendererTest() {
         onNodeWithText("Page: 1 of 3").assertExists()
     }
 
-    // region constructor(manifest, initialPage)
+    // region LessonPagerState(manifest, initialPage: LessonPage?)
     @Test
     fun `LessonPagerState - initialPage - starts on the initial page`() {
         val manifest = Manifest(type = Type.LESSON) {
@@ -129,7 +129,7 @@ class LessonPagerStateTest : BaseRendererTest() {
         val state = LessonPagerState(manifest, initialPage = otherManifest.lessonPage("other"))
         assertEquals("page1", state.settledPage?.id)
     }
-    // endregion constructor(manifest, initialPage)
+    // endregion LessonPagerState(manifest, initialPage: LessonPage?)
 
     // region settledPage
     @Test

--- a/module/renderer/src/commonTest/kotlin/org/cru/godtools/shared/renderer/lesson/LessonPagerStateTest.kt
+++ b/module/renderer/src/commonTest/kotlin/org/cru/godtools/shared/renderer/lesson/LessonPagerStateTest.kt
@@ -50,6 +50,87 @@ class LessonPagerStateTest : BaseRendererTest() {
         onNodeWithText("Page: 1").assertExists()
     }
 
+    @Test
+    fun `rememberLessonPagerState - Initial LessonPage - Hidden`() = runComposeUiTest {
+        val manifest = Manifest(type = Type.LESSON) {
+            listOf(
+                LessonPage(it, id = "page1"),
+                LessonPage(it, id = "page2", isHidden = true),
+                LessonPage(it, id = "page3"),
+            )
+        }
+
+        setContent {
+            ProvideTestCompositionLocals {
+                val pagerState = rememberLessonPagerState(manifest, initialPage = manifest.lessonPage("page2"))
+                Text("Page: ${pagerState.pagerState.currentPage} of ${pagerState.pages.size}")
+            }
+        }
+
+        onNodeWithText("Page: 1 of 3").assertExists()
+    }
+
+    // region constructor(manifest, initialPage)
+    @Test
+    fun `constructor(initialPage) - starts on the initial page`() {
+        val manifest = Manifest(type = Type.LESSON) {
+            listOf(
+                LessonPage(it, id = "page1"),
+                LessonPage(it, id = "page2"),
+            )
+        }
+
+        val state = LessonPagerState(manifest, initialPage = manifest.lessonPage("page2"))
+        assertEquals("page2", state.settledPage?.id, "the pager should start on the initial page")
+    }
+
+    @Test
+    fun `constructor(initialPage) - hidden initial page should be visible`() {
+        val manifest = Manifest(type = Type.LESSON) {
+            listOf(
+                LessonPage(it, id = "page1"),
+                LessonPage(it, id = "page2", isHidden = true),
+                LessonPage(it, id = "page3"),
+            )
+        }
+
+        val state = LessonPagerState(manifest, initialPage = manifest.lessonPage("page2"))
+        assertEquals(
+            listOf("page1", "page2", "page3"),
+            state.pages.map { it.id },
+            "a hidden initial page should be initially visible",
+        )
+        assertEquals("page2", state.settledPage?.id, "the pager should start on the hidden initial page")
+    }
+
+    @Test
+    fun `constructor(initialPage) - null initial page starts on the first page`() {
+        val manifest = Manifest(type = Type.LESSON) {
+            listOf(
+                LessonPage(it, id = "page1"),
+                LessonPage(it, id = "page2"),
+            )
+        }
+
+        val state = LessonPagerState(manifest, initialPage = null)
+        assertEquals("page1", state.settledPage?.id)
+    }
+
+    @Test
+    fun `constructor(initialPage) - initial page missing from the manifest starts on the first page`() {
+        val manifest = Manifest(type = Type.LESSON) {
+            listOf(
+                LessonPage(it, id = "page1"),
+                LessonPage(it, id = "page2"),
+            )
+        }
+        val otherManifest = Manifest(type = Type.LESSON) { listOf(LessonPage(it, id = "other")) }
+
+        val state = LessonPagerState(manifest, initialPage = otherManifest.lessonPage("other"))
+        assertEquals("page1", state.settledPage?.id)
+    }
+    // endregion constructor(manifest, initialPage)
+
     // region settledPage
     @Test
     fun `settledPage - returns the page the pager is settled on`() {
@@ -150,4 +231,6 @@ class LessonPagerStateTest : BaseRendererTest() {
         onNodeWithText("Page Count: 3").assertExists()
         onNodeWithText("Visible: [page2]").assertExists()
     }
+
+    private fun Manifest.lessonPage(id: String) = pages.filterIsInstance<LessonPage>().first { it.id == id }
 }

--- a/module/renderer/src/commonTest/kotlin/org/cru/godtools/shared/renderer/lesson/LessonPagerStateTest.kt
+++ b/module/renderer/src/commonTest/kotlin/org/cru/godtools/shared/renderer/lesson/LessonPagerStateTest.kt
@@ -124,9 +124,8 @@ class LessonPagerStateTest : BaseRendererTest() {
                 LessonPage(it, id = "page2"),
             )
         }
-        val otherManifest = Manifest(type = Type.LESSON) { listOf(LessonPage(it, id = "other")) }
 
-        val state = LessonPagerState(manifest, initialPage = otherManifest.lessonPage("other"))
+        val state = LessonPagerState(manifest, initialPage = LessonPage(id = "other"))
         assertEquals("page1", state.settledPage?.id)
     }
     // endregion LessonPagerState(manifest, initialPage: LessonPage?)


### PR DESCRIPTION
Adds a `rememberLessonPagerState`/`LessonPagerState` overload that accepts the initial `LessonPage` directly, instead of a pager index. When the initial page is a hidden page, it is marked initially visible so the pager can start on it. A `null` or unrecognized page starts on the first page.

This supports deep links that reference hidden pages, per the product intent discussed in CruGlobal/godtools-android#4568: sharing content from a hidden page should land the recipient on that page, not the closest previous visible page. Once the user navigates away, the existing re-hide behavior applies as usual.

## Testing

- New `LessonPagerStateTest` cases: starting on a visible page, starting on a hidden page (revealed + settled), `null` initial page, an initial page not present in the manifest, and a compose-level `rememberLessonPagerState` test with a hidden initial page
- Verified end-to-end against the Android consumer via a local composite build: `godtools-android:ui:lesson-renderer` compiles and its full test suite passes against this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)