### PR TITLE
Clean up LessonPagerState

### DIFF
--- a/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/lesson/LessonPagerState.kt
+++ b/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/lesson/LessonPagerState.kt
@@ -46,14 +46,14 @@ class LessonPagerState private constructor(visiblePages: Collection<String>, pag
     internal val visiblePages = mutableStateSetOf(*visiblePages.toTypedArray())
     val pages by derivedStateOf { allPages.filterVisiblePages(this.visiblePages).toImmutableList() }
 
-    private val _pagerState = pagerState ?: SaveablePagerState(0, 0f) { pages.size }
-    val pagerState: PagerState get() = _pagerState
-    val settledPage by derivedStateOf { pages.getOrNull(_pagerState.settledPage) }
+    val pagerState: PagerState
+        field: SaveablePagerState = pagerState ?: SaveablePagerState(0, 0f) { pages.size }
+    val settledPage by derivedStateOf { pages.getOrNull(this.pagerState.settledPage) }
 
     fun updateManifest(manifest: Manifest) = updatePages(manifest.pages.filterIsInstance<LessonPage>())
     fun updatePages(pages: List<LessonPage>) {
         allPages = pages.toImmutableList()
-        _pagerState.pageCountState.value = { this.pages.size }
+        pagerState.pageCountState.value = { this.pages.size }
     }
 
     companion object {
@@ -61,7 +61,7 @@ class LessonPagerState private constructor(visiblePages: Collection<String>, pag
             save = {
                 listOf(
                     ArrayList(it.visiblePages),
-                    with(SaveablePagerState.Saver) { save(it._pagerState) },
+                    with(SaveablePagerState.Saver) { save(it.pagerState) },
                 )
             },
             restore = {

--- a/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/lesson/LessonPagerState.kt
+++ b/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/lesson/LessonPagerState.kt
@@ -35,13 +35,9 @@ class LessonPagerState private constructor(visiblePages: Collection<String>, pag
         if (manifest != null) updateManifest(manifest) else updatePages(emptyList())
     }
 
-    /**
-     * Create a LessonPagerState that starts on [initialPage], making [initialPage] initially visible when it's a
-     * hidden page. A `null` or unrecognized [initialPage] starts on the first page.
-     */
-    constructor(manifest: Manifest, initialPage: LessonPage?) : this(
-        visiblePages = setOfNotNull(initialPage?.id),
-        pagerState = initialPagerState(manifest, initialPage),
+    constructor(manifest: Manifest, currentPage: LessonPage?) : this(
+        visiblePages = setOfNotNull(currentPage?.id),
+        pagerState = createPagerState(manifest, currentPage),
     ) {
         updateManifest(manifest)
     }
@@ -61,18 +57,6 @@ class LessonPagerState private constructor(visiblePages: Collection<String>, pag
     }
 
     companion object {
-        private fun initialPagerState(manifest: Manifest, initialPage: LessonPage?): SaveablePagerState {
-            val index = when (initialPage) {
-                null -> 0
-
-                else -> manifest.pages.filterIsInstance<LessonPage>()
-                    .filterVisiblePages(setOf(initialPage.id))
-                    .indexOfFirst { it.id == initialPage.id }
-                    .coerceAtLeast(0)
-            }
-            return SaveablePagerState(index, 0f) { index + 1 }
-        }
-
         val Saver = listSaver(
             save = {
                 listOf(
@@ -88,11 +72,23 @@ class LessonPagerState private constructor(visiblePages: Collection<String>, pag
                 )
             },
         )
+
+        private fun createPagerState(manifest: Manifest, currentPage: LessonPage?): SaveablePagerState {
+            val index = when (currentPage) {
+                null -> 0
+
+                else -> manifest.pages.filterIsInstance<LessonPage>()
+                    .filterVisiblePages(setOf(currentPage.id))
+                    .indexOfFirst { it.id == currentPage.id }
+                    .coerceAtLeast(0)
+            }
+            return SaveablePagerState(index, 0f) { index + 1 }
+        }
+
+        private fun List<LessonPage>.filterVisiblePages(revealedHiddenPages: Set<String>) =
+            filter { !it.isHidden || it.id in revealedHiddenPages }
     }
 }
-
-private fun List<LessonPage>.filterVisiblePages(revealedHiddenPages: Set<String>) =
-    filter { !it.isHidden || it.id in revealedHiddenPages }
 
 private class SaveablePagerState(
     currentPage: Int,

--- a/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/lesson/LessonPagerState.kt
+++ b/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/lesson/LessonPagerState.kt
@@ -27,24 +27,24 @@ fun rememberLessonPagerState(manifest: Manifest, initialPage: LessonPage?) =
         .apply { updateManifest(manifest) }
 
 @Stable
-class LessonPagerState private constructor(visiblePages: Collection<String>, pagerState: SaveablePagerState?) {
+class LessonPagerState private constructor(revealedPages: Collection<String>, pagerState: SaveablePagerState?) {
     constructor(manifest: Manifest? = null, currentPage: Int = 0) : this(
-        visiblePages = emptySet(),
+        revealedPages = emptySet(),
         pagerState = SaveablePagerState(currentPage, 0f) { currentPage + 1 },
     ) {
         if (manifest != null) updateManifest(manifest) else updatePages(emptyList())
     }
 
     constructor(manifest: Manifest, currentPage: LessonPage?) : this(
-        visiblePages = setOfNotNull(currentPage?.id),
+        revealedPages = setOfNotNull(currentPage?.id),
         pagerState = createPagerState(manifest, currentPage),
     ) {
         updateManifest(manifest)
     }
 
     internal var allPages: ImmutableList<LessonPage> by mutableStateOf(persistentListOf())
-    internal val visiblePages = mutableStateSetOf(*visiblePages.toTypedArray())
-    val pages by derivedStateOf { allPages.filterVisiblePages(this.visiblePages).toImmutableList() }
+    internal val revealedPages = mutableStateSetOf(*revealedPages.toTypedArray())
+    val pages by derivedStateOf { allPages.filterVisiblePages(this.revealedPages).toImmutableList() }
 
     val pagerState: PagerState
         field: SaveablePagerState = pagerState ?: SaveablePagerState(0, 0f) { pages.size }
@@ -60,14 +60,14 @@ class LessonPagerState private constructor(visiblePages: Collection<String>, pag
         val Saver = listSaver(
             save = {
                 listOf(
-                    ArrayList(it.visiblePages),
+                    ArrayList(it.revealedPages),
                     with(SaveablePagerState.Saver) { save(it.pagerState) },
                 )
             },
             restore = {
                 @Suppress("UNCHECKED_CAST")
                 LessonPagerState(
-                    visiblePages = it[0] as List<String>,
+                    revealedPages = it[0] as List<String>,
                     pagerState = SaveablePagerState.Saver.restore(it[1] as List<Any>),
                 )
             },
@@ -85,8 +85,8 @@ class LessonPagerState private constructor(visiblePages: Collection<String>, pag
             return SaveablePagerState(index, 0f) { index + 1 }
         }
 
-        private fun List<LessonPage>.filterVisiblePages(revealedHiddenPages: Set<String>) =
-            filter { !it.isHidden || it.id in revealedHiddenPages }
+        private fun List<LessonPage>.filterVisiblePages(revealedPages: Set<String>) =
+            filter { !it.isHidden || it.id in revealedPages }
     }
 }
 

--- a/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/lesson/RenderLesson.kt
+++ b/module/renderer/src/commonMain/kotlin/org/cru/godtools/shared/renderer/lesson/RenderLesson.kt
@@ -168,13 +168,13 @@ private fun RenderLessonPager(
     LaunchedEffect(pagerState) {
         snapshotFlow { pagerState.settledPage }
             .mapNotNull { lessonPagerState.pages.getOrNull(it)?.id }
-            .collect { pageId -> lessonPagerState.visiblePages.removeAll { it != pageId } }
+            .collect { pageId -> lessonPagerState.revealedPages.removeAll { it != pageId } }
     }
 
     // handle page listeners
     ContentEventListener(state) { eventId ->
         val page = lessonPagerState.allPages.firstOrNull { eventId in it.listeners } ?: return@ContentEventListener
-        lessonPagerState.visiblePages += page.id
+        lessonPagerState.revealedPages += page.id
         val index = lessonPagerState.pages.indexOf(page).takeUnless { it == -1 } ?: return@ContentEventListener
         pagerState.animateScrollToPage(index)
     }

--- a/module/renderer/src/commonTest/kotlin/org/cru/godtools/shared/renderer/lesson/LessonPagerStateTest.kt
+++ b/module/renderer/src/commonTest/kotlin/org/cru/godtools/shared/renderer/lesson/LessonPagerStateTest.kt
@@ -157,7 +157,7 @@ class LessonPagerStateTest : BaseRendererTest() {
         val state = LessonPagerState(manifest, currentPage = 1)
         assertEquals("page3", state.settledPage?.id, "hidden pages are excluded from pages, shifting the index")
 
-        state.visiblePages += "page2"
+        state.revealedPages += "page2"
         assertEquals("page2", state.settledPage?.id, "settledPage should update when a hidden page becomes visible")
     }
 
@@ -206,11 +206,11 @@ class LessonPagerStateTest : BaseRendererTest() {
                     Text("Current Page: ${lessonPagerState.pagerState.currentPage}")
                     val pageCount by remember { derivedStateOf { lessonPagerState.pagerState.pageCount } }
                     Text("Page Count: $pageCount")
-                    Text("Visible: ${lessonPagerState.visiblePages.toSet()}")
+                    Text("Visible: ${lessonPagerState.revealedPages.toSet()}")
 
                     Button(
                         onClick = {
-                            lessonPagerState.visiblePages += "page2"
+                            lessonPagerState.revealedPages += "page2"
                             coroutineScope.launch { lessonPagerState.pagerState.animateScrollToPage(1) }
                         }
                     ) {

--- a/module/renderer/src/commonTest/kotlin/org/cru/godtools/shared/renderer/lesson/LessonPagerStateTest.kt
+++ b/module/renderer/src/commonTest/kotlin/org/cru/godtools/shared/renderer/lesson/LessonPagerStateTest.kt
@@ -70,7 +70,7 @@ class LessonPagerStateTest : BaseRendererTest() {
         onNodeWithText("Page: 1 of 3").assertExists()
     }
 
-    // region LessonPagerState(manifest, initialPage: LessonPage?)
+    // region LessonPagerState(manifest, currentPage: LessonPage?)
     @Test
     fun `LessonPagerState - initialPage - starts on the initial page`() {
         val manifest = Manifest(type = Type.LESSON) {
@@ -80,7 +80,7 @@ class LessonPagerStateTest : BaseRendererTest() {
             )
         }
 
-        val state = LessonPagerState(manifest, initialPage = manifest.lessonPage("page2"))
+        val state = LessonPagerState(manifest, currentPage = manifest.lessonPage("page2"))
         assertEquals("page2", state.settledPage?.id, "the pager should start on the initial page")
     }
 
@@ -94,7 +94,7 @@ class LessonPagerStateTest : BaseRendererTest() {
             )
         }
 
-        val state = LessonPagerState(manifest, initialPage = manifest.lessonPage("page2"))
+        val state = LessonPagerState(manifest, currentPage = manifest.lessonPage("page2"))
         assertEquals(
             listOf("page1", "page2", "page3"),
             state.pages.map { it.id },
@@ -112,7 +112,7 @@ class LessonPagerStateTest : BaseRendererTest() {
             )
         }
 
-        val state = LessonPagerState(manifest, initialPage = null)
+        val state = LessonPagerState(manifest, currentPage = null)
         assertEquals("page1", state.settledPage?.id)
     }
 
@@ -125,10 +125,10 @@ class LessonPagerStateTest : BaseRendererTest() {
             )
         }
 
-        val state = LessonPagerState(manifest, initialPage = LessonPage(id = "other"))
+        val state = LessonPagerState(manifest, currentPage = LessonPage(id = "other"))
         assertEquals("page1", state.settledPage?.id)
     }
-    // endregion LessonPagerState(manifest, initialPage: LessonPage?)
+    // endregion LessonPagerState(manifest, currentPage: LessonPage?)
 
     // region settledPage
     @Test


### PR DESCRIPTION
## Summary
- Clean up `LessonPagerState` internals: move the `filterVisiblePages` helper and initial pager state factory into the companion object, and reorder members
- Replace the private `_pagerState` property with an explicit backing field on `pagerState`
- Rename `visiblePages` to `revealedPages` to better describe its purpose (hidden pages that have been revealed), and rename the `initialPage` constructor parameter to `currentPage`

No behavior changes — refactoring only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)